### PR TITLE
Add PostgreSQL db for LiteLLM scaling

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -247,6 +247,8 @@ dev:
   litellmConfig:
     litellm_settings:
       telemetry: false  # Don't try to send telemetry to LiteLLM servers.
+    general_settings:
+      master_key: sk-d7a77bcb-3e23-483c-beec-2700f2baeeb1  # A key is required for model management purposes
     model_list: # Add any of your existing (not LISA-hosted) models here.
 #      - model_name: mymodel
 #        litellm_params:

--- a/lambda/utilities/vector_store.py
+++ b/lambda/utilities/vector_store.py
@@ -80,7 +80,7 @@ def get_vector_store_client(store: str, index: str, embeddings: Embeddings) -> V
         connection_string = PGVector.connection_string_from_db_params(
             driver="psycopg2",
             host=connection_info["dbHost"],
-            port=5432,
+            port=connection_info["dbPort"],
             database=connection_info["dbName"],
             user=connection_info["username"],
             password=password,

--- a/lib/api-base/fastApiContainer.ts
+++ b/lib/api-base/fastApiContainer.ts
@@ -81,6 +81,7 @@ export class FastApiContainer extends Construct {
       AWS_REGION: config.region,
       AWS_REGION_NAME: config.region, // for supporting SageMaker endpoints in LiteLLM
       THREADS: Ec2Metadata.get(taskConfig.instanceType).vCpus.toString(),
+      LITELLM_KEY: config.litellmConfig.general_settings.master_key, // for model management operations
     };
 
     if (config.restApiConfig.internetFacing) {

--- a/lib/rag/index.ts
+++ b/lib/rag/index.ts
@@ -252,7 +252,7 @@ export class LisaRagStack extends Stack {
           vpc.vpc.isolatedSubnets.concat(vpc.vpc.privateSubnets).forEach((subnet) => {
             pgvectorSg.connections.allowFrom(
               Peer.ipv4(subnet.ipv4CidrBlock),
-              Port.tcp(5432),
+              Port.tcp(ragConfig.rdsConfig?.dbPort || 5432),
               'Allow private subnets to communicate with PGVector database',
             );
           });
@@ -274,6 +274,7 @@ export class LisaRagStack extends Stack {
               passwordSecretId: rdsPasswordSecret.secretName,
               dbHost: pgvector_db.dbInstanceEndpointAddress,
               dbName: ragConfig.rdsConfig.dbName,
+              dbPort: ragConfig.rdsConfig.dbPort,
             }),
             description: 'Connection info for LISA Serve PGVector database',
           });

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -581,12 +581,14 @@ const AuthConfigSchema = z.object({
  * @property {string} passwordSecretId - SecretsManager Secret ID that stores an existing database password.
  * @property {string} dbHost - Database hostname for existing database instance.
  * @property {string} dbName - Database name for existing database instance.
+ * @property {number} dbPort - Port to open on the database instance.
  */
 const RdsInstanceConfig = z.object({
   username: z.string().optional().default('postgres'),
   passwordSecretId: z.string().optional(),
   dbHost: z.string().optional(),
   dbName: z.string().optional().default('postgres'),
+  dbPort: z.number().optional().default(5432),
 });
 
 /**

--- a/lib/serve/index.ts
+++ b/lib/serve/index.ts
@@ -93,7 +93,7 @@ export class LisaServeApplicationStack extends Stack {
     vpc.vpc.isolatedSubnets.concat(vpc.vpc.privateSubnets).forEach((subnet) => {
       litellmDbSg.connections.allowFrom(
         Peer.ipv4(subnet.ipv4CidrBlock),
-        Port.tcp(5432),
+        Port.tcp(rdsConfig.dbPort),
         'Allow REST API private subnets to communicate with LiteLLM database',
       );
     });
@@ -120,6 +120,7 @@ export class LisaServeApplicationStack extends Stack {
         passwordSecretId: litellmDbPasswordSecret.secretName,
         dbHost: litellmDb.dbInstanceEndpointAddress,
         dbName: rdsConfig.dbName,
+        dbPort: rdsConfig.dbPort,
       }),
     });
     litellmDbPasswordSecret.grantRead(restApi.taskRole);

--- a/lib/serve/rest-api/src/api/endpoints/v2/litellm_passthrough.py
+++ b/lib/serve/rest-api/src/api/endpoints/v2/litellm_passthrough.py
@@ -15,6 +15,7 @@
 """Model invocation routes."""
 
 import logging
+import os
 from collections.abc import Iterator
 from typing import Union
 
@@ -25,6 +26,11 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 # Local LiteLLM installation URL. By default, LiteLLM runs on port 4000. Change the port here if the
 # port was changed as part of the LiteLLM startup in entrypoint.sh
 LITELLM_URL = "http://localhost:4000"
+
+# With the introduction of the LiteLLM database for model configurations, it forces a requirement to have a
+# LiteLLM-vended API key. Since we are not requiring LiteLLM keys for customers, we are using the LiteLLM key
+# required for the db and injecting that into all requests instead to overcome that requirement.
+LITELLM_KEY = os.environ["LITELLM_KEY"]
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +59,13 @@ async def litellm_passthrough(request: Request, api_path: str) -> Response:
     """
     litellm_path = f"{LITELLM_URL}/{api_path}"
     headers = dict(request.headers.items())
+
+    # At this point in the request, we have already validated auth with IdP or persistent token. By using LiteLLM for
+    # model management, LiteLLM requires an admin key, and that forces all requests to require a key as well. To avoid
+    # soliciting yet another form of auth from the user, we add the existing LiteLLM key to the headers that go directly
+    # to the LiteLLM instance.
+    headers["Authorization"] = f"Bearer {LITELLM_KEY}"
+
     http_method = request.method
     if http_method == "GET":
         return JSONResponse(requests.request(method=http_method, url=litellm_path, headers=headers).json())

--- a/lib/serve/rest-api/src/requirements.txt
+++ b/lib/serve/rest-api/src/requirements.txt
@@ -9,6 +9,7 @@ fastapi_utils==0.6.0
 gunicorn==22.0.0
 litellm[proxy]==1.38.12
 loguru==0.7.2
+prisma==0.13.1
 pydantic==1.10.15 # must be <2
 PyJWT==2.8.0
 text-generation==0.6.1

--- a/lib/serve/rest-api/src/utils/generate_litellm_config.py
+++ b/lib/serve/rest-api/src/utils/generate_litellm_config.py
@@ -58,7 +58,10 @@ def generate_config(filepath: str) -> None:
     db_params = json.loads(db_param_response["Parameter"]["Value"])
     secrets_response = secrets_client.get_secret_value(SecretId=db_params["passwordSecretId"])
     password = json.loads(secrets_response["SecretString"])["password"]
-    connection_str = f"postgresql://{db_params['username']}:{password}@{db_params['dbHost']}:5432/{db_params['dbName']}"
+    connection_str = (
+        f"postgresql://{db_params['username']}:{password}@{db_params['dbHost']}:{db_params['dbPort']}"
+        f"/{db_params['dbName']}"
+    )
 
     general_settings = config_contents["general_settings"]
     general_settings.update(

--- a/test/cdk/mocks/config.yaml
+++ b/test/cdk/mocks/config.yaml
@@ -235,6 +235,8 @@ dev:
     #       healthyThresholdCount: 2
     #       unhealthyThresholdCount: 10
   litellmConfig:
+    general_settings:
+      master_key: sk-012345
     litellm_settings:
       telemetry: false
     model_list:

--- a/test/cdk/stacks/serve.test.ts
+++ b/test/cdk/stacks/serve.test.ts
@@ -97,7 +97,7 @@ describe.each(regions)('Serve Nag Pack Tests | Region Test: %s', (awsRegion) => 
 
   test('AwsSolutions CDK NAG Errors', () => {
     const errors = Annotations.fromStack(stack).findError('*', Match.stringLikeRegexp('AwsSolutions-.*'));
-    expect(errors.length).toBe(51);
+    expect(errors.length).toBe(56);
   });
 
   test('NIST800.53r5 CDK NAG Warnings', () => {
@@ -107,6 +107,6 @@ describe.each(regions)('Serve Nag Pack Tests | Region Test: %s', (awsRegion) => 
 
   test('NIST800.53r5 CDK NAG Errors', () => {
     const errors = Annotations.fromStack(stack).findError('*', Match.stringLikeRegexp('NIST.*'));
-    expect(errors.length).toBe(54);
+    expect(errors.length).toBe(64);
   });
 });


### PR DESCRIPTION
This set of changes adds a PostgreSQL database to the Serve infrastructure to help with scaling LiteLLM across multiple instances. This database will be used between multiple REST API containers so that models that are dynamically added to a running LiteLLM instance will update the DB and be available across all other REST API containers behind the LISA Serve endpoint.

Tests have increased error counts because the database is a Single-AZ db. This is expected to be fine because the database is only used for this one purpose and is not anticipated to have any form of high load on it.

This database will be used in further model management feature development.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
