### PR TITLE
Add Bedrock and SageMaker invoke permissions to REST API container

### DIFF
--- a/lib/serve/index.ts
+++ b/lib/serve/index.ts
@@ -29,6 +29,7 @@ import { createCdkId } from '../core/utils';
 import { Vpc } from '../networking/vpc';
 import { BaseProps } from '../schema';
 import { IAuthorizer } from 'aws-cdk-lib/aws-apigateway';
+import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 
 const HERE = path.resolve(__dirname);
 
@@ -151,6 +152,33 @@ export class LisaServeApplicationStack extends Stack {
         // Add parameter as container environment variable for both RestAPI and RagAPI
         restApi.container.addEnvironment('REGISTERED_MODELS_PS_NAME', this.modelsPs.parameterName);
         restApi.node.addDependency(this.modelsPs);
+
+        // Additional permissions for REST API Role
+        const invocation_permissions = new Policy(this, 'ModelInvokePerms', {
+            statements: [
+                new PolicyStatement({
+                    effect: Effect.ALLOW,
+                    actions: [
+                        'bedrock:InvokeModel',
+                        'bedrock:InvokeModelWithResponseStream',
+                    ],
+                    resources: [
+                        'arn:*:bedrock:*::foundation-model/*'
+                    ]
+                }),
+                new PolicyStatement({
+                    effect: Effect.ALLOW,
+                    actions: [
+                        'sagemaker:InvokeEndpoint',
+                        'sagemaker:InvokeEndpointWithResponseStream',
+                    ],
+                    resources: [
+                        'arn:*:sagemaker:*:*:endpoint/*'
+                    ],
+                }),
+            ]
+        });
+        restApi.taskRole.attachInlinePolicy(invocation_permissions);
 
         // Update
         this.restApi = restApi;

--- a/test/cdk/stacks/serve.test.ts
+++ b/test/cdk/stacks/serve.test.ts
@@ -107,7 +107,7 @@ describe.each(regions)('Serve Nag Pack Tests | Region Test: %s', (awsRegion) => 
 
     test('AwsSolutions CDK NAG Errors', () => {
         const errors = Annotations.fromStack(stack).findError('*', Match.stringLikeRegexp('AwsSolutions-.*'));
-        expect(errors.length).toBe(22);
+        expect(errors.length).toBe(24);
     });
 
     test('NIST800.53r5 CDK NAG Warnings', () => {
@@ -117,6 +117,6 @@ describe.each(regions)('Serve Nag Pack Tests | Region Test: %s', (awsRegion) => 
 
     test('NIST800.53r5 CDK NAG Errors', () => {
         const errors = Annotations.fromStack(stack).findError('*', Match.stringLikeRegexp('NIST.*'));
-        expect(errors.length).toBe(33);
+        expect(errors.length).toBe(34);
     });
 });


### PR DESCRIPTION
Adds bedrock and sagemaker permissions so that they don't need to be added to the rest API role manually anymore.

Tested by invoking a bedrock model and an sm endpoint in my account.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
