### PR TITLE
Lock down LiteLLM administrative APIs to admin users

### DIFF
--- a/lib/api-base/fastApiContainer.ts
+++ b/lib/api-base/fastApiContainer.ts
@@ -88,6 +88,8 @@ export class FastApiContainer extends Construct {
             environment.USE_AUTH = 'true';
             environment.AUTHORITY = config.authConfig!.authority;
             environment.CLIENT_ID = config.authConfig!.clientId;
+            environment.ADMIN_GROUP = config.authConfig!.adminGroup;
+            environment.JWT_GROUPS_PROP = config.authConfig!.jwtGroupsProperty;
         } else {
             environment.USE_AUTH = 'false';
         }

--- a/lib/serve/rest-api/src/api/endpoints/v2/litellm_passthrough.py
+++ b/lib/serve/rest-api/src/api/endpoints/v2/litellm_passthrough.py
@@ -45,7 +45,7 @@ OPENAI_ROUTES = (
     "v1/completions",
     # Embeddings
     "embeddings",
-    "/v1/embeddings",
+    "v1/embeddings",
     # Create images
     "images/generations",
     "v1/images/generations",

--- a/lib/serve/rest-api/src/api/endpoints/v2/litellm_passthrough.py
+++ b/lib/serve/rest-api/src/api/endpoints/v2/litellm_passthrough.py
@@ -20,12 +20,45 @@ from collections.abc import Iterator
 from typing import Union
 
 import requests
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
+from starlette.status import HTTP_401_UNAUTHORIZED
+
+from ....auth import get_authorization_token, get_jwks_client, id_token_is_valid, is_admin, is_idp_used
 
 # Local LiteLLM installation URL. By default, LiteLLM runs on port 4000. Change the port here if the
 # port was changed as part of the LiteLLM startup in entrypoint.sh
 LITELLM_URL = "http://localhost:4000"
+
+# The following is an allowlist of OpenAI routes that users would not need elevated permissions to invoke. This is so
+# that we may assume anything *not* in this allowlist is an admin operation that requires greater LiteLLM permissions.
+# Assume that anything not within these routes requires admin permissions, which would only come from the LISA model
+# management API.
+OPENAI_ROUTES = (
+    # List models
+    "models",
+    "v1/models",
+    # Text completions
+    "chat/completions",
+    "v1/chat/completions",
+    "completions",
+    "v1/completions",
+    # Embeddings
+    "embeddings",
+    "/v1/embeddings",
+    # Create images
+    "images/generations",
+    "v1/images/generations",
+    # Audio routes
+    "audio/speech",
+    "v1/audio/speech",
+    "audio/transcriptions",
+    "v1/audio/transcriptions",
+    # Health check routes
+    "health",
+    "health/readiness",
+    "health/liveliness",
+)
 
 # With the introduction of the LiteLLM database for model configurations, it forces a requirement to have a
 # LiteLLM-vended API key. Since we are not requiring LiteLLM keys for customers, we are using the LiteLLM key
@@ -59,6 +92,26 @@ async def litellm_passthrough(request: Request, api_path: str) -> Response:
     """
     litellm_path = f"{LITELLM_URL}/{api_path}"
     headers = dict(request.headers.items())
+
+    # If not handling an OpenAI request, we will also check if the user is an Admin user before allowing the request,
+    # otherwise, we will block it. This prevents non-admins from invoking model management APIs directly. If LISA
+    # Serve is deployed without an IdP configuration, we cannot determine who is an admin user, so all API routes
+    # will default to being openly accessible.
+    if api_path not in OPENAI_ROUTES and is_idp_used():
+        client_id = os.environ.get("CLIENT_ID", "")
+        authority = os.environ.get("AUTHORITY", "")
+        admin_group = os.environ.get("ADMIN_GROUP", "")
+        jwt_groups_property = os.environ.get("JWT_GROUPS_PROP", "")
+
+        id_token = get_authorization_token(headers=headers, header_name="Authorization")
+        jwks_client = get_jwks_client()
+        if jwt_data := id_token_is_valid(
+            id_token=id_token, authority=authority, client_id=client_id, jwks_client=jwks_client
+        ):
+            if not is_admin(jwt_data=jwt_data, admin_group=admin_group, jwt_groups_property=jwt_groups_property):
+                raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+        else:
+            raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Not authenticated")
 
     # At this point in the request, we have already validated auth with IdP or persistent token. By using LiteLLM for
     # model management, LiteLLM requires an admin key, and that forces all requests to require a key as well. To avoid

--- a/lib/serve/rest-api/src/auth.py
+++ b/lib/serve/rest-api/src/auth.py
@@ -35,6 +35,7 @@ API_KEY_HEADER_NAMES = [
 ]
 TOKEN_EXPIRATION_NAME = "tokenExpiration"  # nosec B105
 TOKEN_TABLE_NAME = "TOKEN_TABLE_NAME"  # nosec B105
+USE_AUTH = "USE_AUTH"
 
 
 logger_level = os.environ.get("LOG_LEVEL", "INFO")
@@ -49,9 +50,83 @@ logger.configure(
 )
 
 
+def is_idp_used() -> bool:
+    """Get if the identity provider is being used based on environment variable."""
+    return os.environ.get(USE_AUTH, "false").lower() == "true"
+
+
 if not jwt.algorithms.has_crypto:
     logger.error("No crypto support for JWT.")
     raise RuntimeError("No crypto support for JWT.")
+
+
+def get_oidc_metadata(cert_path: Optional[str] = None) -> Dict[str, Any]:
+    """Get OIDC endpoints and metadata from authority."""
+    authority = os.environ.get("AUTHORITY")
+    resp = requests.get(f"{authority}/.well-known/openid-configuration", verify=cert_path or True, timeout=30)
+    resp.raise_for_status()
+    return resp.json()  # type: ignore
+
+
+def get_jwks_client() -> jwt.PyJWKClient:
+    """Get JWK Client for JWT signing operations."""
+    if ("SSL_CERT_DIR" not in os.environ) or ("SSL_CERT_FILE" not in os.environ):
+        cert_path = None
+        logger.info("Using default certificate for SSL verification.")
+    else:
+        cert_path = str(Path(os.environ["SSL_CERT_DIR"], os.environ["SSL_CERT_FILE"]).absolute())
+        logger.info("Using self-signed certificate for SSL verification.")
+    ssl_context = ssl.create_default_context()
+    if cert_path:
+        ssl_context.load_verify_locations(cert_path)
+    oidc_metadata = get_oidc_metadata(cert_path)
+    return jwt.PyJWKClient(oidc_metadata["jwks_uri"], cache_jwk_set=True, lifespan=360, ssl_context=ssl_context)
+
+
+def id_token_is_valid(
+    id_token: str, client_id: str, authority: str, jwks_client: jwt.PyJWKClient
+) -> Optional[Dict[str, Any]]:
+    """Check whether an ID token is valid and return decoded data."""
+    try:
+        signing_key = jwks_client.get_signing_key_from_jwt(id_token)
+        data: Dict[str, Any] = jwt.decode(
+            id_token,
+            signing_key.key,
+            algorithms=["RS256"],
+            issuer=authority,
+            audience=client_id,
+            options={
+                "verify_signature": True,
+                "verify_exp": True,
+                "verify_nbf": True,
+                "verify_iat": True,
+                "verify_aud": True,
+                "verify_iss": True,
+            },
+        )
+        return data
+    except jwt.exceptions.PyJWTError as e:
+        logger.exception(e)
+        return None
+
+
+def is_admin(jwt_data: dict[str, Any], admin_group: str, jwt_groups_property: str) -> bool:
+    """Check if the user is an admin."""
+    props = jwt_groups_property.split(".")
+    current_node = jwt_data
+    for prop in props:
+        if prop in current_node:
+            current_node = current_node[prop]
+        else:
+            return False
+    return admin_group in current_node
+
+
+def get_authorization_token(headers: Dict[str, str], header_name: str) -> str:
+    """Get Bearer token from Authorization headers if it exists."""
+    if header_name in headers:
+        return headers.get(header_name, "").removeprefix("Bearer").strip()
+    return headers.get(header_name.lower(), "").removeprefix("Bearer").strip()
 
 
 class OIDCHTTPBearer(HTTPBearer):
@@ -61,61 +136,21 @@ class OIDCHTTPBearer(HTTPBearer):
         super().__init__(**kwargs)
         self._token_authorizer = ApiTokenAuthorizer()
 
-        if ("SSL_CERT_DIR" not in os.environ) or ("SSL_CERT_FILE" not in os.environ):
-            cert_path = None
-            logger.info("Using default certificate for SSL verification.")
-        else:
-            cert_path = str(Path(os.environ["SSL_CERT_DIR"], os.environ["SSL_CERT_FILE"]).absolute())
-            logger.info("Using self-signed certificate for SSL verification.")
-        ssl_context = ssl.create_default_context()
-        if cert_path:
-            ssl_context.load_verify_locations(cert_path)
-        oidc_metadata = self.get_oidc_metadata(cert_path)
-        self.jwks_client = jwt.PyJWKClient(
-            oidc_metadata["jwks_uri"], cache_jwk_set=True, lifespan=360, ssl_context=ssl_context
-        )
+        self._jwks_client = get_jwks_client()
 
     async def __call__(self, request: Request) -> Optional[HTTPAuthorizationCredentials]:
         """Verify the provided bearer token or API Key. API Key will take precedence over the bearer token."""
         if self._token_authorizer.is_valid_api_token(request.headers):
             return None  # valid API token, not continuing with OIDC auth
         http_auth_creds = await super().__call__(request)
-        if not self.id_token_is_valid(
-            id_token=http_auth_creds.credentials, authority=os.environ["AUTHORITY"], client_id=os.environ["CLIENT_ID"]
+        if not id_token_is_valid(
+            id_token=http_auth_creds.credentials,
+            authority=os.environ["AUTHORITY"],
+            client_id=os.environ["CLIENT_ID"],
+            jwks_client=self._jwks_client,
         ):
             raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Not authenticated")
         return http_auth_creds
-
-    def get_oidc_metadata(self, cert_path: Optional[str] = None) -> Dict[str, Any]:
-        """Get OIDC endpoints and metadata from authority."""
-        authority = os.environ.get("AUTHORITY")
-        resp = requests.get(f"{authority}/.well-known/openid-configuration", verify=cert_path or True, timeout=30)
-        resp.raise_for_status()
-        return resp.json()  # type: ignore
-
-    def id_token_is_valid(self, id_token: str, client_id: str, authority: str) -> bool:
-        """Check whether an ID token is valid and return decoded data."""
-        try:
-            signing_key = self.jwks_client.get_signing_key_from_jwt(id_token)
-            jwt.decode(
-                id_token,
-                signing_key.key,
-                algorithms=["RS256"],
-                issuer=authority,
-                audience=client_id,
-                options={
-                    "verify_signature": True,
-                    "verify_exp": True,
-                    "verify_nbf": True,
-                    "verify_iat": True,
-                    "verify_aud": True,
-                    "verify_iss": True,
-                },
-            )
-            return True
-        except jwt.exceptions.PyJWTError as e:
-            logger.exception(e)
-            return False
 
 
 class ApiTokenAuthorizer:

--- a/lib/serve/rest-api/src/requirements.txt
+++ b/lib/serve/rest-api/src/requirements.txt
@@ -13,4 +13,5 @@ pydantic==2.8.2
 PyJWT==2.9.0
 text-generation==0.7.0
 prisma==0.13.1
+pynacl==1.5.0
 uvicorn==0.22.0


### PR DESCRIPTION
*Description of changes:*

This set of changes prevents non-admins from performing mutating operations on LiteLLM itself, including, but not limited to adding or deleting models, creating API keys, and more. If the route is a known OpenAI API route, then any authenticated user may use it, but if not, then an administrator, as identified by an IdP-provided admin group, must make the API call. If the user attempts to make these calls but is not an admin, then the request is rejected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
