### PR TITLE
Implement ListModels, GetModel, DeleteModel model management APIs

### DIFF
--- a/lambda/models/clients/__init__.py
+++ b/lambda/models/clients/__init__.py
@@ -1,0 +1,13 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.

--- a/lambda/models/clients/litellm_client.py
+++ b/lambda/models/clients/litellm_client.py
@@ -1,0 +1,66 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Client for interfacing with the LiteLLM proxy's management options directly."""
+
+from typing import Any, Dict, List
+
+import requests
+from starlette.datastructures import Headers
+
+
+class LiteLLMClient:
+    """Client definition for interfacing directly with LiteLLM management operations."""
+
+    def __init__(self, base_uri: str, headers: Headers):
+        self._base_uri = base_uri
+        self._headers = headers
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        """
+        Retrieve all models from the database.
+
+        Note, this is a superset of the models that are visible from the OpenAI API call to /models. If multiple models
+        are defined with the same model name, only one will show in the OpenAI API call because of the model name, but
+        both will show in the management API call because of the differences in unique IDs.
+        """
+        resp = requests.get(self._base_uri + "/model/info", headers=self._headers)
+        all_models = resp.json()
+        models_list: List[Dict[str, Any]] = all_models["data"]
+        return models_list
+
+    def add_model(self, model_name: str, litellm_params: Dict[str, str], additional_metadata: Dict[str, Any]) -> None:
+        """
+        Add a new model configuration to the database.
+
+        The parameters for this method will be used for defining how LiteLLM accesses a model between both the model
+        and the litellm_params dictionary, and anything that is not LiteLLM-specific can be added to the
+        additional_metadata dictionary. Because LiteLLM uses this ID instead of other data, it is possible to add
+        two models with the same name, which causes ambiguous results when using the OpenAI API for listing models as
+        that only shows one model per model name.
+        """
+        requests.post(
+            self._base_uri + "/model/new",
+            headers=self._headers,
+            json={"model_name": model_name, "litellm_params": litellm_params, "model_info": additional_metadata},
+        )
+
+    def delete_model(self, unique_id: str) -> None:
+        """
+        Delete a model from the database.
+
+        The unique_id is the ID that LiteLLM generates on its end when creating a model, regardless of if the model
+        was defined in a static configuration file or if it was added dynamically.
+        """
+        requests.post(self._base_uri + "/model/delete", headers=self._headers, json={"id": unique_id})

--- a/lambda/models/exception/__init__.py
+++ b/lambda/models/exception/__init__.py
@@ -12,6 +12,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from .delete_model_handler import DeleteModelHandler  # noqa: F401
-from .get_model_handler import GetModelHandler  # noqa: F401
-from .list_models_handler import ListModelsHandler  # noqa: F401
+"""Exception definitions for model management APIs."""
+
+
+class ModelNotFoundError(LookupError):
+    """Error to raise when a specified model cannot be found in LiteLLM."""
+
+    pass

--- a/lambda/models/handler/__init__.py
+++ b/lambda/models/handler/__init__.py
@@ -1,0 +1,13 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.

