### PR TITLE
Add self-signed cert support for model management operations

### DIFF
--- a/lambda/models/clients/litellm_client.py
+++ b/lambda/models/clients/litellm_client.py
@@ -14,7 +14,7 @@
 
 """Client for interfacing with the LiteLLM proxy's management options directly."""
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 import requests
 from starlette.datastructures import Headers
@@ -25,10 +25,11 @@ from ..exception import ModelNotFoundError
 class LiteLLMClient:
     """Client definition for interfacing directly with LiteLLM management operations."""
 
-    def __init__(self, base_uri: str, headers: Headers, timeout: int = 30):
+    def __init__(self, base_uri: str, headers: Headers, verify: Union[str, bool], timeout: int = 30):
         self._base_uri = base_uri
         self._headers = headers
         self._timeout = timeout
+        self._verify = verify
 
     def list_models(self) -> List[Dict[str, Any]]:
         """
@@ -38,7 +39,12 @@ class LiteLLMClient:
         are defined with the same model name, only one will show in the OpenAI API call because of the model name, but
         both will show in the management API call because of the differences in unique IDs.
         """
-        resp = requests.get(self._base_uri + "/model/info", headers=self._headers, timeout=self._timeout)
+        resp = requests.get(
+            self._base_uri + "/model/info",
+            headers=self._headers,
+            timeout=self._timeout,
+            verify=self._verify,
+        )
         all_models = resp.json()
         models_list: List[Dict[str, Any]] = all_models["data"]
         return models_list
@@ -62,6 +68,7 @@ class LiteLLMClient:
                 "model_info": additional_metadata,
             },
             timeout=self._timeout,
+            verify=self._verify,
         )
 
     def delete_model(self, unique_id: str) -> None:
@@ -76,6 +83,7 @@ class LiteLLMClient:
             headers=self._headers,
             json={"id": unique_id},
             timeout=self._timeout,
+            verify=self._verify,
         )
 
     def get_model(self, unique_id: str) -> Dict[str, Any]:

--- a/lambda/models/handler/base_handler.py
+++ b/lambda/models/handler/base_handler.py
@@ -15,7 +15,7 @@
 """Base Handler definition for model management API definitions."""
 
 
-from typing import Any
+from typing import Any, Union
 
 from starlette.datastructures import Headers
 
@@ -25,9 +25,9 @@ from ..clients.litellm_client import LiteLLMClient
 class BaseApiHandler:
     """Base Handler class for all model management APIs."""
 
-    def __init__(self, base_uri: str, headers: Headers):
+    def __init__(self, base_uri: str, headers: Headers, verify: Union[str, bool]):
         """Create a LiteLLM client for all child objects to use."""
-        self._litellm_client = LiteLLMClient(base_uri=base_uri, headers=headers)
+        self._litellm_client = LiteLLMClient(base_uri=base_uri, headers=headers, verify=verify)
 
     def __call__(self, *args: Any, **kwargs: Any) -> None:
         """All handlers must implement the __call__ method."""

--- a/lib/models/model-api.ts
+++ b/lib/models/model-api.ts
@@ -25,7 +25,6 @@ import { Construct } from 'constructs';
 
 import { PythonLambdaFunction, registerAPIEndpoint } from '../api-base/utils';
 import { BaseProps } from '../schema';
-import { add } from 'husky';
 
 /**
  * Properties for ModelsApi Construct.

--- a/lib/models/model-api.ts
+++ b/lib/models/model-api.ts
@@ -98,6 +98,7 @@ export class ModelsApi extends Construct {
                 environment: {
                     LISA_API_URL_PS_NAME: lisaServeEndpointUrlPs.parameterName,
                     REST_API_VERSION: config.restApiConfig.apiVersion,
+                    RESTAPI_SSL_CERT_ARN: config.restApiConfig.loadBalancerConfig.sslCertIamArn ?? '',
                 }
             },
             config.lambdaConfig.pythonRuntime,


### PR DESCRIPTION
Adds a fix for when self-signed certs are in use instead of a public certificate from ACM


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
