### PR TITLE
Adding confirmation modal for start/stop/delete actions

### DIFF
--- a/lambda/models/lambda_functions.py
+++ b/lambda/models/lambda_functions.py
@@ -60,25 +60,45 @@ async def list_models() -> list[ListModelResponse]:
     """Endpoint to list models."""
     # TODO add service to list models
     return [
-        ListModelResponse(
-            ModelId="my_first_model",
-            ModelName="my_first_model",
-            ModelType=ModelType.TEXTGEN,
-            Status=ModelStatus.CREATING,
-            Streaming=True,
-            ModelUrl="http://some.cool.alb.amazonaws.com/path/to/endpoint",
-            ContainerConfig=ContainerConfig.DUMMY(),
-        ),
-        ListModelResponse(
-            ModelId="my_second_model",
-            ModelName="my_second_model",
-            ModelType=ModelType.TEXTGEN,
-            Status=ModelStatus.IN_SERVICE,
-            Streaming=True,
-            ModelUrl="http://some.cool.alb.amazonaws.com/path/to/endpoint",
-            ContainerConfig=ContainerConfig.DUMMY(),
-        ),
+        _create_dummy_model("my_first_model", ModelType.TEXTGEN, ModelStatus.CREATING),
+        _create_dummy_model("my_second_model", ModelType.EMBEDDING, ModelStatus.IN_SERVICE),
+        _create_dummy_model("my_third_model", ModelType.EMBEDDING, ModelStatus.STOPPING),
+        _create_dummy_model("my_fourth_model", ModelType.TEXTGEN, ModelStatus.STOPPED),
+        _create_dummy_model("my_fifth_model", ModelType.EMBEDDING, ModelStatus.UPDATING),
+        _create_dummy_model("my_sixth_model", ModelType.EMBEDDING, ModelStatus.DELETING),
+        _create_dummy_model("my_seventh_model", ModelType.TEXTGEN, ModelStatus.FAILED),
+        _create_dummy_model("my_eighth_model", ModelType.TEXTGEN, ModelStatus.FAILED),
+        _create_dummy_model("my_ninth_model", ModelType.EMBEDDING, ModelStatus.DELETING),
+        _create_dummy_model("my_tenth_model", ModelType.TEXTGEN, ModelStatus.UPDATING),
+        _create_dummy_model("my_eleventh_model", ModelType.EMBEDDING, ModelStatus.STOPPED),
+        _create_dummy_model("my_twelfth_model", ModelType.EMBEDDING, ModelStatus.STOPPING),
+        _create_dummy_model("my_thirteenth_model", ModelType.TEXTGEN, ModelStatus.IN_SERVICE),
+        _create_dummy_model("my_fourteenth_model", ModelType.TEXTGEN, ModelStatus.CREATING),
+        _create_dummy_model("my_fifteenth_model", ModelType.EMBEDDING, ModelStatus.CREATING),
+        _create_dummy_model("my_sixteenth_model", ModelType.TEXTGEN, ModelStatus.IN_SERVICE),
+        _create_dummy_model("my_seventeenth_model", ModelType.EMBEDDING, ModelStatus.STOPPING),
+        _create_dummy_model("my_eighteenth_model", ModelType.EMBEDDING, ModelStatus.STOPPED),
+        _create_dummy_model("my_nineteenth_model", ModelType.EMBEDDING, ModelStatus.UPDATING),
+        _create_dummy_model("my_twentieth_model", ModelType.TEXTGEN, ModelStatus.DELETING),
+        _create_dummy_model("my_twenty_first_model", ModelType.TEXTGEN, ModelStatus.FAILED),
+        _create_dummy_model("my_twenty_second_model", ModelType.EMBEDDING, ModelStatus.FAILED),
+        _create_dummy_model("my_twenty_third_model", ModelType.EMBEDDING, ModelStatus.DELETING),
+        _create_dummy_model("my_twenty_fourth_model", ModelType.TEXTGEN, ModelStatus.UPDATING),
+        _create_dummy_model("my_twenty_fifth_model", ModelType.TEXTGEN, ModelStatus.STOPPED),
+        _create_dummy_model("my_twenty_sixth_model", ModelType.TEXTGEN, ModelStatus.IN_SERVICE),
     ]
