### PR TITLE
Lambda Authorizer updates

### DIFF
--- a/lambda/authorizer/lambda_functions.py
+++ b/lambda/authorizer/lambda_functions.py
@@ -101,14 +101,14 @@ def lambda_handler(event: Dict[str, Any], context) -> Dict[str, Any]:  # type: i
         logger.info(f"REST API authorization handler completed with 'Allow' for resource {event['methodArn']}")
         return allow_policy
 
+    # Try to authenticate with API Token
     elif path.startswith("/llm"):
-        logger.info("EVAAAANNNN")
         token = _get_api_token_info(id_token)
         if token:
             token_expiration = int(token.get(TOKEN_EXPIRATION_NAME, datetime.max.timestamp()))
             current_time = int(datetime.now().timestamp())
             if current_time < token_expiration and path.removeprefix("/llm/v2/serve/") in OPENAI_ROUTES:  # token has not expired yet - NON Admin Route
-                allow_policy = generate_policy(effect="Allow", resource=event["methodArn"], username=token["username"])
+                allow_policy = generate_policy(effect="Allow", resource=event["methodArn"], username=f"ApiToken:{id_token}")
                 logger.debug(f"Generated policy: {allow_policy}")
                 logger.info(f"REST API authorization handler completed with 'Allow' for resource {event['methodArn']}")
                 return allow_policy

--- a/lambda/authorizer/lambda_functions.py
+++ b/lambda/authorizer/lambda_functions.py
@@ -16,15 +16,49 @@
 import logging
 import os
 import ssl
+from datetime import datetime
 from typing import Any, Dict
 
 import create_env_variables  # noqa: F401
+import boto3
 import jwt
 import requests
 from utilities.common_functions import authorization_wrapper, get_id_token
 
 logger = logging.getLogger(__name__)
+ddb_resource = boto3.resource("dynamodb", region_name=os.environ["AWS_REGION"])
+token_table = ddb_resource.Table(os.environ["TOKEN_TABLE_NAME"]) # nosec B105
+TOKEN_EXPIRATION_NAME = "tokenExpiration"  # nosec B105
 
+# The following is an allowlist of OpenAI routes that users would not need elevated permissions to invoke. This is so
+# that we may assume anything *not* in this allowlist is an admin operation that requires greater LiteLLM permissions.
+# Assume that anything not within these routes requires admin permissions, which would only come from the LISA model
+# management API.
+OPENAI_ROUTES = (
+    # List models
+    "/llm/models",
+    "/llm/v1/models",
+    # Text completions
+    "/llm/chat/completions",
+    "/llm/v1/chat/completions",
+    "/llm/completions",
+    "/llm/v1/completions",
+    # Embeddings
+    "/llm/embeddings",
+    "/llm/v1/embeddings",
+    # Create images
+    "/llm/images/generations",
+    "/llm/v1/images/generations",
+    # Audio routes
+    "/llm/audio/speech",
+    "/llm/v1/audio/speech",
+    "/llm/audio/transcriptions",
+    "/llm/v1/audio/transcriptions",
+    # Health check routes
+    "/llm/health",
+    "/llm/health/readiness",
+    "/llm/health/liveliness",
+)
 
 @authorization_wrapper
 def lambda_handler(event: Dict[str, Any], context) -> Dict[str, Any]:  # type: ignore [no-untyped-def]
@@ -57,10 +91,26 @@ def lambda_handler(event: Dict[str, Any], context) -> Dict[str, Any]:  # type: i
             username = jwt_data.get("sub", "user")
             logger.info(f"Deny access to {username} due to non-admin accessing /models api.")
             return deny_policy
+        elif requested_resource.startswith("/llm") and requested_resource not in OPENAI_ROUTES and not is_admin_user:
+            username = jwt_data.get("sub", "user")
+            logger.info(f"Deny access to {username} due to non-admin accessing litellm admin api.")
+            return deny_policy
 
         logger.debug(f"Generated policy: {allow_policy}")
         logger.info(f"REST API authorization handler completed with 'Allow' for resource {event['methodArn']}")
         return allow_policy
