### PR TITLE
create/poll stack implementations

### DIFF
--- a/ecs_model_deployer/src/lib/ecsCluster.ts
+++ b/ecs_model_deployer/src/lib/ecsCluster.ts
@@ -311,7 +311,7 @@ export class ECSCluster extends Construct {
         // ALB metric for ASG to use for auto scaling EC2 instances
         // TODO: Update this to step scaling for embedding models??
         const requestCountPerTargetMetric = new Metric({
-            metricName: ecsConfig.autoScalingConfig.metricConfig.AlbMetricName,
+            metricName: ecsConfig.autoScalingConfig.metricConfig.albMetricName,
             namespace: 'AWS/ApplicationELB',
             dimensionsMap: {
                 TargetGroup: targetGroup.targetGroupFullName,

--- a/ecs_model_deployer/src/lib/schema.ts
+++ b/ecs_model_deployer/src/lib/schema.ts
@@ -400,7 +400,7 @@ const LoadBalancerConfigSchema = z.object({
  *
  */
 const MetricConfigSchema = z.object({
-    AlbMetricName: z.string(),
+    albMetricName: z.string(),
     targetValue: z.number(),
     duration: z.number().default(60),
     estimatedInstanceWarmup: z.number().min(0).default(180),

--- a/lambda/models/state_machine/create_model.py
+++ b/lambda/models/state_machine/create_model.py
@@ -20,13 +20,16 @@ from copy import deepcopy
 from typing import Any, Dict
 
 import boto3
+from botocore.config import Config
 from models.domain_objects import CreateModelRequest
 
-lambdaClient = boto3.client("lambda")
+lambdaConfig = Config(connect_timeout=60, read_timeout=600, retries={"max_attempts": 1})
+lambdaClient = boto3.client("lambda", config=lambdaConfig)
 ecrClient = boto3.client("ecr")
 ec2Client = boto3.client("ec2")
 ddbResource = boto3.resource("dynamodb")
 model_table = ddbResource.Table(os.environ["MODEL_TABLE_NAME"])
+cfnClient = boto3.client("cloudformation")
 
 
 def handle_set_model_to_creating(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
@@ -97,14 +100,69 @@ def handle_poll_docker_image_available(event: Dict[str, Any], context: Any) -> D
 def handle_start_create_stack(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """Start model infrastructure creation."""
     output_dict = deepcopy(event)
+    request = CreateModelRequest.validate(event)
+
+    prepared_event = {}
+
+    def camelize_object(o):
+        o2 = {}
+        for k in o:
+            fixed_k = k[:1].lower() + k[1:]
+            if isinstance(o[k], dict):
+                o2[fixed_k] = camelize_object(o[k])
+            else:
+                o2[fixed_k] = o[k]
+        return o2
+
+    prepared_event = camelize_object(event)
+    prepared_event["containerConfig"]["environment"] = event["ContainerConfig"]["Environment"]
+    prepared_event["containerConfig"]["image"] = {
+        "repositoryArn": os.environ["ECR_REPOSITORY_ARN"],
+        "tag": event["image_info"]["image_tag"],
+        "type": "ecr",
+    }
+
+    response = lambdaClient.invoke(
+        FunctionName=os.environ["ECS_MODEL_DEPLOYER_FN_ARN"],
+        Payload=json.dumps({"modelConfig": prepared_event}),
+    )
+
+    payload = response["Payload"].read()
+    payload = json.loads(payload)
+    stack_name = payload.get("stackName")
+
+    response = cfnClient.describe_stacks(StackName=stack_name)
+    stack_arn = response["Stacks"][0]["StackId"]
+    output_dict["stack_name"] = stack_name
+    output_dict["stack_arn"] = stack_arn
+
+    model_table.update_item(
+        Key={"model_id": request.ModelId},
+        UpdateExpression="SET StackName = :stack_name, StackArn = :stack_arn",
+        ExpressionAttributeValues={":stack_name": {"S": stack_name}, ":stack_arn": {"S": stack_arn}},
+    )
+
+    output_dict["remaining_polls_stack"] = 30
+
     return output_dict
 
 
 def handle_poll_create_stack(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """Check that model infrastructure creation has completed or not."""
     output_dict = deepcopy(event)
-    output_dict["continue_polling_stack"] = False
-    return output_dict
+    response = cfnClient.describe_stacks(StackName=event["stack_name"])
+    stackStatus = response["Stacks"][0]["StackStatus"]
+    if stackStatus in ["CREATE_COMPLETE", "UPDATE_COMPLETE"]:
+        output_dict["continue_polling_stack"] = False
+        return output_dict
+    elif stackStatus in ["CREATE_IN_PROGRESS", "UPDATE_IN_PROGRESS"]:
+        output_dict["continue_polling_stack"] = True
+        output_dict["remaining_polls_stack"] -= 1
+        if output_dict["remaining_polls_stack"] <= 0:
+            raise Exception("Maximum number of CloudFormation polls reached")
+        return output_dict
+    else:
+        raise Exception(f"Stack in unexpected state: {stackStatus}")
 
 
 def handle_add_model_to_litellm(event: Dict[str, Any], context: Any) -> Dict[str, Any]:

--- a/lib/models/model-api.ts
+++ b/lib/models/model-api.ts
@@ -112,7 +112,7 @@ export class ModelsApi extends Construct {
 
         const ecsModelImages = new EcsModelImageRepository(this, createCdkId(['ecs-image-model-repo']));
 
-        new ECSModelDeployer(this, 'ecs-model-deployer', {
+        const ecsModelDeployer = new ECSModelDeployer(this, 'ecs-model-deployer', {
             securityGroupId: vpc.securityGroups.ecsModelAlbSg.securityGroupId,
             vpcId: vpc.vpc.vpcId,
             config: config
@@ -161,7 +161,8 @@ export class ModelsApi extends Construct {
                                 'lambda:InvokeFunction'
                             ],
                             resources: [
-                                dockerImageBuilder.dockerImageBuilderFn.functionArn
+                                dockerImageBuilder.dockerImageBuilderFn.functionArn,
+                                ecsModelDeployer.ecsModelDeployerFn.functionArn
                             ]
                         }),
                         new PolicyStatement({
@@ -194,7 +195,8 @@ export class ModelsApi extends Construct {
             vpc: vpc.vpc,
             securityGroups: securityGroups,
             dockerImageBuilderFnArn: dockerImageBuilder.dockerImageBuilderFn.functionArn,
-            ecsModelImageRepositoryName: ecsModelImages.repo.repositoryName
+            ecsModelDeployerFnArn: ecsModelDeployer.ecsModelDeployerFn.functionArn,
+            ecsModelImageRepository: ecsModelImages.repo
         });
 
         const deleteModelStateMachine = new DeleteModelStateMachine(this, 'DeleteModelWorkflow', {


### PR DESCRIPTION
create/poll stack implementations

9/6 0300: still need to test polling, there might be an issue with long images getting built connection reset by peer. issue with environment variables getting camelized then not making it to container

9/6 0630: Got a completely zero-touch create model execution that built the image, started the stack, polled it successfully until it completed.