--- a/lambda/models/handler/base_handler.py
+++ b/lambda/models/handler/base_handler.py
@@ -1,0 +1,34 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Base Handler definition for model management API definitions."""
+
+
+from typing import Any
+
+from starlette.datastructures import Headers
+
+from ..clients.litellm_client import LiteLLMClient
+
+
+class BaseApiHandler:
+    """Base Handler class for all model management APIs."""
+
+    def __init__(self, base_uri: str, headers: Headers):
+        """Create a LiteLLM client for all child objects to use."""
+        self._litellm_client = LiteLLMClient(base_uri=base_uri, headers=headers)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> None:
+        """All handlers must implement the __call__ method."""
+        raise NotImplementedError("__call__ method must be defined in child API Handler class.")

--- a/lambda/models/handler/delete_model_handler.py
+++ b/lambda/models/handler/delete_model_handler.py
@@ -1,0 +1,32 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Handler for DeleteModel requests."""
+
+from ..domain_objects import DeleteModelResponse, ModelStatus
+from .base_handler import BaseApiHandler
+from .utils import to_lisa_model
+
+
+class DeleteModelHandler(BaseApiHandler):
+    """Handler class for DeleteModel requests."""
+
+    def __call__(self, unique_id: str) -> DeleteModelResponse:  # type: ignore
+        """Delete model infrastructure and remove model reference from LiteLLM."""
+        model = self._litellm_client.get_model(unique_id=unique_id)
+        # TODO Use model definition to get CloudFormation stack to delete.
+        self._litellm_client.delete_model(unique_id=unique_id)
+        lisa_model = to_lisa_model(model_dict=model)
+        lisa_model.Status = ModelStatus.DELETING
+        return DeleteModelResponse(Model=lisa_model)

--- a/lambda/models/handler/get_model_handler.py
+++ b/lambda/models/handler/get_model_handler.py
@@ -12,6 +12,17 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from .delete_model_handler import DeleteModelHandler  # noqa: F401
-from .get_model_handler import GetModelHandler  # noqa: F401
-from .list_models_handler import ListModelsHandler  # noqa: F401
+"""Handler for GetModel requests."""
+
+from ..domain_objects import GetModelResponse
+from .base_handler import BaseApiHandler
+from .utils import to_lisa_model
+
+
+class GetModelHandler(BaseApiHandler):
+    """Handler class for GetModel requests."""
+
+    def __call__(self, unique_id: str) -> GetModelResponse:  # type: ignore
+        """Get model metadata from LiteLLM and translate to a model management response object."""
+        model = self._litellm_client.get_model(unique_id=unique_id)
+        return GetModelResponse(Model=to_lisa_model(model))

--- a/lambda/models/handler/list_models_handler.py
+++ b/lambda/models/handler/list_models_handler.py
@@ -1,0 +1,48 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Handler for ListModels requests."""
+
+from starlette.datastructures import Headers
+
+from ..clients.litellm_client import LiteLLMClient
+from ..domain_objects import LISAModel, ListModelsResponse, ModelStatus
+
+
+class ListModelsHandler:
+    """Handler class for ListModels requests."""
+
+    def __init__(self, base_uri: str, headers: Headers):
+        """Create ListModelsHandler with URI for accessing LiteLLM directly."""
+        self._litellm_client = LiteLLMClient(base_uri=base_uri, headers=headers)
+
+    def __call__(self) -> ListModelsResponse:
+        """Call handler to get all models from LiteLLM database and transform results into API response format."""
+        litellm_models = self._litellm_client.list_models()
+        models_list = [
+            LISAModel(
+                ModelId=m["model_name"],
+                ModelName=m["litellm_params"]["model"].removeprefix("openai/"),
+                UniqueId=m["model_info"]["id"],
+                Status=m["model_info"].get("model_status", ModelStatus.IN_SERVICE),
+                ModelType=m["model_info"].get("model_type", "textgen"),
+                Streaming=m["model_info"].get("streaming", False),
+                ModelUrl=m["litellm_params"].get("api_base", None),
+                ContainerConfig=m["model_info"].get("container_config", None),
+                AutoScalingConfig=m["model_info"].get("autoscaling_config", None),
+                LoadBalancerConfig=m["model_info"].get("loadbalancer_config", None),
+            )
+            for m in litellm_models
+        ]
+        return ListModelsResponse(Models=models_list)

--- a/lambda/models/handler/utils.py
+++ b/lambda/models/handler/utils.py
@@ -1,0 +1,35 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Common utility functions across all API handlers."""
+
+from typing import Any, Dict
+
+from ..domain_objects import LISAModel, ModelStatus
+
+
+def to_lisa_model(model_dict: Dict[str, Any]) -> LISAModel:
+    """Convert LiteLLM model dictionary to a LISAModel object."""
+    return LISAModel(
+        ModelId=model_dict["model_name"],
+        ModelName=model_dict["litellm_params"]["model"].removeprefix("openai/"),
+        UniqueId=model_dict["model_info"]["id"],
+        Status=model_dict["model_info"].get("model_status", ModelStatus.IN_SERVICE),
+        ModelType=model_dict["model_info"].get("model_type", "textgen"),
+        Streaming=model_dict["model_info"].get("streaming", False),
+        ModelUrl=model_dict["litellm_params"].get("api_base", None),
+        ContainerConfig=model_dict["model_info"].get("container_config", None),
+        AutoScalingConfig=model_dict["model_info"].get("autoscaling_config", None),
+        LoadBalancerConfig=model_dict["model_info"].get("loadbalancer_config", None),
+    )