+
+    elif requested_resource.startswith("/llm"):
+        token = _get_api_token_info(id_token)
+        if token:
+            token_expiration = int(token.get(TOKEN_EXPIRATION_NAME, datetime.max.timestamp()))
+            current_time = int(datetime.now().timestamp())
+            if current_time < token_expiration:  # token has not expired yet
+                allow_policy = generate_policy(effect="Allow", resource=event["methodArn"], username=token["username"])
+                logger.debug(f"Generated policy: {allow_policy}")
+                logger.info(f"REST API authorization handler completed with 'Allow' for resource {event['methodArn']}")
+                return allow_policy
+
 
     logger.info(f"REST API authorization handler completed with 'Deny' for resource {event['methodArn']}")
     return deny_policy
@@ -76,6 +126,12 @@ def generate_policy(*, effect: str, resource: str, username: str = "username") -
         },
     }
     return policy
+
+
+def _get_api_token_info(token: str) -> Any:
+    """Return DDB entry for token if it exists."""
+    ddb_response = token_table.get_item(Key={"token": token}, ReturnConsumedCapacity="NONE")
+    return ddb_response.get("Item", None)
 
 
 def id_token_is_valid(*, id_token: str, client_id: str, authority: str) -> Dict[str, Any] | None:

--- a/lambda/authorizer/lambda_functions.py
+++ b/lambda/authorizer/lambda_functions.py
@@ -36,28 +36,28 @@ TOKEN_EXPIRATION_NAME = "tokenExpiration"  # nosec B105
 # management API.
 OPENAI_ROUTES = (
     # List models
-    "/llm/models",
-    "/llm/v1/models",
+    "models",
+    "v1/models",
     # Text completions
-    "/llm/chat/completions",
-    "/llm/v1/chat/completions",
-    "/llm/completions",
-    "/llm/v1/completions",
+    "chat/completions",
+    "v1/chat/completions",
+    "completions",
+    "v1/completions",
     # Embeddings
-    "/llm/embeddings",
-    "/llm/v1/embeddings",
+    "embeddings",
+    "v1/embeddings",
     # Create images
-    "/llm/images/generations",
-    "/llm/v1/images/generations",
+    "images/generations",
+    "v1/images/generations",
     # Audio routes
-    "/llm/audio/speech",
-    "/llm/v1/audio/speech",
-    "/llm/audio/transcriptions",
-    "/llm/v1/audio/transcriptions",
+    "audio/speech",
+    "v1/audio/speech",
+    "audio/transcriptions",
+    "v1/audio/transcriptions",
     # Health check routes
-    "/llm/health",
-    "/llm/health/readiness",
-    "/llm/health/liveliness",
+    "health",
+    "health/readiness",
+    "health/liveliness",
 )
 
 @authorization_wrapper
@@ -91,7 +91,7 @@ def lambda_handler(event: Dict[str, Any], context) -> Dict[str, Any]:  # type: i
             username = jwt_data.get("sub", "user")
             logger.info(f"Deny access to {username} due to non-admin accessing /models api.")
             return deny_policy
-        elif requested_resource.startswith("/llm") and requested_resource not in OPENAI_ROUTES and not is_admin_user:
+        elif requested_resource.startswith("/llm") and requested_resource.removeprefix("/llm/v2/serve") not in OPENAI_ROUTES and not is_admin_user:
             username = jwt_data.get("sub", "user")
             logger.info(f"Deny access to {username} due to non-admin accessing litellm admin api.")
             return deny_policy

--- a/lambda/utilities/common_functions.py
+++ b/lambda/utilities/common_functions.py
@@ -279,6 +279,8 @@ def get_id_token(event: dict) -> str:
         auth_header = event["headers"]["authorization"].split(" ")
     elif "Authorization" in event["headers"]:
         auth_header = event["headers"]["Authorization"].split(" ")
+    else:
+        raise ValueError("Missing authorization token.")
 
     token = auth_header[1]
     return str(token)

--- a/lambda/utilities/common_functions.py
+++ b/lambda/utilities/common_functions.py
@@ -279,6 +279,10 @@ def get_id_token(event: dict) -> str:
         auth_header = event["headers"]["authorization"].split(" ")
     elif "Authorization" in event["headers"]:
         auth_header = event["headers"]["Authorization"].split(" ")
