### PR TITLE
APIGW -> ALB Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ LISA accelerates the use of generative AI applications by providing scalable, lo
 LISA was inspired by another AWS open source project [aws-genai-llm-chatbot](https://github.com/aws-samples/aws-genai-llm-chatbot) and deploys LLMs using the [text-generation-inference](https://github.com/huggingface/text-generation-inference/tree/main) container from HuggingFace. LISA is different from it's inspiration in a few ways:
 
 1.  LISA is designed to operate in Amazon Dedicated Cloud (ADC) partitions.
-2.  LISA is designed to be composable so we've separated the the underlying LLM serving capability, this repository contains, LISA-Serve and the chat frontend, LISA-Chat, which are deployable as separate stacks.
+2.  LISA is designed to be composable so we've separated the underlying LLM serving capability. This repository contains LISA-Serve, the chat frontend, and LISA-Chat, which are deployable as separate stacks.
 
 ## Getting Started
 
-LISA leverages AWS's cloud development toolkit (cdk). Users of LISA should be familiar with CDK and infrastructure-as-code principles. If CDK is new to you please see the [documentation on CDK](https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html) and talk to your AWS support team to help get you started.
+LISA leverages AWS's cloud development toolkit (CDK). Users of LISA should be familiar with CDK and infrastructure-as-code principles. If CDK is new to you please see the [documentation on CDK](https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html) and talk to your AWS support team to help get you started.
 
 LISA uses a `make` system that leverages both environment variables and a configuration file. Most of the commands to deploy LISA are wrapped in high level `make` actions, please see [Makefile](./Makefile).
 
@@ -36,7 +36,7 @@ Let's start by downloading the repository:
 
 ```
 git clone <path-to-lisa-repo>
-cd lisa
+cd LISA
 ```
 
 ### Define Environment Variables

--- a/lib/api-base/ecsCluster.ts
+++ b/lib/api-base/ecsCluster.ts
@@ -37,7 +37,7 @@ import {
   Protocol,
   Volume,
 } from 'aws-cdk-lib/aws-ecs';
-import { ApplicationLoadBalancer, BaseApplicationListenerProps } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { ApplicationListener, ApplicationLoadBalancer, BaseApplicationListenerProps } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import { IRole, ManagedPolicy, Role } from 'aws-cdk-lib/aws-iam';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
@@ -58,6 +58,8 @@ interface ECSClusterProps extends BaseProps {
   securityGroup: SecurityGroup;
   vpc: IVpc;
   alb: ApplicationLoadBalancer;
+  listener: ApplicationListener;
+  listenerProps: BaseApplicationListenerProps;
 }
 
 /**
@@ -80,7 +82,7 @@ export class ECSCluster extends Construct {
    */
   constructor(scope: Construct, id: string, props: ECSClusterProps) {
     super(scope, id);
-    const { config, vpc, securityGroup, ecsConfig, alb } = props;
+    const { config, vpc, ecsConfig, alb, listener, listenerProps } = props;
 
     // Create ECS cluster
     const cluster = new Cluster(this, createCdkId([ecsConfig.identifier, 'Cl']), {
@@ -260,19 +262,20 @@ export class ECSCluster extends Construct {
     service.node.addDependency(autoScalingGroup);
   
 
-    // Add listener
-    const listenerProps: BaseApplicationListenerProps = {
-      port: ecsConfig.loadBalancerConfig.sslCertIamArn ? 443 : 80,
-      open: ecsConfig.internetFacing,
-      certificates: ecsConfig.loadBalancerConfig.sslCertIamArn
-        ? [{ certificateArn: ecsConfig.loadBalancerConfig.sslCertIamArn }]
-        : undefined,
-    };
+    // // Add listener
+    // const listenerProps: BaseApplicationListenerProps = {
+    //   port: ecsConfig.loadBalancerConfig.sslCertIamArn ? 443 : 80,
+    //   open: ecsConfig.internetFacing,
+    //   certificates: ecsConfig.loadBalancerConfig.sslCertIamArn
+    //     ? [{ certificateArn: ecsConfig.loadBalancerConfig.sslCertIamArn }]
+    //     : undefined,
+    // };
 
-    const listener = alb.addListener(
-      createCdkId([ecsConfig.identifier, 'ApplicationListener']),
-      listenerProps,
-    );
+    // const listener = alb.addListener(
+    //   createCdkId([ecsConfig.identifier, 'ApplicationListener']),
+    //   listenerProps,
+    // );
+
     const protocol = listenerProps.port === 443 ? 'https' : 'http';
 
     // Add targets

--- a/lib/api-base/fastApiContainer.ts
+++ b/lib/api-base/fastApiContainer.ts
@@ -24,7 +24,7 @@ import { dump as yamlDump } from 'js-yaml';
 
 import { ECSCluster } from './ecsCluster';
 import { BaseProps, Ec2Metadata, EcsSourceType, FastApiContainerConfig } from '../schema';
-import { ApplicationLoadBalancer } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { ApplicationListener, ApplicationLoadBalancer, BaseApplicationListenerProps } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 
 // This is the amount of memory to buffer (or subtract off) from the total instance memory, if we don't include this,
 // the container can have a hard time finding available RAM resources to start and the tasks will fail deployment
@@ -44,6 +44,8 @@ interface FastApiContainerProps extends BaseProps {
   tokenTable: ITable;
   vpc: IVpc;
   alb: ApplicationLoadBalancer;
+  listener: ApplicationListener;
+  listenerProps: BaseApplicationListenerProps;
 }
 
 /**
@@ -67,7 +69,7 @@ export class FastApiContainer extends Construct {
   constructor(scope: Construct, id: string, props: FastApiContainerProps) {
     super(scope, id);
 
-    const { config, securityGroup, taskConfig, tokenTable, vpc, alb } = props;
+    const { config, securityGroup, taskConfig, tokenTable, vpc, alb, listener, listenerProps } = props;
 
     let buildArgs: Record<string, string> | undefined = undefined;
     if (taskConfig.containerConfig.image.type === EcsSourceType.ASSET) {
@@ -105,6 +107,8 @@ export class FastApiContainer extends Construct {
       securityGroup,
       vpc,
       alb,
+      listener,
+      listenerProps,
     });
     tokenTable.grantReadData(apiCluster.taskRole);
 

--- a/lib/api-base/fastApiContainer.ts
+++ b/lib/api-base/fastApiContainer.ts
@@ -23,6 +23,7 @@ import { Construct } from 'constructs';
 
 import { ECSCluster } from './ecsCluster';
 import { BaseProps, Ec2Metadata, EcsSourceType, FastApiContainerConfig } from '../schema';
+import { ApplicationLoadBalancer } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 
 // This is the amount of memory to buffer (or subtract off) from the total instance memory, if we don't include this,
 // the container can have a hard time finding available RAM resources to start and the tasks will fail deployment
@@ -41,6 +42,7 @@ interface FastApiContainerProps extends BaseProps {
   taskConfig: FastApiContainerConfig;
   tokenTable: ITable;
   vpc: IVpc;
+  alb: ApplicationLoadBalancer;
 }
 
 /**
@@ -64,7 +66,7 @@ export class FastApiContainer extends Construct {
   constructor(scope: Construct, id: string, props: FastApiContainerProps) {
     super(scope, id);
 
-    const { config, securityGroup, taskConfig, tokenTable, vpc } = props;
+    const { config, securityGroup, taskConfig, tokenTable, vpc, alb } = props;
 
     let buildArgs: Record<string, string> | undefined = undefined;
     if (taskConfig.containerConfig.image.type === EcsSourceType.ASSET) {
@@ -99,6 +101,7 @@ export class FastApiContainer extends Construct {
       },
       securityGroup,
       vpc,
+      alb,
     });
     tokenTable.grantReadData(apiCluster.taskRole);
 

--- a/lib/api-base/rest-api-gw.ts
+++ b/lib/api-base/rest-api-gw.ts
@@ -50,6 +50,7 @@ export class RestApiGateway extends Construct {
       throttlingBurstLimit: 100,
     };
 
+    //TODO: convert this to an ALB
     this.restApi = new RestApi(this, `${id}-RestApi`, {
       description: 'The User Interface and session management Lambda API Layer.',
       endpointConfiguration: { types: [EndpointType.REGIONAL] },

--- a/lib/api-base/utils.ts
+++ b/lib/api-base/utils.ts
@@ -98,6 +98,7 @@ export function registerAPIEndpoint(
     vpc,
     securityGroups,
   });
+  //TODO: attach this function to the ALB
   const functionResource = getOrCreateResource(scope, api.root, funcDef.path.split('/'));
   functionResource.addMethod(funcDef.method, new LambdaIntegration(handler), {
     authorizer,

--- a/lib/chat/api/session.ts
+++ b/lib/chat/api/session.ts
@@ -146,7 +146,7 @@ export class SessionApi extends Construct {
     apis.forEach((f) => {
       const lambdaFunction = registerAPIEndpoint(
         this,
-        restApi,
+        restApi, //TODO: register API endpoints with ALB instead of APIGW
         authorizer,
         config.lambdaSourcePath,
         [commonLambdaLayer],

--- a/lib/chat/index.ts
+++ b/lib/chat/index.ts
@@ -22,6 +22,7 @@ import { Construct } from 'constructs';
 
 import { SessionApi } from './api/session';
 import { BaseProps } from '../schema';
+import { ApplicationListener, ApplicationLoadBalancer } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 
 interface CustomLisaChatStackProps extends BaseProps {
   authorizer: IAuthorizer;
@@ -29,6 +30,8 @@ interface CustomLisaChatStackProps extends BaseProps {
   rootResourceId: string;
   securityGroups?: ISecurityGroup[];
   vpc?: IVpc;
+  alb: ApplicationLoadBalancer;
+  listener: ApplicationListener;
 }
 type LisaChatStackProps = CustomLisaChatStackProps & StackProps;
 
@@ -44,7 +47,7 @@ export class LisaChatApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props: LisaChatStackProps) {
     super(scope, id, props);
 
-    const { authorizer, config, restApiId, rootResourceId, securityGroups, vpc } = props;
+    const { authorizer, config, restApiId, rootResourceId, securityGroups, vpc, alb, listener } = props;
 
     // Add REST API Lambdas to APIGW
     new SessionApi(this, 'SessionApi', {
@@ -54,6 +57,8 @@ export class LisaChatApplicationStack extends Stack {
       rootResourceId,
       securityGroups,
       vpc,
+      alb,
+      listener,
     });
   }
 }

--- a/lib/rag/api/repository.ts
+++ b/lib/rag/api/repository.ts
@@ -128,7 +128,7 @@ export class RepositoryApi extends Construct {
     apis.forEach((f) => {
       registerAPIEndpoint(
         this,
-        restApi,
+        restApi, //TODO: convert to ALB
         authorizer,
         config.lambdaSourcePath,
         commonLayers,

--- a/lib/serve/index.ts
+++ b/lib/serve/index.ts
@@ -27,13 +27,15 @@ import { FastApiContainer } from '../api-base/fastApiContainer';
 import { createCdkId, getModelIdentifier } from '../core/utils';
 import { Vpc } from '../networking/vpc';
 import { BaseProps, ModelType, RegisteredModel } from '../schema';
-import { ApplicationLoadBalancer } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { ApplicationListener, ApplicationLoadBalancer, BaseApplicationListenerProps } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 
 const HERE = path.resolve(__dirname);
 
 interface CustomLisaStackProps extends BaseProps {
   vpc: Vpc;
   alb: ApplicationLoadBalancer;
+  listener: ApplicationListener;
+  listenerProps: BaseApplicationListenerProps;
 }
 type LisaStackProps = CustomLisaStackProps & StackProps;
 
@@ -54,7 +56,7 @@ export class LisaServeApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props: LisaStackProps) {
     super(scope, id, props);
 
-    const { config, vpc, alb } = props;
+    const { config, vpc, alb, listener, listenerProps } = props;
 
     // Create DynamoDB Table for enabling API token usage
     const tokenTable = new Table(this, 'TokenTable', {
@@ -77,7 +79,9 @@ export class LisaServeApplicationStack extends Stack {
       taskConfig: config.restApiConfig,
       tokenTable: tokenTable,
       vpc: vpc.vpc,
-      alb
+      alb,
+      listener,
+      listenerProps,
     });
 
     // Create Parameter Store entry with RestAPI URI

--- a/lib/serve/index.ts
+++ b/lib/serve/index.ts
@@ -27,11 +27,13 @@ import { FastApiContainer } from '../api-base/fastApiContainer';
 import { createCdkId, getModelIdentifier } from '../core/utils';
 import { Vpc } from '../networking/vpc';
 import { BaseProps, ModelType, RegisteredModel } from '../schema';
+import { ApplicationLoadBalancer } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 
 const HERE = path.resolve(__dirname);
 
 interface CustomLisaStackProps extends BaseProps {
   vpc: Vpc;
+  alb: ApplicationLoadBalancer;
 }
 type LisaStackProps = CustomLisaStackProps & StackProps;
 
@@ -52,7 +54,7 @@ export class LisaServeApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props: LisaStackProps) {
     super(scope, id, props);
 
-    const { config, vpc } = props;
+    const { config, vpc, alb } = props;
 
     // Create DynamoDB Table for enabling API token usage
     const tokenTable = new Table(this, 'TokenTable', {
@@ -75,6 +77,7 @@ export class LisaServeApplicationStack extends Stack {
       taskConfig: config.restApiConfig,
       tokenTable: tokenTable,
       vpc: vpc.vpc,
+      alb
     });
 
     // Create Parameter Store entry with RestAPI URI

--- a/lib/stages.ts
+++ b/lib/stages.ts
@@ -132,7 +132,8 @@ export class LisaServeApplicationStage extends Stage {
       stackName: createCdkId([config.deploymentName, config.appName, 'API']),
       description: `LISA-API: ${config.deploymentName}-${config.deploymentStage}`,
       vpc: networkingStack.vpc.vpc,
-      securityGroup: networkingStack.vpc.securityGroups.restApiAlbSg
+      securityGroup: networkingStack.vpc.securityGroups.restApiAlbSg,
+      sslCertIamArn: config.restApiConfig.loadBalancerConfig.sslCertIamArn,
     });
     apiBaseStack.addDependency(coreStack);
     stacks.push(apiBaseStack);
@@ -143,6 +144,8 @@ export class LisaServeApplicationStage extends Stage {
       stackName: createCdkId([config.deploymentName, config.appName, 'serve', config.deploymentStage]),
       vpc: networkingStack.vpc,
       alb: apiBaseStack.loadBalancer,
+      listener: apiBaseStack.listener,
+      listenerProps: apiBaseStack.listenerProps
     });
     stacks.push(serveStack);
     serveStack.addDependency(iamStack);
@@ -161,6 +164,8 @@ export class LisaServeApplicationStage extends Stage {
       restApiId: apiBaseStack.restApiId,
       rootResourceId: apiBaseStack.rootResourceId,
       vpc: networkingStack.vpc.vpc,
+      alb: apiBaseStack.loadBalancer,
+      listener: apiBaseStack.listener,
     });
     chatStack.addDependency(apiBaseStack);
     chatStack.addDependency(coreStack);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "lisa",
-  "version": "0.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lisa",
-      "version": "0.1.0",
-      "license": "ISC",
+      "version": "1.2.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "aws-cdk-lib": "2.125.0",
         "cdk-nag": "^2.27.198",


### PR DESCRIPTION
*Description of changes:*

* Move the ALB created in the ecsCluster stack into a common place where it can be re-used. A public LB is created for FastAPI and other public API endpoints, with a new private ALB being created to specifically handle private model endpoints.

TODO:
* create endpoints for the session and RAG endpoints
* create an endpoint for website hosting

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