--- a/lib/core/layers/fastapi/requirements.txt
+++ b/lib/core/layers/fastapi/requirements.txt
@@ -1,3 +1,5 @@
+boto3==1.34.131
 fastapi==0.111.0
 mangum==0.17.0
 pydantic==2.8.2
+requests==2.32.2

--- a/lib/models/index.ts
+++ b/lib/models/index.ts
@@ -22,10 +22,12 @@ import { Construct } from 'constructs';
 
 import { ModelsApi } from './model-api';
 import { BaseProps } from '../schema';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 
 type LisaModelsApiStackProps = BaseProps &
   StackProps & {
       authorizer: IAuthorizer;
+      lisaServeEndpointUrlPs: StringParameter;
       restApiId: string;
       rootResourceId: string;
       securityGroups?: ISecurityGroup[];
@@ -44,12 +46,13 @@ export class LisaModelsApiStack extends Stack {
     constructor (scope: Construct, id: string, props: LisaModelsApiStackProps) {
         super(scope, id, props);
 
-        const { authorizer, config, restApiId, rootResourceId, securityGroups, vpc } = props;
+        const { authorizer, lisaServeEndpointUrlPs, config, restApiId, rootResourceId, securityGroups, vpc } = props;
 
         // Add REST API Lambdas to APIGW
         new ModelsApi(this, 'ModelsApi', {
             authorizer,
             config,
+            lisaServeEndpointUrlPs,
             restApiId,
             rootResourceId,
             securityGroups,

--- a/lib/stages.ts
+++ b/lib/stages.ts
@@ -157,6 +157,7 @@ export class LisaServeApplicationStage extends Stage {
             ...baseStackProps,
             authorizer: apiBaseStack.authorizer,
             description: `LISA-models: ${config.deploymentName}-${config.deploymentStage}`,
+            lisaServeEndpointUrlPs: serveStack.endpointUrl,
             restApiId: apiBaseStack.restApiId,
             rootResourceId: apiBaseStack.rootResourceId,
             stackName: createCdkId([config.deploymentName, config.appName, 'models', config.deploymentStage]),


### PR DESCRIPTION
This set of changes implements the ListModels, GetModel, and DeleteModel API for the model management feature. 
* ListModels will list all the models that are stored in the LiteLLM database and return any information that we store as additional metadata through the Create API once that one is implemented.
* GetModel will get the metadata for one specific model. It appears LiteLLM is unable to filter for the model on its own, so this is implemented as a filter over the ListModels API.
* DeleteModel in its current form will delete a reference from LiteLLM. Once we have more information from the CreateModel API, we can add logic to delete the CloudFormation stack associated with the custom infrastructure we spin up for users in this API.

Main changes
* Addition of LiteLLM client to make the management API calls directly
* Creation of a handler class for each specific API- this will start a pattern of offloading the handler logic outside of the REST API definitions file to keep the API definition file a little cleaner
* Abstracted the base handler class to make class definitions less repetitive to implement
* Added functionality for ListModels, GetModel
* Created initial revision of DeleteModel


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