+
+
+def _create_dummy_model(model_name: str, model_type: ModelType, model_status: ModelStatus) -> ListModelResponse:
+    return ListModelResponse(
+        ModelId=f"{model_name}_id",
+        ModelName=model_name,
+        ModelType=model_type,
+        Status=model_status,
+        Streaming=model_type == ModelType.TEXTGEN,
+        ModelUrl="http://some.cool.alb.amazonaws.com/path/to/endpoint",
+        ContainerConfig=ContainerConfig.DUMMY(),
+    )
 
 
 @app.get(path="/{model_id}")  # type: ignore

--- a/lib/user-interface/react/src/App.tsx
+++ b/lib/user-interface/react/src/App.tsx
@@ -29,6 +29,7 @@ import { useAppSelector } from './config/store';
 import { selectCurrentUserIsAdmin } from './shared/reducers/user.reducer';
 import ModelManagement from './pages/ModelManagement';
 import NotificationBanner from './shared/notification/notification';
+import ConfirmationModal, { ConfirmationModalProps } from './shared/modal/confirmation-modal';
 
 const PrivateRoute = ({ children }) => {
     const auth = useAuth();
@@ -56,6 +57,7 @@ const AdminRoute = ({ children }) => {
 function App () {
     const [showTools, setShowTools] = useState(false);
     const [tools, setTools] = useState(null);
+    const confirmationModal: ConfirmationModalProps = useAppSelector((state) => state.modal.confirmationModal);
 
     useEffect(() => {
         if (tools) {
@@ -114,6 +116,7 @@ function App () {
                     </Routes>
                 }
             />
+            {confirmationModal && <ConfirmationModal {...confirmationModal} />}
             {window.env.SYSTEM_BANNER?.text && <SystemBanner position='BOTTOM' />}
         </HashRouter>
     );

--- a/lib/user-interface/react/src/components/model-management/ModelManagementActions.tsx
+++ b/lib/user-interface/react/src/components/model-management/ModelManagementActions.tsx
@@ -27,6 +27,8 @@ import {
     useStopModelMutation,
 } from '../../shared/reducers/model-management.reducer';
 import { MutationTrigger } from '@reduxjs/toolkit/dist/query/react/buildHooks';
+import { Action, ThunkDispatch } from '@reduxjs/toolkit';
+import { setConfirmationModal } from '../../shared/reducers/modal.reducer';
 
 export type ModelActionProps = {
     selectedItems: IModel[];
@@ -41,7 +43,7 @@ function ModelActions (props: ModelActionProps): ReactElement {
 
     return (
         <SpaceBetween direction='horizontal' size='xs'>
-            {ModelActionButton(notificationService, props)}
+            {ModelActionButton(dispatch, notificationService, props)}
             <Button iconName='add-plus' variant='primary' onClick={() => {
                 props.setEdit(false);
                 props.setNewModelModelVisible(true);
@@ -58,7 +60,7 @@ function ModelActions (props: ModelActionProps): ReactElement {
     );
 }
 
-function ModelActionButton (notificationService: INotificationService, props?: any): ReactElement {
+function ModelActionButton (dispatch: ThunkDispatch<any, any, Action>, notificationService: INotificationService, props?: any): ReactElement {
     const selectedModel: IModel = props?.selectedItems[0];
     const [
         deleteMutation,
@@ -131,7 +133,7 @@ function ModelActionButton (notificationService: INotificationService, props?: a
             disabled={!selectedModel}
             loading={isDeleteLoading || isStopLoading || isStartLoading}
             onItemClick={(e) =>
-                ModelActionHandler(e, selectedModel, notificationService, deleteMutation, stopMutation, startMutation)
+                ModelActionHandler(e, selectedModel, dispatch, notificationService, deleteMutation, stopMutation, startMutation)
             }
         >
             Actions
@@ -142,6 +144,7 @@ function ModelActionButton (notificationService: INotificationService, props?: a
 const ModelActionHandler = async (
     e: any,
     selectedModel: IModel,
+    dispatch: ThunkDispatch<any, any, Action>,
     notificationService: INotificationService,
     deleteMutation: MutationTrigger<any>,
     stopMutation: MutationTrigger<any>,
@@ -149,16 +152,37 @@ const ModelActionHandler = async (
 ) => {
     switch (e.detail.id) {
         case 'startModel':
-            startMutation(selectedModel.ModelId);
+            dispatch(
+                setConfirmationModal({
+                    action: 'Start',
+                    resourceName: 'Model',
+                    onConfirm: () => startMutation(selectedModel.ModelId),
+                    description: `This will start the following model: ${selectedModel.ModelId}.`
+                })
+            );
             break;
         case 'stopModel':
-            stopMutation(selectedModel.ModelId);
+            dispatch(
+                setConfirmationModal({
+                    action: 'Stop',
+                    resourceName: 'Model',
+                    onConfirm: () => stopMutation(selectedModel.ModelId),
+                    description: `This will stop the following model: ${selectedModel.ModelId}.`
+                })
+            );
             break;
         case 'editModel':
             notificationService.generateNotification('Calling Edit Model', 'success');
             break;
         case 'deleteModel':
-            deleteMutation(selectedModel.ModelId);
+            dispatch(
+                setConfirmationModal({
+                    action: 'Delete',
+                    resourceName: 'Model',
+                    onConfirm: () => deleteMutation(selectedModel.ModelId),
+                    description: `This will delete the following model: ${selectedModel.ModelId}.`
+                })
+            );
             break;
         default:
             return;

--- a/lib/user-interface/react/src/components/model-management/ModelManagementUtils.tsx
+++ b/lib/user-interface/react/src/components/model-management/ModelManagementUtils.tsx
@@ -65,14 +65,15 @@ export const CARD_DEFINITIONS = {
 };
 
 export const PAGE_SIZE_OPTIONS = [
-    { value: 10, label: '10 Models' },
-    { value: 30, label: '30 Models' },
-    { value: 50, label: '50 Models' },
+    { value: 6, label: '6 Models' },
+    { value: 12, label: '12 Models' },
+    { value: 24, label: '24 Models' },
+    { value: 48, label: '48 Models' },
 ];
 
 export const DEFAULT_PREFERENCES = {
-    pageSize: 30,
-    visibleContent: ['ModelType', 'ModelStatus'],
+    pageSize: 12,
+    visibleContent: ['ModelId', 'ModelType', 'ModelUrl', 'Streaming', 'ModelStatus'],
 };
 
 export const VISIBLE_CONTENT_OPTIONS = [

--- a/lib/user-interface/react/src/shared/modal/confirmation-modal.tsx
+++ b/lib/user-interface/react/src/shared/modal/confirmation-modal.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Modal as CloudscapeModal, Box, SpaceBetween, Button } from '@cloudscape-design/components';
-import React, { useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { useAppDispatch } from '../../config/store';
 import { dismissModal } from '../reducers/modal.reducer';
 import { MutationActionCreatorResult } from '@reduxjs/toolkit/query';
@@ -38,7 +38,7 @@ function ConfirmationModal ({
     postConfirm,
     description,
     disabled,
-}: ConfirmationModalProps) {
+}: ConfirmationModalProps) : ReactElement{
     const [processing, setProcessing] = useState(false);
     const dispatch = useAppDispatch();
 

--- a/lib/user-interface/react/src/shared/modal/confirmation-modal.tsx
+++ b/lib/user-interface/react/src/shared/modal/confirmation-modal.tsx
@@ -1,0 +1,82 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import { Modal as CloudscapeModal, Box, SpaceBetween, Button } from '@cloudscape-design/components';
+import React, { useState } from 'react';
+import { useAppDispatch } from '../../config/store';
+import { dismissModal } from '../reducers/modal.reducer';
+import { MutationActionCreatorResult } from '@reduxjs/toolkit/query';
+
+export type CallbackFunction<T = any, R = void> = (props?: T) => R;
+
+export type ConfirmationModalProps = {
+    action: string;
+    resourceName: string;
+    onConfirm: () =>  MutationActionCreatorResult<any>;
+    postConfirm?: CallbackFunction;
+    description?: string;
+    disabled?: boolean;
+};
+
+function ConfirmationModal ({
+    action,
+    resourceName,
+    onConfirm,
+    postConfirm,
+    description,
+    disabled,
+}: ConfirmationModalProps) {
+    const [processing, setProcessing] = useState(false);
+    const dispatch = useAppDispatch();
+
+    return (
+        <CloudscapeModal
+            onDismiss={() => [dispatch(dismissModal())]}
+            visible={true}
+            closeAriaLabel='Close modal'
+            footer={
+                <Box float='right'>
+                    <SpaceBetween direction='horizontal' size='xs'>
+                        <Button onClick={() => [dispatch(dismissModal())]}>
+                            Cancel
+                        </Button>
+                        <Button
+                            data-cy='modal-confirm'
+                            variant='primary'
+                            onClick={async () => {
+                                setProcessing(true);
+                                await onConfirm();
+                                dispatch(dismissModal());
+                                if (postConfirm) {
+                                    postConfirm();
+                                }
+                            }}
+                            loading={processing}
+                            disabled={disabled}
+                        >
+                            {action}
+                        </Button>
+                    </SpaceBetween>
+                </Box>
+            }
+            header={`${action} "${resourceName}"?`}
+        >
+            {description}
+        </CloudscapeModal>
+    );
+}
+
+export default ConfirmationModal;

--- a/lib/user-interface/react/src/shared/reducers/index.ts
+++ b/lib/user-interface/react/src/shared/reducers/index.ts
@@ -18,11 +18,13 @@ import { ReducersMapObject } from '@reduxjs/toolkit';
 
 import userReducer from './user.reducer';
 import notificationReducer from './notification.reducer';
+import modalReducer from './modal.reducer';
 import { modelManagementApi } from './model-management.reducer';
 
 const rootReducer: ReducersMapObject = {
     user: userReducer,
     notification: notificationReducer,
+    modal: modalReducer,
     [modelManagementApi.reducerPath]: modelManagementApi.reducer,
 };
 

--- a/lib/user-interface/react/src/shared/reducers/modal.reducer.ts
+++ b/lib/user-interface/react/src/shared/reducers/modal.reducer.ts
@@ -1,0 +1,39 @@
+/**
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { ConfirmationModalProps } from '../modal/confirmation-modal';
+
+const initialState = {
+    confirmationModal: undefined as ConfirmationModalProps | undefined,
+};
+
+const modalSlice = createSlice({
+    name: 'modal',
+    initialState,
+    reducers: {
+        setConfirmationModal (state, action: PayloadAction<ConfirmationModalProps>) {
+            state.confirmationModal = action.payload;
+        },
+        dismissModal (state) {
+            state.confirmationModal = undefined;
+        },
+    },
+});
+
+// Reducer
+export const { setConfirmationModal, dismissModal} = modalSlice.actions;
+export default modalSlice.reducer;


### PR DESCRIPTION
*Description of changes:*

When doing destructive actions we want to make sure our users are prompted for confirmation prior to that action being taken. That being said, I have added a confirmation modal that will ask the user if they are sure they want to proceed prior to taking any model start/stop/delete action. This can be seen in the below demo:

![demo](https://github.com/user-attachments/assets/dd351c96-4415-422f-befa-9fc0746ea10d)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