+    elif "Api-Key" in event["headers"]:
+        auth_header = ["", event["headers"]["Api-Key"]]
+    elif "api-key" in event["headers"]:
+        auth_header = ["", event["headers"]["api-key"]]
     else:
         raise ValueError("Missing authorization token.")
 

--- a/lambda/utilities/common_functions.py
+++ b/lambda/utilities/common_functions.py
@@ -284,21 +284,6 @@ def get_id_token(event: dict) -> str:
     return str(token)
 
 
-def get_api_key(event: dict) -> str:
-    """Return token from event request headers.
-
-    Extracts bearer token from authorization header in lambda event.
-    """
-    auth_header = None
-
-    if "Api-Key" in event["headers"]:
-        auth_header = event["headers"]["Api-Key"]
-    elif "api-key" in event["headers"]:
-        auth_header = event["headers"]["api-key"]
-
-    return auth_header
-
-
 @cache
 def get_cert_path(iam_client: Any) -> Union[str, bool]:
     """

--- a/lambda/utilities/common_functions.py
+++ b/lambda/utilities/common_functions.py
@@ -279,15 +279,24 @@ def get_id_token(event: dict) -> str:
         auth_header = event["headers"]["authorization"].split(" ")
     elif "Authorization" in event["headers"]:
         auth_header = event["headers"]["Authorization"].split(" ")
-    elif "Api-Key" in event["headers"]:
-        auth_header = ["", event["headers"]["Api-Key"].removeprefix("Bearer ")]
-    elif "api-key" in event["headers"]:
-        auth_header = ["", event["headers"]["api-key"].removeprefix("Bearer ")]
-    else:
-        raise ValueError("Missing authorization token.")
 
     token = auth_header[1]
     return str(token)
+
+
+def get_api_key(event: dict) -> str:
+    """Return token from event request headers.
+
+    Extracts bearer token from authorization header in lambda event.
+    """
+    auth_header = None
+
+    if "Api-Key" in event["headers"]:
+        auth_header = event["headers"]["Api-Key"]
+    elif "api-key" in event["headers"]:
+        auth_header = event["headers"]["api-key"]
+
+    return auth_header
 
 
 @cache

--- a/lambda/utilities/common_functions.py
+++ b/lambda/utilities/common_functions.py
@@ -280,9 +280,9 @@ def get_id_token(event: dict) -> str:
     elif "Authorization" in event["headers"]:
         auth_header = event["headers"]["Authorization"].split(" ")
     elif "Api-Key" in event["headers"]:
-        auth_header = ["", event["headers"]["Api-Key"]]
+        auth_header = ["", event["headers"]["Api-Key"].removeprefix("Bearer ")]
     elif "api-key" in event["headers"]:
-        auth_header = ["", event["headers"]["api-key"]]
+        auth_header = ["", event["headers"]["api-key"].removeprefix("Bearer ")]
     else:
         raise ValueError("Missing authorization token.")
 

--- a/lib/api-base/authorizer.ts
+++ b/lib/api-base/authorizer.ts
@@ -91,6 +91,8 @@ export class CustomAuthorizer extends Construct {
             securityGroups: securityGroups,
         });
 
+        props.tokenTable?.grantReadData(authorizerLambda);
+
         // Update
         this.authorizer = new RequestAuthorizer(this, 'APIGWAuthorizer', {
             handler: authorizerLambda,

--- a/lib/api-base/authorizer.ts
+++ b/lib/api-base/authorizer.ts
@@ -23,6 +23,7 @@ import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
 import { BaseProps } from '../schema';
+import { ITable } from 'aws-cdk-lib/aws-dynamodb';
 
 /**
  * Properties for RestApiGateway Construct.
@@ -36,6 +37,7 @@ type AuthorizerProps = {
     role?: IRole;
     vpc?: IVpc;
     securityGroups?: ISecurityGroup[];
+    tokenTable: ITable | undefined;
 } & BaseProps;
 
 /**
@@ -82,6 +84,7 @@ export class CustomAuthorizer extends Construct {
                 AUTHORITY: config.authConfig!.authority,
                 ADMIN_GROUP: config.authConfig!.adminGroup,
                 JWT_GROUPS_PROP: config.authConfig!.jwtGroupsProperty,
+                TOKEN_TABLE_NAME: props.tokenTable?.tableName ?? ''
             },
             role: role,
             vpc: vpc,

--- a/lib/api-base/ecsCluster.ts
+++ b/lib/api-base/ecsCluster.ts
@@ -282,7 +282,7 @@ export class ECSCluster extends Construct {
         if (props.addNlb) {
             this.nlb = new NetworkLoadBalancer(this, createCdkId([ecsConfig.identifier, 'NLB']), {
                 deletionProtection: config.removalPolicy !== RemovalPolicy.DESTROY,
-                crossZoneEnabled: true,
+                crossZoneEnabled: false,
                 internetFacing: ecsConfig.internetFacing,
                 loadBalancerName: createCdkId([config.deploymentName, ecsConfig.identifier, 'NLB'], 32, 2),
                 securityGroups: [securityGroup],

--- a/lib/api-base/fastApiContainer.ts
+++ b/lib/api-base/fastApiContainer.ts
@@ -16,7 +16,7 @@
 
 import { CfnOutput } from 'aws-cdk-lib';
 import { ITable } from 'aws-cdk-lib/aws-dynamodb';
-import { SecurityGroup, IVpc } from 'aws-cdk-lib/aws-ec2';
+import { IVpc, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import { AmiHardwareType, ContainerDefinition } from 'aws-cdk-lib/aws-ecs';
 import { IRole } from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
@@ -25,6 +25,7 @@ import { dump as yamlDump } from 'js-yaml';
 import { ECSCluster } from './ecsCluster';
 import { BaseProps, Ec2Metadata, EcsSourceType, FastApiContainerConfig } from '../schema';
 import {
+    AuthorizationType,
     ConnectionType,
     Cors,
     IAuthorizer,
@@ -149,6 +150,7 @@ export class FastApiContainer extends Construct {
             anyMethod: true,
             defaultMethodOptions: {
                 authorizer: props.authorizer,
+                authorizationType: AuthorizationType.CUSTOM,
                 requestParameters: {
                     'method.request.path.proxy': true
                 }

--- a/lib/core/api_base.ts
+++ b/lib/core/api_base.ts
@@ -21,6 +21,7 @@ import { Construct } from 'constructs';
 
 import { CustomAuthorizer } from '../api-base/authorizer';
 import { BaseProps } from '../schema';
+import { AttributeType, BillingMode, ITable, Table, TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
 
 type LisaApiBaseStackProps = {
     vpc: IVpc;
@@ -33,11 +34,28 @@ export class LisaApiBaseStack extends Stack {
     public readonly restApiId: string;
     public readonly rootResourceId: string;
     public readonly restApiUrl: string;
+    public readonly tokenTable: ITable | undefined;
 
     constructor (scope: Construct, id: string, props: LisaApiBaseStackProps) {
         super(scope, id, props);
 
         const { config, vpc } = props;
+
+        let tokenTable;
+        if (config.restApiConfig.internetFacing) {
+            // Create DynamoDB Table for enabling API token usage
+            tokenTable = new Table(this, 'TokenTable', {
+                tableName: `${config.deploymentName}-LISAApiTokenTable`,
+                partitionKey: {
+                    name: 'token',
+                    type: AttributeType.STRING,
+                },
+                billingMode: BillingMode.PAY_PER_REQUEST,
+                encryption: TableEncryption.AWS_MANAGED,
+                removalPolicy: config.removalPolicy,
+            });
+        }
+        this.tokenTable = tokenTable;
 
         const deployOptions: StageOptions = {
             stageName: config.deploymentStage,
@@ -61,6 +79,7 @@ export class LisaApiBaseStack extends Stack {
         // Create the authorizer Lambda for APIGW
         const authorizer = new CustomAuthorizer(this, 'LisaApiAuthorizer', {
             config: config,
+            tokenTable: tokenTable,
             vpc,
         });
 

--- a/lib/core/api_base.ts
+++ b/lib/core/api_base.ts
@@ -45,7 +45,7 @@ export class LisaApiBaseStack extends Stack {
         if (config.restApiConfig.internetFacing) {
             // Create DynamoDB Table for enabling API token usage
             tokenTable = new Table(this, 'TokenTable', {
-                tableName: `${config.deploymentName}-LISAApiTokenTable`,
+                tableName: `${config.deploymentName}-LISAApiTokensTable`,
                 partitionKey: {
                     name: 'token',
                     type: AttributeType.STRING,

--- a/lib/networking/vpc/index.ts
+++ b/lib/networking/vpc/index.ts
@@ -118,7 +118,7 @@ export class Vpc extends Construct {
         // All HTTP VPC traffic -> ECS model ALB
         ecsModelAlbSg.addIngressRule(Peer.ipv4(vpc.vpcCidrBlock), Port.tcp(80), 'Allow VPC traffic on port 80');
 
-        restApiAlbSg.addIngressRule(Peer.ipv4(vpc.vpcCidrBlock), Port.tcp(80), 'Allow VPC traffic on port 80');
+        restApiAlbSg.addIngressRule(Peer.anyIpv4(), Port.tcp(80), 'Allow any traffic on port 80');
 
         // Update
         this.vpc = vpc;

--- a/lib/serve/index.ts
+++ b/lib/serve/index.ts
@@ -18,7 +18,6 @@
 import path from 'path';
 
 import { Stack, StackProps } from 'aws-cdk-lib';
-import { AttributeType, BillingMode, Table, TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
 import { Peer, Port, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import { Credentials, DatabaseInstance, DatabaseInstanceEngine } from 'aws-cdk-lib/aws-rds';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
@@ -29,6 +28,7 @@ import { createCdkId } from '../core/utils';
 import { Vpc } from '../networking/vpc';
 import { BaseProps } from '../schema';
 import { IAuthorizer } from 'aws-cdk-lib/aws-apigateway';
+import { ITable } from 'aws-cdk-lib/aws-dynamodb';
 
 const HERE = path.resolve(__dirname);
 
@@ -37,6 +37,7 @@ type CustomLisaStackProps = {
     authorizer: IAuthorizer;
     restApiId: string;
     rootResourceId: string;
+    tokenTable: ITable | undefined;
 } & BaseProps;
 type LisaStackProps = CustomLisaStackProps & StackProps;
 
@@ -57,23 +58,8 @@ export class LisaServeApplicationStack extends Stack {
     constructor (scope: Construct, id: string, props: LisaStackProps) {
         super(scope, id, props);
 
-        const { config, vpc } = props;
+        const { config, vpc, tokenTable } = props;
         const rdsConfig = config.restApiConfig.rdsConfig;
-
-        let tokenTable;
-        if (config.restApiConfig.internetFacing) {
-            // Create DynamoDB Table for enabling API token usage
-            tokenTable = new Table(this, 'TokenTable', {
-                tableName: `${config.deploymentName}-LISAApiTokenTable`,
-                partitionKey: {
-                    name: 'token',
-                    type: AttributeType.STRING,
-                },
-                billingMode: BillingMode.PAY_PER_REQUEST,
-                encryption: TableEncryption.AWS_MANAGED,
-                removalPolicy: config.removalPolicy,
-            });
-        }
 
         // Create REST API
         const restApi = new FastApiContainer(this, 'RestApi', {

--- a/lib/stages.ts
+++ b/lib/stages.ts
@@ -145,6 +145,7 @@ export class LisaServeApplicationStage extends Stage {
             description: `LISA-serve: ${config.deploymentName}-${config.deploymentStage}`,
             stackName: createCdkId([config.deploymentName, config.appName, 'serve', config.deploymentStage]),
             vpc: networkingStack.vpc,
+            tokenTable: apiBaseStack.tokenTable
         });
         stacks.push(serveStack);
 

--- a/test/cdk/stacks/core-api-base.test.ts
+++ b/test/cdk/stacks/core-api-base.test.ts
@@ -97,7 +97,7 @@ describe.each(regions)('API Core Nag Pack Tests | Region Test: %s', (awsRegion) 
     //TODO Update expect values to remediate CDK NAG findings and remove debug
     test('AwsSolutions CDK NAG Warnings', () => {
         const warnings = Annotations.fromStack(stack).findWarning('*', Match.stringLikeRegexp('AwsSolutions-.*'));
-        expect(warnings.length).toBe(1);
+        expect(warnings.length).toBe(2);
     });
 
     test('AwsSolutions CDK NAG Errors', () => {
@@ -112,6 +112,6 @@ describe.each(regions)('API Core Nag Pack Tests | Region Test: %s', (awsRegion) 
 
     test('NIST800.53r5 CDK NAG Errors', () => {
         const errors = Annotations.fromStack(stack).findError('*', Match.stringLikeRegexp('NIST.*'));
-        expect(errors.length).toBe(6);
+        expect(errors.length).toBe(9);
     });
 });

--- a/test/cdk/stacks/networking.test.ts
+++ b/test/cdk/stacks/networking.test.ts
@@ -29,12 +29,12 @@ import { BaseProps, Config, ConfigFile, ConfigSchema } from '../../../lib/schema
 type TestConfig = [string, number, number, number, number];
 
 const regions: TestConfig[] = [
-    ['us-east-1', 2, 1, 5, 5],
-    ['us-gov-west-1', 2, 1, 5, 5],
-    ['us-gov-east-1', 2, 1, 5, 5],
-    ['us-isob-east-1', 2, 1, 5, 5],
-    ['us-iso-east-1', 2, 1, 5, 5],
-    ['us-iso-west-1', 2, 1, 5, 5],
+    ['us-east-1', 1, 2, 3, 5],
+    ['us-gov-west-1', 1, 2, 3, 5],
+    ['us-gov-east-1', 1, 2, 3, 5],
+    ['us-isob-east-1', 1, 2, 3, 5],
+    ['us-iso-east-1', 1, 2, 3, 5],
+    ['us-iso-west-1', 1, 2, 3, 5],
 ];
 
 describe.each<TestConfig>(regions)(

--- a/test/cdk/stacks/serve.test.ts
+++ b/test/cdk/stacks/serve.test.ts
@@ -88,6 +88,7 @@ describe.each(regions)('Serve Nag Pack Tests | Region Test: %s', (awsRegion) => 
             authorizer: apiBaseStack.authorizer,
             restApiId: apiBaseStack.restApiId,
             rootResourceId: apiBaseStack.rootResourceId,
+            tokenTable: apiBaseStack.tokenTable
         });
         // WHEN
         Aspects.of(stack).add(new AwsSolutionsChecks({ verbose: true }));
@@ -102,7 +103,7 @@ describe.each(regions)('Serve Nag Pack Tests | Region Test: %s', (awsRegion) => 
     //TODO Update expect values to remediate CDK NAG findings and remove debug
     test('AwsSolutions CDK NAG Warnings', () => {
         const warnings = Annotations.fromStack(stack).findWarning('*', Match.stringLikeRegexp('AwsSolutions-.*'));
-        expect(warnings.length).toBe(1);
+        expect(warnings.length).toBe(0);
     });
 
     test('AwsSolutions CDK NAG Errors', () => {
@@ -117,6 +118,6 @@ describe.each(regions)('Serve Nag Pack Tests | Region Test: %s', (awsRegion) => 
 
     test('NIST800.53r5 CDK NAG Errors', () => {
         const errors = Annotations.fromStack(stack).findError('*', Match.stringLikeRegexp('NIST.*'));
-        expect(errors.length).toBe(34);
+        expect(errors.length).toBe(32);
     });
 });


### PR DESCRIPTION
*Description of changes:*

Now that fastapi container is behind our APIGW we can use our authorizer to determine if a user should have access to a specific resource. We now:
- Verify that admins are calling anything that isn't a specific OpenAI URL in `/llm`
- If an invalid Bearer token is provided check to see if it is in our token DB and allow access to only OpenAI URLs if valid and present


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
