### PR TITLE
Add Create and Delete state machines for model management

### DIFF
--- a/lambda/dockerimagebuilder/__init__.py
+++ b/lambda/dockerimagebuilder/__init__.py
@@ -35,7 +35,7 @@ docker push {{ECR_URI}}:{{IMAGE_ID}}
 """
 
 
-def handler(event: Dict[str, Any], context) -> Dict[str, Any]:  # type: ignore [no-untyped-def]
+def handler(event: Dict[str, Any], context) -> None:  # type: ignore [no-untyped-def]
     base_image = event["base_image"]
     layer_to_add = event["layer_to_add"]
     mounts3_deb_url = event["mounts3_deb_url"]

--- a/lambda/models/exception/__init__.py
+++ b/lambda/models/exception/__init__.py
@@ -16,6 +16,12 @@
 
 
 class ModelNotFoundError(LookupError):
-    """Error to raise when a specified model cannot be found in LiteLLM."""
+    """Error to raise when a specified model cannot be found in the database."""
+
+    pass
+
+
+class ModelAlreadyExistsError(LookupError):
+    """Error to raise when a specified model already exists in the database."""
 
     pass

--- a/lambda/models/handler/__init__.py
+++ b/lambda/models/handler/__init__.py
@@ -12,6 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from .create_model_handler import CreateModelHandler  # noqa: F401
 from .delete_model_handler import DeleteModelHandler  # noqa: F401
 from .get_model_handler import GetModelHandler  # noqa: F401
 from .list_models_handler import ListModelsHandler  # noqa: F401

--- a/lambda/models/handler/create_model_handler.py
+++ b/lambda/models/handler/create_model_handler.py
@@ -14,14 +14,15 @@
 
 """Handler for CreateModel requests."""
 
-import boto3
 import os
+
+import boto3
+from models.exception import ModelAlreadyExistsError
+from utilities.common_functions import retry_config
 
 from ..domain_objects import CreateModelRequest, CreateModelResponse, ModelStatus
 from .base_handler import BaseApiHandler
 from .utils import to_lisa_model
-from utilities.common_functions import retry_config
-from models.exception import ModelAlreadyExistsError
 
 stepfunctions = boto3.client("stepfunctions", region_name=os.environ["AWS_REGION"], config=retry_config)
 dynamodb = boto3.resource("dynamodb", region_name=os.environ["AWS_REGION"], config=retry_config)

--- a/lambda/models/handler/create_model_handler.py
+++ b/lambda/models/handler/create_model_handler.py
@@ -1,0 +1,60 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Handler for CreateModel requests."""
+
+import boto3
+import os
+
+from ..domain_objects import CreateModelRequest, CreateModelResponse, ModelStatus
+from .base_handler import BaseApiHandler
+from .utils import to_lisa_model
+from utilities.common_functions import retry_config
+from models.exception import ModelAlreadyExistsError
+
+stepfunctions = boto3.client("stepfunctions", region_name=os.environ["AWS_REGION"], config=retry_config)
+dynamodb = boto3.resource("dynamodb", region_name=os.environ["AWS_REGION"], config=retry_config)
+model_table = dynamodb.Table(os.environ["MODEL_TABLE_NAME"])
+
+
+class CreateModelHandler(BaseApiHandler):
+    """Handler class for CreateModel requests."""
+
+    def __call__(self, create_request: CreateModelRequest) -> CreateModelResponse:  # type: ignore
+        """Create model infrastructure and add model data to LiteLLM database."""
+        unique_id = create_request.ModelId
+
+        # If model exists in DDB, then fail out. ModelId must be unique.
+        table_item = model_table.get_item(Key={"model_id": unique_id}).get("Item", None)
+        if table_item:
+            raise ModelAlreadyExistsError(f"Model '{unique_id}' already exists. Please select another name.")
+
+        stepfunctions.start_execution(
+            stateMachineArn=os.environ["CREATE_SFN_ARN"], input=create_request.model_dump_json()
+        )
+
+        # Placeholder data until model data is persisted in database via state machine workflow
+        lisa_model = to_lisa_model(
+            {
+                "model_name": unique_id,
+                "litellm_params": {
+                    "model": unique_id,
+                },
+                "model_info": {
+                    "id": unique_id,
+                    "model_status": ModelStatus.CREATING,
+                },
+            }
+        )
+        return CreateModelResponse(Model=lisa_model)

