### PR TITLE
Add support for vLLM embedding models

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,9 @@ you can do so.
     remain the same as the model definition examples we have for the TGI or TEI models. vLLM can also support embedding
     models in this way, so all you need to do is refer to the embedding model artifacts and remove the `streaming` field
     to deploy the embedding model.
+  - vLLM has support for the OpenAI Embeddings API, but model support for it is limited because the feature is new. Currently,
+    the only supported embedding model with vLLM is [intfloat/e5-mistral-7b-instruct](https://huggingface.co/intfloat/e5-mistral-7b-instruct),
+    but this list is expected to grow over time as vLLM updates.
     ```yaml
     ecsModels:
       - modelName: mistralai/Mistral-7B-Instruct-v0.2
@@ -294,7 +297,7 @@ you can do so.
         inferenceContainer: vllm # vLLM-specific config
         containerConfig:
           image:
-            baseImage: vllm/vllm-openai:v0.4.2 # vLLM-specific config
+            baseImage: vllm/vllm-openai:v0.5.0 # vLLM-specific config
             path: lib/serve/ecs-model/vllm # vLLM-specific config
     ```
 - If you are deploying the LISA Chat User Interface you can optionally specify the path to the pre-built

--- a/lisa-sdk/lisapy/langchain.py
+++ b/lisa-sdk/lisapy/langchain.py
@@ -129,6 +129,9 @@ class LisaOpenAIEmbeddings(BaseModel, Embeddings):
             openai_api_base=self.lisa_openai_api_base,
             openai_api_key="ignored",  # pragma: allowlist secret
             model=self.model,
+            model_kwargs={
+                "encoding_format": "float",  # keep values as floats because base64 is not widely supported
+            },
             http_async_client=HttpAsyncClient(verify=self.verify),
             http_client=HttpClient(verify=self.verify),
             default_headers=self.headers,


### PR DESCRIPTION
This change adds explicit support for vLLM embedding models (all one of them so far) for use within LISA. Either LiteLLM or LangChain was defaulting the embeddings API to using base64 as the encoding format, which the intfloat model threw errors on. By changing the encoding format to float, we preserve the functionality of the existing RAG implementation, and prevent the intfloat model from failing when it's called with default parameters.

Tested by deploying to my account and using the intfloat model for document upload and search within the chat UI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
