### PR TITLE
Add default top_p value for Chat UI

### DIFF
--- a/lib/user-interface/react/src/components/chatbot/ModelKwargs.tsx
+++ b/lib/user-interface/react/src/components/chatbot/ModelKwargs.tsx
@@ -34,7 +34,7 @@ export default function ModelKwargsEditor({ setModelConfig, visible, setVisible 
   // Default stop sequences based on User/Assistant instruction prompting for Falcon, Mistral, etc.
   const [maxNewTokens, setMaxNewTokens] = useState(null);
   const [n, setN] = useState(null);
-  const [topP, setTopP] = useState(null);
+  const [topP, setTopP] = useState(0.01);
   const [frequencyPenalty, setFrequencyPenalty] = useState(null);
   const [presencePenalty, setPresencePenalty] = useState(null);
   const [temperature, setTemperature] = useState(null);
@@ -127,7 +127,7 @@ export default function ModelKwargsEditor({ setModelConfig, visible, setVisible 
           <Input
             value={topP?.toString()}
             type="number"
-            step={0.1}
+            step={0.01}
             inputMode="decimal"
             disableBrowserAutocorrect={true}
             onChange={(event) => {


### PR DESCRIPTION
For models that are using vLLM, they respond nicely if the top_p parameter is not set, but the TGI models fail with an unclear message in the chat UI unless you're looking directly at the network calls in your browser. vLLM allows values for top_p within 0<N<=1, but TGI requires 0<N<1, which is where that error comes from if the value is not set and we default to `1` for the parameter.

Because there's a good chance our users are going to use a TGI container for their models, setting the value to 0.01 does not greatly impact the quality of responses that come back from either model (tested with mistral-7b on both TGI and vLLM).

The goal of this change is to reduce the amount of friction it takes to get started with the Chat UI out of the box, regardless of which model is being used.

For ease of editing the numbers in the application, I'm keeping the `topP?.toString` instead of `topP?.toFixed` as it was more difficult to edit or delete the number as a fixed precision number instead of a generic string.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
