### PR TITLE
Set default penalty params to null when unspecified

### DIFF
--- a/lib/user-interface/react/src/components/chatbot/Chat.tsx
+++ b/lib/user-interface/react/src/components/chatbot/Chat.tsx
@@ -279,7 +279,7 @@ export default function Chat({ sessionId }) {
   };
 
   const createOpenAiClient = (streaming: boolean) => {
-    const client = new ChatOpenAI({
+    return new ChatOpenAI({
       modelName: selectedModel?.id,
       openAIApiKey: auth.user?.id_token,
       configuration: {
@@ -287,24 +287,8 @@ export default function Chat({ sessionId }) {
       },
       streaming,
       maxTokens: modelConfig?.max_tokens,
-      n: modelConfig?.n,
-      topP: modelConfig?.top_p,
-      frequencyPenalty: modelConfig?.frequency_penalty,
-      presencePenalty: modelConfig?.presence_penalty,
-      temperature: modelConfig?.temperature,
-      stop: modelConfig?.stop,
       modelKwargs: modelConfig?.modelKwargs,
     });
-    // LangChain's JS OpenAI client sets default values that we do not want if we didn't set them.
-    // The following parameters are preferred to be null instead of having a numeric default value
-    // as they degrade the quality of the model response if set incorrectly by default.
-    if (!modelConfig?.frequency_penalty && modelConfig?.frequency_penalty !== 0) {
-      client.frequencyPenalty = null;
-    }
-    if (!modelConfig?.presence_penalty && modelConfig?.presence_penalty !== 0) {
-      client.presencePenalty = null;
-    }
-    return client;
   };
 
   const contextualizeQSystemPrompt = `Given a chat history and the latest user question

--- a/lib/user-interface/react/src/components/chatbot/Chat.tsx
+++ b/lib/user-interface/react/src/components/chatbot/Chat.tsx
@@ -279,7 +279,7 @@ export default function Chat({ sessionId }) {
   };
 
   const createOpenAiClient = (streaming: boolean) => {
-    return new ChatOpenAI({
+    const client = new ChatOpenAI({
       modelName: selectedModel?.id,
       openAIApiKey: auth.user?.id_token,
       configuration: {
@@ -295,6 +295,16 @@ export default function Chat({ sessionId }) {
       stop: modelConfig?.stop,
       modelKwargs: modelConfig?.modelKwargs,
     });
+    // LangChain's JS OpenAI client sets default values that we do not want if we didn't set them.
+    // The following parameters are preferred to be null instead of having a numeric default value
+    // as they degrade the quality of the model response if set incorrectly by default.
+    if (!modelConfig?.frequency_penalty && modelConfig?.frequency_penalty !== 0) {
+      client.frequencyPenalty = null;
+    }
+    if (!modelConfig?.presence_penalty && modelConfig?.presence_penalty !== 0) {
+      client.presencePenalty = null;
+    }
+    return client;
   };
 
   const contextualizeQSystemPrompt = `Given a chat history and the latest user question

--- a/lib/user-interface/react/src/components/chatbot/ModelKwargs.tsx
+++ b/lib/user-interface/react/src/components/chatbot/ModelKwargs.tsx
@@ -44,19 +44,19 @@ export default function ModelKwargsEditor({ setModelConfig, visible, setVisible 
   useEffect(() => {
     const modelConfig: ModelConfig = {
       max_tokens: maxNewTokens,
-      n: n,
-      top_p: topP,
-      frequency_penalty: frequencyPenalty,
-      presence_penalty: presencePenalty,
-      temperature: temperature,
-      stop: stopSequences.map((elem) => {
-        try {
-          return unraw(elem);
-        } catch (error) {
-          return elem;
-        }
-      }),
       modelKwargs: {
+        n: n,
+        top_p: topP,
+        frequency_penalty: frequencyPenalty,
+        presence_penalty: presencePenalty,
+        temperature: temperature,
+        stop: stopSequences.map((elem) => {
+          try {
+            return unraw(elem);
+          } catch (error) {
+            return elem;
+          }
+        }),
         seed,
       },
     };
@@ -96,7 +96,7 @@ export default function ModelKwargsEditor({ setModelConfig, visible, setVisible 
         </FormField>
         <FormField
           label="n"
-          constraintText="Must be greater than or equal to 1 - Defaults to 1 if not specified."
+          constraintText="Must be greater than or equal to 1 - Defaults to null if not specified."
           description="How many completions to generate for each prompt."
         >
           <Input
@@ -190,7 +190,7 @@ export default function ModelKwargsEditor({ setModelConfig, visible, setVisible 
         </FormField>
         <FormField
           label="temperature"
-          constraintText="Must be between 0 and 2.0 - Defaults to 1 if not specified."
+          constraintText="Must be between 0 and 2.0 - Defaults to null if not specified."
           description="What sampling temperature to use, between 0 and 2.
                   Higher values like 0.8 will make the output more random,
                   while lower values like 0.2 will make it more focused

--- a/lib/user-interface/react/src/components/chatbot/ModelKwargs.tsx
+++ b/lib/user-interface/react/src/components/chatbot/ModelKwargs.tsx
@@ -142,7 +142,7 @@ export default function ModelKwargsEditor({ setModelConfig, visible, setVisible 
         </FormField>
         <FormField
           label="frequency_penalty"
-          constraintText="Must be between -2.0 and 2.0 - Defaults to 0 if not specified."
+          constraintText="Must be between -2.0 and 2.0 - Defaults to null if not specified."
           description="Number between -2.0 and 2.0. Positive values
                     penalize new tokens based on their existing
                     frequency in the text so far, decreasing the model's
@@ -166,7 +166,7 @@ export default function ModelKwargsEditor({ setModelConfig, visible, setVisible 
         </FormField>
         <FormField
           label="presence_penalty"
-          constraintText="Must be between -2.0 and 2.0 - Defaults to 0 if not specified."
+          constraintText="Must be between -2.0 and 2.0 - Defaults to null if not specified."
           description="Number between -2.0 and 2.0. Positive values
                       penalize new tokens based on whether they appear
                       in the text so far, increasing the model's

--- a/lib/user-interface/react/src/components/types.tsx
+++ b/lib/user-interface/react/src/components/types.tsx
@@ -21,12 +21,6 @@ import { BaseMessage, BaseMessageFields, MessageContent, MessageType } from '@la
  */
 export type ModelConfig = {
   max_tokens?: number;
-  n?: number | null;
-  top_p?: number | null;
-  frequency_penalty?: number | null;
-  presence_penalty?: number | null;
-  temperature?: number | null;
-  stop: string[];
   modelKwargs?: ModelArgs;
 };
 
@@ -34,6 +28,12 @@ export type ModelConfig = {
  * Used to specify additional parameters in how the LLM processes inputs
  */
 export type ModelArgs = {
+  n?: number | null;
+  top_p?: number | null;
+  frequency_penalty?: number | null;
+  presence_penalty?: number | null;
+  temperature?: number | null;
+  stop: string[];
   seed?: number | null;
 };
 


### PR DESCRIPTION
The LangChain JS library sets some default values for presence and frequency penalties if we don't set them as part of the OpenAI client. As a result, we end up with a non-required numeric value (0) that we did not intend to put there, which heavily degrades the model responses on tgi containers. These changes override the defaults set by the client so that the values are either the numeric value we set, including 0, otherwise they will be null. I validated that this happens by setting and unsetting the values in the model kwargs of the Chat UI and checked the request data from the network tab of my browser. Now, by default, these values won't be set unless we want them to be.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