--- a/lambda/models/handler/delete_model_handler.py
+++ b/lambda/models/handler/delete_model_handler.py
@@ -23,7 +23,7 @@ class DeleteModelHandler(BaseApiHandler):
     """Handler class for DeleteModel requests."""
 
     def __call__(self, unique_id: str) -> DeleteModelResponse:  # type: ignore
-        """Delete model infrastructure and remove model reference from LiteLLM."""
+        """Kick off state machine to delete infrastructure and remove model reference from LiteLLM."""
         model = self._litellm_client.get_model(unique_id=unique_id)
         # TODO Use model definition to get CloudFormation stack to delete.
         self._litellm_client.delete_model(unique_id=unique_id)

--- a/lambda/models/state_machine/__init__.py
+++ b/lambda/models/state_machine/__init__.py
@@ -1,0 +1,13 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.

--- a/lambda/models/state_machine/create_model.py
+++ b/lambda/models/state_machine/create_model.py
@@ -13,3 +13,45 @@
 #   limitations under the License.
 
 """Lambda handlers for CreateModel state machine."""
+
+from copy import deepcopy
+from typing import Any, Dict
+
+
+def handle_set_model_to_creating(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Set DDB entry to CREATING status."""
+    output_dict = deepcopy(event)
+    output_dict["create_infra"] = True
+    return output_dict
+
+
+def handle_start_copy_docker_image(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Start process for copying Docker image into local AWS account."""
+    output_dict = deepcopy(event)
+    return output_dict
+
+
+def handle_poll_docker_image_available(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Check that Docker image is available in account or not."""
+    output_dict = deepcopy(event)
+    output_dict["continue_polling_docker"] = False
+    return output_dict
+
+
+def handle_start_create_stack(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Start model infrastructure creation."""
+    output_dict = deepcopy(event)
+    return output_dict
+
+
+def handle_poll_create_stack(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Check that model infrastructure creation has completed or not."""
+    output_dict = deepcopy(event)
+    output_dict["continue_polling_stack"] = False
+    return output_dict
+
+
+def handle_add_model_to_litellm(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Add model to LiteLLM once it is created."""
+    output_dict = deepcopy(event)
+    return output_dict

--- a/lambda/models/state_machine/create_model.py
+++ b/lambda/models/state_machine/create_model.py
@@ -1,0 +1,15 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Lambda handlers for CreateModel state machine."""

--- a/lambda/models/state_machine/delete_model.py
+++ b/lambda/models/state_machine/delete_model.py
@@ -1,0 +1,101 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Lambda handlers for DeleteModel state machine."""
+
+import os
+from copy import deepcopy
+from datetime import datetime
+from typing import Any, Dict
+from uuid import uuid4
+
+import boto3
+from utilities.common_functions import retry_config
+
+from ..domain_objects import ModelStatus
+
+cloudformation = boto3.client("cloudformation", region_name=os.environ["AWS_REGION"], config=retry_config)
+dynamodb = boto3.resource("dynamodb", region_name=os.environ["AWS_REGION"], config=retry_config)
+ddb_table = dynamodb.Table(os.environ["MODEL_TABLE_NAME"])
+
+# DDB and Payload fields
+CFN_STACK_ARN = "cloudformation_stack_arn"
+MODEL_ID = "model_id"
+
+
+def handle_set_model_to_deleting(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Start deletion workflow based on user-specified model input."""
+    output_dict = deepcopy(event)
+    model_id = event[MODEL_ID]
+    model_key = {MODEL_ID: model_id}
+    item = ddb_table.get_item(
+        Key=model_key,
+        ConsistentRead=True,
+        ReturnConsumedCapacity="NONE",
+    ).get("Item", None)
+    if not item:
+        raise RuntimeError(f"Requested model '{model_id}' was not found in DynamoDB table.")
+    output_dict[CFN_STACK_ARN] = item.get(CFN_STACK_ARN, None)
+
+    ddb_table.update_item(
+        Key=model_key,
+        UpdateExpression="SET last_modified_date = :lmd, model_status = :ms",
+        ExpressionAttributeValues={
+            ":lmd": int(datetime.utcnow().timestamp()),
+            ":ms": ModelStatus.DELETING,
+        },
+    )
+    return output_dict
+
+
+def handle_delete_from_litellm(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Delete model reference from LiteLLM."""
+    output_dict = deepcopy(event)
+    pass  # TODO: allow LiteLLM direct modifications from SFN/Lambda without direct user credentials
+    return output_dict
+
+
+def handle_delete_stack(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Initialize stack deletion."""
+    stack_arn = event[CFN_STACK_ARN]
+    client_request_token = str(uuid4())
+    cloudformation.delete_stack(
+        StackName=stack_arn,
+        ClientRequestToken=client_request_token,
+    )
+    return event  # no payload mutations needed between this and next state
+
+
+def handle_monitor_delete_stack(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Get stack status while it is being deleted and evaluate if state machine should continue polling."""
+    output_dict = deepcopy(event)
+    stack_arn = event[CFN_STACK_ARN]
+    stack_metadata = cloudformation.describe_stacks(StackName=stack_arn)["Stacks"][0]
+    stack_status = stack_metadata["StackStatus"]
+    continue_polling = True  # stack not done yet, so continue monitoring
+    if stack_status == "DELETE_COMPLETE":
+        continue_polling = False  # stack finished, allow state machine to stop polling
+    elif stack_status.endswith("COMPLETE") or stack_status.endswith("FAILED"):
+        # Didn't expect anything else, so raise error to fail state machine
+        raise RuntimeError(f"Stack entered unexpected terminal state '{stack_status}'.")
+    output_dict["continue_polling"] = continue_polling
+
+    return output_dict
+
+
+def handle_delete_from_ddb(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Delete item from DDB after successful deletion workflow."""
+    model_key = {MODEL_ID: event[MODEL_ID]}
+    ddb_table.delete_item(Key=model_key)
+    return event

--- a/lib/models/model-api.ts
+++ b/lib/models/model-api.ts
@@ -18,7 +18,16 @@ import crypto from 'node:crypto';
 
 import { IAuthorizer, RestApi } from 'aws-cdk-lib/aws-apigateway';
 import { ISecurityGroup } from 'aws-cdk-lib/aws-ec2';
-import { Effect, IRole, Policy, PolicyDocument, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import {
+    Effect,
+    IRole,
+    ManagedPolicy,
+    Policy,
+    PolicyDocument,
+    PolicyStatement,
+    Role,
+    ServicePrincipal,
+} from 'aws-cdk-lib/aws-iam';
 import { LayerVersion } from 'aws-cdk-lib/aws-lambda';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
@@ -211,6 +220,9 @@ export class ModelsApi extends Construct {
 
         const stateMachinesLambdaRole = new Role(this, 'ModelsSfnLambdaRole', {
             assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
+            managedPolicies: [
+                ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole'),
+            ],
             inlinePolicies: {
                 lambdaPermissions: new PolicyDocument({
                     statements: [

--- a/lib/models/state-machine/constants.ts
+++ b/lib/models/state-machine/constants.ts
@@ -1,0 +1,23 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import { Duration } from 'aws-cdk-lib';
+import { WaitTime } from 'aws-cdk-lib/aws-stepfunctions';
+
+export const LAMBDA_MEMORY: number = 128;
+export const LAMBDA_TIMEOUT: Duration = Duration.seconds(60);
+export const OUTPUT_PATH: string = '$.Payload';
+export const POLLING_TIMEOUT: WaitTime = WaitTime.duration(Duration.seconds(60));

--- a/lib/models/state-machine/create-model.ts
+++ b/lib/models/state-machine/create-model.ts
@@ -1,0 +1,197 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import { Construct } from 'constructs';
+import { BaseProps } from '../../schema';
+import { ITable } from 'aws-cdk-lib/aws-dynamodb';
+import { Code, Function, ILayerVersion } from 'aws-cdk-lib/aws-lambda';
+import { IRole } from 'aws-cdk-lib/aws-iam';
+import { ISecurityGroup, IVpc } from 'aws-cdk-lib/aws-ec2';
+import { LambdaInvoke } from 'aws-cdk-lib/aws-stepfunctions-tasks';
+
+
+type CreateModelStateMachineProps = BaseProps & {
+    modelTable: ITable,
+    lambdaLayers: ILayerVersion[],
+    role?: IRole,
+    vpc?: IVpc,
+    securityGroups?: ISecurityGroup[];
+};
+
+/**
+ * State Machine for creating models.
+ */
+export class CreateModelStateMachine extends Construct {
+    readonly stateMachineArn: string;
+
+    constructor (scope: Construct, id: string, props: CreateModelStateMachineProps) {
+        super(scope, id);
+
+        const {config, modelTable, lambdaLayers, role, vpc, securityGroups} = props;
+
+        const setModelToCreating = new LambdaInvoke(this, 'SetModelToCreating', {
+            lambdaFunction: new Function(this, 'SetModelToCreatingFunc', {
+                runtime: config.lambdaConfig.pythonRuntime,
+                handler: 'models.state_machine.create_model.handle_set_model_to_creating',
+                code: Code.fromAsset(config.lambdaSourcePath),
+                timeout: LAMBDA_TIMEOUT,
+                memorySize: LAMBDA_MEMORY,
+                role: role,
+                vpc: vpc,
+                securityGroups: securityGroups,
+                layers: lambdaLayers,
+                environment: {
+                    MODEL_TABLE_NAME: modelTable.tableName,
+                },
+            }),
+            outputPath: OUTPUT_PATH,
+        });
+
+        const createModelInfraChoice = new Choice(this, 'CreateModelInfraChoice');
+
+        const startCopyDockerImage = new LambdaInvoke(this, 'StartCopyDockerImage', {
+            lambdaFunction: new Function(this, 'StartCopyDockerImageFunc', {
+                runtime: config.lambdaConfig.pythonRuntime,
+                handler: 'models.state_machine.create_model.handle_start_copy_docker_image',
+                code: Code.fromAsset(config.lambdaSourcePath),
+                timeout: LAMBDA_TIMEOUT,
+                memorySize: LAMBDA_MEMORY,
+                role: role,
+                vpc: vpc,
+                securityGroups: securityGroups,
+                layers: lambdaLayers,
+                environment: {
+                    MODEL_TABLE_NAME: modelTable.tableName,
+                },
+            }),
+            outputPath: OUTPUT_PATH,
+        });
+
+        const pollDockerImageAvailable = new LambdaInvoke(this, 'PollDockerImageAvailable', {
+            lambdaFunction: new Function(this, 'PollDockerImageAvailableFunc', {
+                runtime: config.lambdaConfig.pythonRuntime,
+                handler: 'models.state_machine.create_model.handle_poll_docker_image_available',
+                code: Code.fromAsset(config.lambdaSourcePath),
+                timeout: LAMBDA_TIMEOUT,
+                memorySize: LAMBDA_MEMORY,
+                role: role,
+                vpc: vpc,
+                securityGroups: securityGroups,
+                layers: lambdaLayers,
+                environment: {
+                    MODEL_TABLE_NAME: modelTable.tableName,
+                },
+            }),
+            outputPath: OUTPUT_PATH
+        });
+
+        const pollDockerImageChoice = new Choice(this, 'PollDockerImageChoice');
+
+        const waitBeforePollingDockerImage = new Wait(this, 'WaitBeforePollingDockerImage', {
+            time: POLLING_TIMEOUT,
+        });
+
+        const startCreateStack = new LambdaInvoke(this, 'StartCreateStack', {
+            lambdaFunction: new Function(this, 'StartCreateStackFunc', {
+                runtime: config.lambdaConfig.pythonRuntime,
+                handler: 'models.state_machine.create_model.handle_start_create_stack',
+                code: Code.fromAsset(config.lambdaSourcePath),
+                timeout: LAMBDA_TIMEOUT,
+                memorySize: LAMBDA_MEMORY,
+                role: role,
+                vpc: vpc,
+                securityGroups: securityGroups,
+                layers: lambdaLayers,
+                environment: {
+                    MODEL_TABLE_NAME: modelTable.tableName,
+                },
+            }),
+            outputPath: OUTPUT_PATH,
+        });
+
+        const pollCreateStack = new LambdaInvoke(this, 'PollCreateStack', {
+            lambdaFunction: new Function(this, 'PollCreateStackFunc', {
+                runtime: config.lambdaConfig.pythonRuntime,
+                handler: 'models.state_machine.create_model.handle_poll_create_stack',
+                code: Code.fromAsset(config.lambdaSourcePath),
+                timeout: LAMBDA_TIMEOUT,
+                memorySize: LAMBDA_MEMORY,
+                role: role,
+                vpc: vpc,
+                securityGroups: securityGroups,
+                layers: lambdaLayers,
+                environment: {
+                    MODEL_TABLE_NAME: modelTable.tableName,
+                },
+            }),
+            outputPath: OUTPUT_PATH,
+        });
+
+        const pollCreateStackChoice = new Choice(this, 'PollCreateStackChoice');
+
+        const waitBeforePollingCreateStack = new Wait(this, 'WaitBeforePollingCreateStack', {
+            time: POLLING_TIMEOUT,
+        });
+
+        const addModelToLitellm = new LambdaInvoke(this, 'AddModelToLitellm', {
+            lambdaFunction: new Function(this, 'AddModelToLitellmFunc', {
+                runtime: config.lambdaConfig.pythonRuntime,
+                handler: 'models.state_machine.create_model.handle_add_model_to_litellm',
+                code: Code.fromAsset(config.lambdaSourcePath),
+                timeout: LAMBDA_TIMEOUT,
+                memorySize: LAMBDA_MEMORY,
+                role: role,
+                vpc: vpc,
+                securityGroups: securityGroups,
+                layers: lambdaLayers,
+                environment: {
+                    MODEL_TABLE_NAME: modelTable.tableName,
+                },
+            }),
+            outputPath: OUTPUT_PATH,
+        });
+
+        const successState = new Succeed(this, 'CreateSuccess');
+
+        // State Machine definition
+        setModelToCreating.next(createModelInfraChoice);
+        createModelInfraChoice
+            .when(Condition.booleanEquals('$.create_infra', true), startCopyDockerImage)
+            .otherwise(addModelToLitellm);
+
+        startCopyDockerImage.next(pollDockerImageAvailable);
+        pollDockerImageAvailable.next(pollDockerImageChoice);
+        pollDockerImageChoice
+            .when(Condition.booleanEquals('$.continue_polling_docker', true), waitBeforePollingDockerImage)
+            .otherwise(startCreateStack);
+        waitBeforePollingDockerImage.next(pollDockerImageAvailable);
+
+        startCreateStack.next(pollCreateStack);
+        pollCreateStack.next(pollCreateStackChoice);
+        pollCreateStackChoice
+            .when(Condition.booleanEquals('$.continue_polling_stack', true), waitBeforePollingCreateStack)
+            .otherwise(addModelToLitellm);
+        waitBeforePollingCreateStack.next(pollCreateStack);
+
+        addModelToLitellm.next(successState);
+
+        const stateMachine = new StateMachine(this, 'CreateModelSM', {
+            definitionBody: DefinitionBody.fromChainable(setModelToCreating),
+        });
+
+        this.stateMachineArn = stateMachine.stateMachineArn;
+    }
+}

--- a/lib/models/state-machine/create-model.ts
+++ b/lib/models/state-machine/create-model.ts
@@ -14,18 +14,26 @@
  limitations under the License.
  */
 
+import {
+    Choice,
+    Condition,
+    DefinitionBody,
+    StateMachine,
+    Succeed,
+    Wait,
+} from 'aws-cdk-lib/aws-stepfunctions';
 import { Construct } from 'constructs';
 import { BaseProps } from '../../schema';
 import { ITable } from 'aws-cdk-lib/aws-dynamodb';
 import { Code, Function, ILayerVersion } from 'aws-cdk-lib/aws-lambda';
 import { IRole } from 'aws-cdk-lib/aws-iam';
+import { LAMBDA_MEMORY, LAMBDA_TIMEOUT, OUTPUT_PATH, POLLING_TIMEOUT } from './constants';
 import { ISecurityGroup, IVpc } from 'aws-cdk-lib/aws-ec2';
 import { LambdaInvoke } from 'aws-cdk-lib/aws-stepfunctions-tasks';
 
-
 type CreateModelStateMachineProps = BaseProps & {
     modelTable: ITable,
-    lambdaLayers: ILayerVersion[],
+    lambdaLayers: ILayerVersion[];
     role?: IRole,
     vpc?: IVpc,
     securityGroups?: ISecurityGroup[];

--- a/lib/models/state-machine/delete-model.ts
+++ b/lib/models/state-machine/delete-model.ts
@@ -1,0 +1,182 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+
+import { Construct } from 'constructs';
+import { LambdaInvoke } from 'aws-cdk-lib/aws-stepfunctions-tasks';
+import {
+    Choice,
+    Condition,
+    DefinitionBody,
+    StateMachine,
+    Succeed,
+    Wait,
+    WaitTime,
+} from 'aws-cdk-lib/aws-stepfunctions';
+import { Duration } from 'aws-cdk-lib';
+import { Code, Function, ILayerVersion } from 'aws-cdk-lib/aws-lambda';
+import { BaseProps } from '../../schema';
+import { IRole } from 'aws-cdk-lib/aws-iam';
+import { ISecurityGroup, IVpc } from 'aws-cdk-lib/aws-ec2';
+import { ITable } from 'aws-cdk-lib/aws-dynamodb';
+
+type DeleteModelStateMachineProps = BaseProps & {
+    modelTable: ITable,
+    lambdaLayers: ILayerVersion[],
+    role?: IRole,
+    vpc?: IVpc,
+    securityGroups?: ISecurityGroup[];
+};
+
+
+/**
+ * State Machine for deleting models.
+ */
+export class DeleteModelStateMachine extends Construct {
+    readonly stateMachineArn: string;
+
+    constructor (scope: Construct, id: string, props: DeleteModelStateMachineProps) {
+        super(scope, id);
+
+        const { config, modelTable, lambdaLayers, role, vpc, securityGroups } = props;
+
+        // Needs to return if model has a stack to delete or if it is only in LiteLLM. Updates model state to DELETING.
+        // Input payload to state machine contains the model name that we want to delete.
+        const setModelToDeleting = new LambdaInvoke(this, 'SetModelToDeleting', {
+            lambdaFunction: new Function(this, 'SetModelToDeletingFunc', {
+                runtime: config.lambdaConfig.pythonRuntime,
+                handler: 'models.state_machine.delete_model.handle_set_model_to_deleting',
+                code: Code.fromAsset(config.lambdaSourcePath),
+                timeout: Duration.seconds(60),
+                memorySize: 128,
+                role: role,
+                vpc: vpc,
+                securityGroups: securityGroups,
+                layers: lambdaLayers,
+                environment: {
+                    MODEL_TABLE_NAME: modelTable.tableName,
+                },
+            }),
+            outputPath: '$.Payload',
+        });
+
+        const deleteFromLitellm = new LambdaInvoke(this, 'DeleteFromLitellm', {
+            lambdaFunction: new Function(this, 'DeleteFromLitellmFunc', {
+                runtime: config.lambdaConfig.pythonRuntime,
+                handler: 'models.state_machine.delete_model.handle_delete_from_litellm',
+                code: Code.fromAsset(config.lambdaSourcePath),
+                timeout: Duration.seconds(60),
+                memorySize: 128,
+                role: role,
+                vpc: vpc,
+                securityGroups: securityGroups,
+                layers: lambdaLayers,
+                environment: {
+                    MODEL_TABLE_NAME: modelTable.tableName,
+                },
+            }),
+            outputPath: '$.Payload',
+        });
+
+        const deleteStack = new LambdaInvoke(this, 'DeleteStack', {
+            lambdaFunction: new Function(this, 'DeleteStackFunc', {
+                runtime: config.lambdaConfig.pythonRuntime,
+                handler: 'models.state_machine.delete_model.handle_delete_stack',
+                code: Code.fromAsset(config.lambdaSourcePath),
+                timeout: Duration.seconds(60),
+                memorySize: 128,
+                role: role,
+                vpc: vpc,
+                securityGroups: securityGroups,
+                layers: lambdaLayers,
+                environment: {
+                    MODEL_TABLE_NAME: modelTable.tableName,
+                },
+            }),
+            outputPath: '$.Payload',
+        });
+
+        const monitorDeleteStack = new LambdaInvoke(this, 'MonitorDeleteStack', {
+            lambdaFunction: new Function(this, 'MonitorDeleteStackFunc', {
+                runtime: config.lambdaConfig.pythonRuntime,
+                handler: 'models.state_machine.delete_model.handle_monitor_delete_stack',
+                code: Code.fromAsset(config.lambdaSourcePath),
+                timeout: Duration.seconds(60),
+                memorySize: 128,
+                role: role,
+                vpc: vpc,
+                securityGroups: securityGroups,
+                layers: lambdaLayers,
+                environment: {
+                    MODEL_TABLE_NAME: modelTable.tableName,
+                },
+            }),
+            outputPath: '$.Payload',
+        });
+
+        const deleteFromDdb = new LambdaInvoke(this, 'DeleteFromDdb', {
+            lambdaFunction: new Function(this, 'DeleteFromDdbFunc', {
+                runtime: config.lambdaConfig.pythonRuntime,
+                handler: 'models.state_machine.delete_model.handle_delete_from_ddb',
+                code: Code.fromAsset(config.lambdaSourcePath),
+                timeout: Duration.seconds(60),
+                memorySize: 128,
+                role: role,
+                vpc: vpc,
+                securityGroups: securityGroups,
+                layers: lambdaLayers,
+                environment: {
+                    MODEL_TABLE_NAME: modelTable.tableName,
+                },
+            }),
+            outputPath: '$.Payload',
+        });
+
+        const successState = new Succeed(this, 'DeleteSuccess');
+
+        const deleteStackChoice = new Choice(this, 'DeleteStackChoice');
+        const pollDeleteStackChoice = new Choice(this, 'PollDeleteStackChoice');
+        const waitBeforePollingStackStatus = new Wait(this, 'WaitBeforePollDeleteStack', {
+            time: WaitTime.duration(Duration.seconds(60)),
+        });
+
+        // State Machine definition
+        setModelToDeleting.next(deleteFromLitellm);
+        deleteFromLitellm.next(deleteStackChoice);
+
+        deleteStackChoice
+            .when(Condition.isNotNull('$.cloudformation_stack_arn'), deleteStack)
+            .otherwise(deleteFromDdb);
+
+        deleteStack.next(monitorDeleteStack);
+        monitorDeleteStack.next(pollDeleteStackChoice);
+
+        waitBeforePollingStackStatus.next(monitorDeleteStack);
+
+        pollDeleteStackChoice
+            .when(Condition.booleanEquals('$.continue_polling', true), waitBeforePollingStackStatus)
+            .otherwise(deleteFromDdb);
+
+
+        deleteFromDdb.next(successState);
+
+        const stateMachine = new StateMachine(this, 'DeleteModelSM', {
+            definitionBody: DefinitionBody.fromChainable(setModelToDeleting),
+        });
+
+        this.stateMachineArn = stateMachine.stateMachineArn;
+    }
+}


### PR DESCRIPTION
This set of changes adds state machines for handling the creation and deletion of models. These can be used as examples for the eventual implementation of the UpdateModel workflow. This includes, but does not fully implement files for CreateModel, but those will be filled out in a future revision.

## Highlevel changes
* add models table
* add state machine infrastructure for DeleteModel
* add lambda functions for DeleteModel
* add state machine infrastructure for CreateModel
* add lambda functions for CreateModel
* state machine lambdas are created within VPC

## Known issues or limitations with current review
* The CreateModel workflow is just a skeleton and it is not fully built out. This is intentional to allow others to implement its components in parallel in future revisions.
* LiteLLM integration has not been added to the state machines. These are passthrough stages right now until we update our Authentication to allow for requests to the LiteLLM instances from the Lambda functions within the state machines.
* The DeleteStack state does not actually have permissions to delete anything in CloudFormation (aside from the stack). This is generally not a problem as long as the CreateModel implementation sets an IAM role as part of the stack creation process.
* Because we know we're changing the LiteLLM integration, the List and Get APIs will have to change in the future to pull from DDB instead of LiteLLM for their metadata.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
