### PR TITLE
Fix None values from config file where array is expected

### DIFF
--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -727,7 +727,12 @@ const LiteLLMModel = z.object({
  */
 const LiteLLMConfig = z.object({
   environment_variables: z.map(z.string(), z.string()).optional(),
-  model_list: z.array(LiteLLMModel).optional().nullable().default([]),
+  model_list: z
+    .array(LiteLLMModel)
+    .optional()
+    .nullable()
+    .default([])
+    .transform((value) => value ?? []),
   litellm_settings: z.object({
     // ALL (https://github.com/BerriAI/litellm/blob/main/litellm/__init__.py)
     telemetry: z.boolean().default(false).optional(),

--- a/lib/serve/rest-api/src/utils/generate_litellm_config.py
+++ b/lib/serve/rest-api/src/utils/generate_litellm_config.py
@@ -48,7 +48,9 @@ def generate_config(filepath: str) -> None:
         }
         for model in registered_models
     ]
-    config_contents["model_list"].extend(litellm_model_params)
+    config_models = config_contents["model_list"] or []  # ensure config_models is a list and not None
+    config_models.extend(litellm_model_params)
+    config_contents["model_list"] = config_models
     # Write updated config back to original path
     with open(filepath, "w") as fp:
         yaml.safe_dump(config_contents, fp)


### PR DESCRIPTION
I received a report that one of my recent changes was causing an error when deploying the REST API container without a LiteLLM models list defined, which is the default for new config files. Because it was left as a null value and not an array, the Python file for generating the rest of the LiteLLM config received a None instead of an empty list. This fix includes two fixes for the same issue:

1. On the typescript side, the schema was updated so that it forces an array if the array is not defined. The "default" function only applies if the field is `undefined`, not if it's `null`: the case we're solving for.
2. On the python side, we now check if the model list is truthy before trying to extend it, which catches the None case. If it is None (or any falsy value), it'll return an empty list, which can then be extended properly.

Tested by deploying to my account with these changes and with the `models_list` defined, but not populated, as in, my config is:
```yaml
  litellmConfig:
    litellm_settings:
      telemetry: false  # Don't try to send telemetry to LiteLLM servers.
      drop_params: true  # don't fail if params not recognized
    model_list: # evaluates to `null` because field is defined but has no value. I want this to become []
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
