### PR TITLE
Add more helpful messaging to account validation error

### DIFF
--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -866,7 +866,7 @@ const RawConfigSchema = z
             .or(z.string())
             .transform((value) => value.toString())
             .refine((value) => value.length === 12, {
-                message: 'AWS account number should be 12 digits',
+                message: 'AWS account number should be 12 digits. If your account ID starts with 0, then please surround the ID with quotation marks.',
             }),
         region: z.string(),
         vpcId: z.string().optional(),
@@ -879,7 +879,7 @@ const RawConfigSchema = z
             .array(z.union([z.number(), z.string()]))
             .transform((arr) => arr.map(String))
             .refine((value) => value.every((num) => num.length === 12), {
-                message: 'AWS account number should be 12 digits',
+                message: 'AWS account number should be 12 digits. If your account ID starts with 0, then please surround the ID with quotation marks.',
             })
             .optional(),
         deployRag: z.boolean().optional().default(false),


### PR DESCRIPTION
We had some stories of deployment pains when users had accounts with leading 0's in their account IDs. We already had validation but because it wasn't clear that the error was due to yaml cutting off the leading 0's from a number, customers were not always sure how to resolve the error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
