### PR TITLE
Upgrade pypdf version

### DIFF
--- a/lambda/utilities/file_processing.py
+++ b/lambda/utilities/file_processing.py
@@ -23,8 +23,8 @@ import docx
 from botocore.exceptions import ClientError
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_core.documents import Document
-from PyPDF2 import PdfReader
-from PyPDF2.errors import PdfReadError
+from pypdf import PdfReader
+from pypdf.errors import PdfReadError
 from utilities.constants import DOCX_FILE, PDF_FILE, TEXT_FILE
 from utilities.exceptions import RagUploadException
 

--- a/lib/rag/layer/requirements.txt
+++ b/lib/rag/layer/requirements.txt
@@ -1,12 +1,12 @@
 boto3>=1.34.131
 botocore>=1.34.131
-opensearch-py==2.6.0
-requests-aws4auth==1.2.3
-PyPDF2==3.0.1
 langchain==0.2.9
 langchain-community==0.2.9
 langchain-openai==0.1.8
+opensearch-py==2.6.0
 pgvector==0.2.5
 psycopg2-binary==2.9.9
+pypdf==4.3.1
 python-docx==1.1.0
+requests-aws4auth==1.2.3
 urllib3<2


### PR DESCRIPTION
This commit gets rid of one of the dependabot security issues.

*Issue #, if available:*
https://github.com/awslabs/LISA/security/dependabot/1

*Description of changes:*
* Gets rid of a dependabot security issue. Tested that this works by deploying to test account and uploading a pdf in the RAG UI. Validated that the PDF was successfully parsed and embedded and that I could retrieve context from its contents.
* I also alphabetized the dependencies

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
