### PR TITLE
Deprecate v1 routes in favor of v2

### DIFF
--- a/lib/serve/rest-api/src/api/routes.py
+++ b/lib/serve/rest-api/src/api/routes.py
@@ -28,9 +28,13 @@ logger = logging.getLogger(__name__)
 security = OIDCHTTPBearer()
 router = APIRouter()
 
-router.include_router(models.router, prefix="/v1", tags=["models"], dependencies=[Depends(security)])
-router.include_router(embeddings.router, prefix="/v1", tags=["embeddings"], dependencies=[Depends(security)])
-router.include_router(generation.router, prefix="/v1", tags=["generation"], dependencies=[Depends(security)])
+router.include_router(models.router, prefix="/v1", tags=["models"], dependencies=[Depends(security)], deprecated=True)
+router.include_router(
+    embeddings.router, prefix="/v1", tags=["embeddings"], dependencies=[Depends(security)], deprecated=True
+)
+router.include_router(
+    generation.router, prefix="/v1", tags=["generation"], dependencies=[Depends(security)], deprecated=True
+)
 router.include_router(
     litellm_passthrough.router, prefix="/v2/serve", tags=["litellm_passthrough"], dependencies=[Depends(security)]
 )


### PR DESCRIPTION
As we encourage users to use the v2 routes, we don't want to entirely remove v1 just yet, but we do want to discourage its usage. From the OpenAPI docs that are generated, I can now see that the /v1/ routes are deprecated, and only the v2 routes and health check route are still supported. Screenshot of the docs page from FastAPI attached: 
<img width="1480" alt="Screenshot 2024-06-06 at 6 24 07 PM" src="https://github.com/awslabs/LISA/assets/4528106/b71a9c3f-b534-4a39-822c-62c05c74ea37">

I validated that the v1 routes still work alongside the v2 routes. This is mostly a cosmetic change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
