### PR TITLE
Migrate APIs to DDB instead of LiteLLM db

### DIFF
--- a/ecs_model_deployer/src/lib/ecsCluster.ts
+++ b/ecs_model_deployer/src/lib/ecsCluster.ts
@@ -15,7 +15,7 @@
 */
 
 // ECS Cluster Construct.
-import { Duration, RemovalPolicy } from 'aws-cdk-lib';
+import { CfnOutput, Duration, RemovalPolicy } from 'aws-cdk-lib';
 import { BlockDeviceVolume, GroupMetrics, Monitoring } from 'aws-cdk-lib/aws-autoscaling';
 import { Metric, Stats } from 'aws-cdk-lib/aws-cloudwatch';
 import { InstanceType, ISecurityGroup, IVpc } from 'aws-cdk-lib/aws-ec2';
@@ -324,12 +324,12 @@ export class ECSCluster extends Construct {
             estimatedInstanceWarmup: Duration.seconds(ecsConfig.autoScalingConfig.metricConfig.duration),
         });
 
-        const domain =
-      ecsConfig.loadBalancerConfig.domainName !== null
-          ? ecsConfig.loadBalancerConfig.domainName
-          : loadBalancer.loadBalancerDnsName;
-        const endpoint = `http://${domain}`;
-        this.endpointUrl = endpoint;
+        this.endpointUrl = loadBalancer.loadBalancerDnsName;
+
+        new CfnOutput(this, 'modelEndpointurl', {
+            key: 'modelEndpointUrl',
+            value: this.endpointUrl,
+        });
 
         // Update
         this.container = container;

--- a/lambda/models/domain_objects.py
+++ b/lambda/models/domain_objects.py
@@ -65,99 +65,98 @@ class ModelType(str, Enum):
 class MetricConfig(BaseModel):
     """Metric configuration for autoscaling."""
 
-    AlbMetricName: str
-    TargetValue: int
-    Duration: int
-    EstimatedInstanceWarmup: int
+    albMetricName: str
+    targetValue: int
+    duration: int
+    estimatedInstanceWarmup: int
 
 
 class LoadBalancerHealthCheckConfig(BaseModel):
     """Health check configuration for a load balancer."""
 
-    Path: str
-    Interval: int
-    Timeout: int
-    HealthyThresholdCount: int
-    UnhealthyThresholdCount: int
+    path: str
+    interval: int
+    timeout: int
+    healthyThresholdCount: int
+    unhealthyThresholdCount: int
 
 
 class LoadBalancerConfig(BaseModel):
     """Load balancer configuration."""
 
-    HealthCheckConfig: LoadBalancerHealthCheckConfig
+    healthCheckConfig: LoadBalancerHealthCheckConfig
 
 
 class AutoScalingConfig(BaseModel):
     """Autoscaling configuration."""
 
-    MinCapacity: int
-    MaxCapacity: int
-    Cooldown: int
-    DefaultInstanceWarmup: int
-    MetricConfig: MetricConfig
+    minCapacity: int
+    maxCapacity: int
+    cooldown: int
+    defaultInstanceWarmup: int
+    metricConfig: MetricConfig
 
 
 class ContainerHealthCheckConfig(BaseModel):
     """Health check configuration for a container."""
 
-    Command: Union[str, list[str]]
-    Interval: int
-    StartPeriod: int
-    Timeout: int
-    Retries: int
+    command: Union[str, list[str]]
+    interval: int
+    startPeriod: int
+    timeout: int
+    retries: int
 
 
 class ContainerConfigImage(BaseModel):
     """Image image configuration for a container."""
 
-    BaseImage: str
-    Path: str
-    Type: str
+    baseImage: str
+    path: str
+    type: str
 
 
 class ContainerConfig(BaseModel):
     """Container configuration."""
 
-    BaseImage: ContainerConfigImage
-    SharedMemorySize: int
-    HealthCheckConfig: ContainerHealthCheckConfig
-    Environment: dict[str, str]
+    baseImage: ContainerConfigImage
+    sharedMemorySize: int
+    healthCheckConfig: ContainerHealthCheckConfig
+    environment: dict[str, str]
 
 
 class LISAModel(BaseModel):
     """Core model definition fields."""
 
-    AutoScalingConfig: Optional[AutoScalingConfig]
-    ContainerConfig: Optional[ContainerConfig]
-    LoadBalancerConfig: Optional[LoadBalancerConfig]
-    ModelId: str
-    ModelName: str
-    ModelType: ModelType
-    ModelUrl: Optional[str]
-    Status: ModelStatus
-    Streaming: bool
-    UniqueId: str
+    autoScalingConfig: Optional[AutoScalingConfig] = None
+    containerConfig: Optional[ContainerConfig] = None
+    loadBalancerConfig: Optional[LoadBalancerConfig] = None
+    modelId: str
+    modelName: str
+    modelType: ModelType
+    modelUrl: Optional[str] = None
+    status: ModelStatus
+    streaming: bool
 
 
 class ApiResponseBase(BaseModel):
     """Common API response definition for most API calls."""
 
-    Model: LISAModel
+    model: LISAModel
 
 
 class CreateModelRequest(BaseModel):
     """Request object when creating a new model."""
 
-    AutoScalingConfig: Optional[AutoScalingConfig]
-    ContainerConfig: Optional[ContainerConfig]
-    InferenceContainer: Optional[InferenceContainer]
-    InstanceType: Optional[Annotated[str, AfterValidator(validate_instance_type)]]
-    LoadBalancerConfig: Optional[LoadBalancerConfig]
-    ModelId: str
-    ModelName: str
-    ModelType: ModelType
-    ModelUrl: Optional[str]
-    Streaming: bool
+    autoScalingConfig: Optional[AutoScalingConfig] = None
+    containerConfig: Optional[ContainerConfig] = None
+    inferenceContainer: Optional[InferenceContainer] = None
+    instanceType: Optional[Annotated[str, AfterValidator(validate_instance_type)]] = None
+    loadBalancerConfig: Optional[LoadBalancerConfig] = None
+    modelId: str
+    modelName: str
+    modelType: ModelType
+    modelUrl: Optional[str] = None
+    streaming: bool
 
 
 class CreateModelResponse(ApiResponseBase):
@@ -169,7 +168,7 @@ class CreateModelResponse(ApiResponseBase):
 class ListModelsResponse(BaseModel):
     """Response object when listing models."""
 
-    Models: List[LISAModel]
+    models: List[LISAModel]
 
 
 class GetModelResponse(ApiResponseBase):
@@ -181,15 +180,15 @@ class GetModelResponse(ApiResponseBase):
 class UpdateModelRequest(BaseModel):
     """Request object when updating a model."""
 
-    AutoScalingConfig: Optional[AutoScalingConfig]
-    ContainerConfig: Optional[ContainerConfig]
-    InferenceContainer: Optional[InferenceContainer]
-    InstanceType: Optional[Annotated[str, AfterValidator(validate_instance_type)]]
-    LoadBalancerConfig: Optional[LoadBalancerConfig]
-    ModelId: Optional[str]
-    ModelName: Optional[str]
-    ModelType: Optional[ModelType]
-    Streaming: Optional[bool]
+    autoScalingConfig: Optional[AutoScalingConfig] = None
+    containerConfig: Optional[ContainerConfig] = None
+    inferenceContainer: Optional[InferenceContainer] = None
+    instanceType: Optional[Annotated[str, AfterValidator(validate_instance_type)]] = None
+    loadBalancerConfig: Optional[LoadBalancerConfig] = None
+    modelId: str
+    modelName: Optional[str] = None
+    modelType: Optional[ModelType] = None
+    streaming: Optional[bool] = None
 
 
 class UpdateModelResponse(ApiResponseBase):

--- a/lambda/models/domain_objects.py
+++ b/lambda/models/domain_objects.py
@@ -32,7 +32,6 @@ class InferenceContainer(str, Enum):
     TGI = "tgi"
     TEI = "tei"
     VLLM = "vllm"
-    INSTRUCTOR = "instructor"
 
 
 class ModelStatus(str, Enum):
@@ -130,6 +129,7 @@ class LISAModel(BaseModel):
     autoScalingConfig: Optional[AutoScalingConfig] = None
     containerConfig: Optional[ContainerConfig] = None
     loadBalancerConfig: Optional[LoadBalancerConfig] = None
+    instanceType: Optional[Annotated[str, AfterValidator(validate_instance_type)]] = None
     modelId: str
     modelName: str
     modelType: ModelType

--- a/lambda/models/handler/base_handler.py
+++ b/lambda/models/handler/base_handler.py
@@ -15,9 +15,7 @@
 """Base Handler definition for model management API definitions."""
 
 
-from typing import Any, Union
-
-from starlette.datastructures import Headers
+from typing import Any
 
 from ..clients.litellm_client import LiteLLMClient
 
@@ -25,9 +23,16 @@ from ..clients.litellm_client import LiteLLMClient
 class BaseApiHandler:
     """Base Handler class for all model management APIs."""
 
-    def __init__(self, base_uri: str, headers: Headers, verify: Union[str, bool]):
-        """Create a LiteLLM client for all child objects to use."""
-        self._litellm_client = LiteLLMClient(base_uri=base_uri, headers=headers, verify=verify)
+    def __init__(
+        self,
+        stepfunctions_client: Any,
+        model_table_resource: Any,
+        litellm_client: LiteLLMClient,
+    ):
+        """Make all clients available for use in any handler class."""
+        self._stepfunctions = stepfunctions_client
+        self._model_table = model_table_resource
+        self._litellm_client = litellm_client
 
     def __call__(self, *args: Any, **kwargs: Any) -> None:
         """All handlers must implement the __call__ method."""

--- a/lambda/models/handler/create_model_handler.py
+++ b/lambda/models/handler/create_model_handler.py
@@ -39,14 +39,10 @@ class CreateModelHandler(BaseApiHandler):
             stateMachineArn=os.environ["CREATE_SFN_ARN"], input=create_request.model_dump_json()
         )
 
-        # Placeholder data until model data is persisted in database via state machine workflow
         lisa_model = to_lisa_model(
             {
-                "modelId": model_id,
-                "modelName": create_request.modelName,
-                "modelType": create_request.modelType,
-                "status": ModelStatus.CREATING,
-                "streaming": create_request.streaming,
+                "model_config": create_request.model_dump(),
+                "model_status": ModelStatus.CREATING,
             }
         )
         return CreateModelResponse(model=lisa_model)

--- a/lambda/models/handler/create_model_handler.py
+++ b/lambda/models/handler/create_model_handler.py
@@ -16,17 +16,11 @@
 
 import os
 
-import boto3
 from models.exception import ModelAlreadyExistsError
-from utilities.common_functions import retry_config
 
 from ..domain_objects import CreateModelRequest, CreateModelResponse, ModelStatus
 from .base_handler import BaseApiHandler
 from .utils import to_lisa_model
-
-stepfunctions = boto3.client("stepfunctions", region_name=os.environ["AWS_REGION"], config=retry_config)
-dynamodb = boto3.resource("dynamodb", region_name=os.environ["AWS_REGION"], config=retry_config)
-model_table = dynamodb.Table(os.environ["MODEL_TABLE_NAME"])
 
 
 class CreateModelHandler(BaseApiHandler):
@@ -34,28 +28,29 @@ class CreateModelHandler(BaseApiHandler):
 
     def __call__(self, create_request: CreateModelRequest) -> CreateModelResponse:  # type: ignore
         """Create model infrastructure and add model data to LiteLLM database."""
-        unique_id = create_request.ModelId
+        model_id = create_request.modelId
 
         # If model exists in DDB, then fail out. ModelId must be unique.
-        table_item = model_table.get_item(Key={"model_id": unique_id}).get("Item", None)
+        table_item = self._model_table.get_item(Key={"model_id": model_id}).get("Item", None)
         if table_item:
-            raise ModelAlreadyExistsError(f"Model '{unique_id}' already exists. Please select another name.")
+            raise ModelAlreadyExistsError(f"Model '{model_id}' already exists. Please select another name.")
 
-        stepfunctions.start_execution(
+        self._stepfunctions.start_execution(
             stateMachineArn=os.environ["CREATE_SFN_ARN"], input=create_request.model_dump_json()
         )
 
         # Placeholder data until model data is persisted in database via state machine workflow
         lisa_model = to_lisa_model(
             {
-                "model_name": unique_id,
+                "model_name": model_id,
                 "litellm_params": {
-                    "model": unique_id,
+                    "model": create_request.modelName,
                 },
                 "model_info": {
-                    "id": unique_id,
+                    "id": model_id,
                     "model_status": ModelStatus.CREATING,
+                    "streaming": create_request.streaming,
                 },
             }
         )
-        return CreateModelResponse(Model=lisa_model)
+        return CreateModelResponse(model=lisa_model)

--- a/lambda/models/handler/create_model_handler.py
+++ b/lambda/models/handler/create_model_handler.py
@@ -42,15 +42,11 @@ class CreateModelHandler(BaseApiHandler):
         # Placeholder data until model data is persisted in database via state machine workflow
         lisa_model = to_lisa_model(
             {
-                "model_name": model_id,
-                "litellm_params": {
-                    "model": create_request.modelName,
-                },
-                "model_info": {
-                    "id": model_id,
-                    "model_status": ModelStatus.CREATING,
-                    "streaming": create_request.streaming,
-                },
+                "modelId": model_id,
+                "modelName": create_request.modelName,
+                "modelType": create_request.modelType,
+                "status": ModelStatus.CREATING,
+                "streaming": create_request.streaming,
             }
         )
         return CreateModelResponse(model=lisa_model)

--- a/lambda/models/handler/delete_model_handler.py
+++ b/lambda/models/handler/delete_model_handler.py
@@ -19,7 +19,7 @@ import os
 
 from models.exception import ModelNotFoundError
 
-from ..domain_objects import DeleteModelResponse, ModelStatus
+from ..domain_objects import DeleteModelResponse
 from .base_handler import BaseApiHandler
 from .utils import to_lisa_model
 
@@ -37,19 +37,5 @@ class DeleteModelHandler(BaseApiHandler):
             stateMachineArn=os.environ["DELETE_SFN_ARN"], input=json.dumps({"modelId": model_id})
         )
 
-        # Placeholder info until all model info is properly stored in DDB
-        lisa_model = to_lisa_model(
-            {
-                "model_name": model_id,
-                "litellm_params": {
-                    "model": table_item["model_config"]["modelName"],
-                },
-                "model_info": {
-                    "id": table_item["litellm_id"],
-                    "model_status": ModelStatus.DELETING,
-                    "streaming": table_item["model_config"]["streaming"],
-                },
-            }
-        )
-
+        lisa_model = to_lisa_model(table_item)
         return DeleteModelResponse(model=lisa_model)

--- a/lambda/models/handler/get_model_handler.py
+++ b/lambda/models/handler/get_model_handler.py
@@ -15,6 +15,7 @@
 """Handler for GetModel requests."""
 
 from ..domain_objects import GetModelResponse
+from ..exception import ModelNotFoundError
 from .base_handler import BaseApiHandler
 from .utils import to_lisa_model
 
@@ -24,5 +25,7 @@ class GetModelHandler(BaseApiHandler):
 
     def __call__(self, model_id: str) -> GetModelResponse:  # type: ignore
         """Get model metadata from LiteLLM and translate to a model management response object."""
-        model = self._litellm_client.get_model(identifier=model_id)
-        return GetModelResponse(Model=to_lisa_model(model))
+        ddb_item = self._model_table.get_item(Key={"model_id": model_id}).get("Item", None)
+        if not ddb_item:
+            raise ModelNotFoundError(f"Model '{model_id}' was not found.")
+        return GetModelResponse(model=to_lisa_model(ddb_item))

--- a/lambda/models/handler/get_model_handler.py
+++ b/lambda/models/handler/get_model_handler.py
@@ -22,7 +22,7 @@ from .utils import to_lisa_model
 class GetModelHandler(BaseApiHandler):
     """Handler class for GetModel requests."""
 
-    def __call__(self, unique_id: str) -> GetModelResponse:  # type: ignore
+    def __call__(self, model_id: str) -> GetModelResponse:  # type: ignore
         """Get model metadata from LiteLLM and translate to a model management response object."""
-        model = self._litellm_client.get_model(unique_id=unique_id)
+        model = self._litellm_client.get_model(identifier=model_id)
         return GetModelResponse(Model=to_lisa_model(model))

--- a/lambda/models/handler/utils.py
+++ b/lambda/models/handler/utils.py
@@ -22,14 +22,13 @@ from ..domain_objects import LISAModel, ModelStatus
 def to_lisa_model(model_dict: Dict[str, Any]) -> LISAModel:
     """Convert LiteLLM model dictionary to a LISAModel object."""
     return LISAModel(
-        ModelId=model_dict["model_name"],
-        ModelName=model_dict["litellm_params"]["model"].removeprefix("openai/"),
-        UniqueId=model_dict["model_info"]["id"],
-        Status=model_dict["model_info"].get("model_status", ModelStatus.IN_SERVICE),
-        ModelType=model_dict["model_info"].get("model_type", "textgen"),
-        Streaming=model_dict["model_info"].get("streaming", False),
-        ModelUrl=model_dict["litellm_params"].get("api_base", None),
-        ContainerConfig=model_dict["model_info"].get("container_config", None),
-        AutoScalingConfig=model_dict["model_info"].get("autoscaling_config", None),
-        LoadBalancerConfig=model_dict["model_info"].get("loadbalancer_config", None),
+        modelId=model_dict["model_name"],
+        modelName=model_dict["litellm_params"]["model"].removeprefix("openai/"),
+        status=model_dict["model_info"].get("model_status", ModelStatus.IN_SERVICE),
+        modelType=model_dict["model_info"].get("model_type", "textgen"),
+        streaming=model_dict["model_info"].get("streaming", False),
+        modelUrl=model_dict["litellm_params"].get("api_base", None),
+        containerConfig=model_dict["model_info"].get("container_config", None),
+        autoScalingConfig=model_dict["model_info"].get("autoscaling_config", None),
+        loadBalancerConfig=model_dict["model_info"].get("loadbalancer_config", None),
     )

--- a/lambda/models/handler/utils.py
+++ b/lambda/models/handler/utils.py
@@ -16,19 +16,13 @@
 
 from typing import Any, Dict
 
-from ..domain_objects import LISAModel, ModelStatus
+from ..domain_objects import LISAModel
 
 
 def to_lisa_model(model_dict: Dict[str, Any]) -> LISAModel:
-    """Convert LiteLLM model dictionary to a LISAModel object."""
-    return LISAModel(
-        modelId=model_dict["model_name"],
-        modelName=model_dict["litellm_params"]["model"].removeprefix("openai/"),
-        status=model_dict["model_info"].get("model_status", ModelStatus.IN_SERVICE),
-        modelType=model_dict["model_info"].get("model_type", "textgen"),
-        streaming=model_dict["model_info"].get("streaming", False),
-        modelUrl=model_dict["litellm_params"].get("api_base", None),
-        containerConfig=model_dict["model_info"].get("container_config", None),
-        autoScalingConfig=model_dict["model_info"].get("autoscaling_config", None),
-        loadBalancerConfig=model_dict["model_info"].get("loadbalancer_config", None),
-    )
+    """Convert DDB model entry dictionary to a LISAModel object."""
+    model_dict["model_config"]["status"] = model_dict["model_status"]
+    if "model_url" in model_dict:
+        model_dict["model_config"]["modelUrl"] = model_dict["model_url"]
+    lisa_model: LISAModel = LISAModel.model_validate(model_dict["model_config"])
+    return lisa_model

--- a/lambda/models/state_machine/create_model.py
+++ b/lambda/models/state_machine/create_model.py
@@ -216,7 +216,7 @@ def handle_add_model_to_litellm(event: Dict[str, Any], context: Any) -> Dict[str
             ":ms": ModelStatus.IN_SERVICE,
             ":lid": litellm_id,
             ":lm": int(datetime.utcnow().timestamp()),
-            ":mu": litellm_params.get("api_base", "")
+            ":mu": litellm_params.get("api_base", ""),
         },
     )
 

--- a/lambda/models/state_machine/create_model.py
+++ b/lambda/models/state_machine/create_model.py
@@ -17,19 +17,23 @@
 import json
 import os
 from copy import deepcopy
+from datetime import datetime
 from typing import Any, Dict
 
 import boto3
 from botocore.config import Config
-from models.domain_objects import CreateModelRequest
+from models.clients.litellm_client import LiteLLMClient
+from models.domain_objects import CreateModelRequest, ModelStatus
+from utilities.common_functions import get_rest_api_container_endpoint, retry_config
 
 lambdaConfig = Config(connect_timeout=60, read_timeout=600, retries={"max_attempts": 1})
-lambdaClient = boto3.client("lambda", config=lambdaConfig)
-ecrClient = boto3.client("ecr")
-ec2Client = boto3.client("ec2")
-ddbResource = boto3.resource("dynamodb")
+lambdaClient = boto3.client("lambda", region_name=os.environ["AWS_REGION"], config=lambdaConfig)
+ecrClient = boto3.client("ecr", region_name=os.environ["AWS_REGION"], config=retry_config)
+ec2Client = boto3.client("ec2", region_name=os.environ["AWS_REGION"], config=retry_config)
+ddbResource = boto3.resource("dynamodb", region_name=os.environ["AWS_REGION"], config=retry_config)
 model_table = ddbResource.Table(os.environ["MODEL_TABLE_NAME"])
-cfnClient = boto3.client("cloudformation")
+cfnClient = boto3.client("cloudformation", region_name=os.environ["AWS_REGION"], config=retry_config)
+litellm_client = LiteLLMClient(base_uri=get_rest_api_container_endpoint())
 
 
 def handle_set_model_to_creating(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
@@ -37,22 +41,29 @@ def handle_set_model_to_creating(event: Dict[str, Any], context: Any) -> Dict[st
     output_dict = deepcopy(event)
     request = CreateModelRequest.validate(event)
 
-    if (
-        request.AutoScalingConfig  # noqa: W503
-        and request.ContainerConfig  # noqa: W503
-        and request.InferenceContainer  # noqa: W503
-        and request.InstanceType  # noqa: W503
-        and request.LoadBalancerConfig  # noqa: W503
-    ):
-        model_table.update_item(
-            Key={"model_id": request.ModelId},
-            UpdateExpression="SET #s = :status, ModelConfig = :modelConfig",
-            ExpressionAttributeValues={":status": {"S": "CREATING"}, ":modelConfig": {"M": event}},
-            ExpressionAttributeNames={"#s": "Status"},
+    is_lisa_managed = all(
+        (
+            bool(request_param)
+            for request_param in (
+                request.autoScalingConfig,
+                request.containerConfig,
+                request.inferenceContainer,
+                request.instanceType,
+                request.loadBalancerConfig,
+            )
         )
-        output_dict["create_infra"] = True
-    else:
-        output_dict["create_infra"] = False
+    )
+
+    model_table.update_item(
+        Key={"model_id": request.modelId},
+        UpdateExpression="SET model_status = :model_status, model_config = :model_config, last_modified_date = :lm",
+        ExpressionAttributeValues={
+            ":model_status": ModelStatus.CREATING,
+            ":model_config": event,
+            ":lm": int(datetime.utcnow().timestamp()),
+        },
+    )
+    output_dict["create_infra"] = is_lisa_managed
     return output_dict
 
 
@@ -65,8 +76,8 @@ def handle_start_copy_docker_image(event: Dict[str, Any], context: Any) -> Dict[
         FunctionName=os.environ["DOCKER_IMAGE_BUILDER_FN_ARN"],
         Payload=json.dumps(
             {
-                "base_image": request.ContainerConfig.BaseImage.BaseImage,
-                "layer_to_add": request.ContainerConfig.BaseImage.Path,
+                "base_image": request.containerConfig.baseImage.baseImage,
+                "layer_to_add": request.containerConfig.baseImage.path,
             }
         ),
     )
@@ -105,8 +116,6 @@ def handle_start_create_stack(event: Dict[str, Any], context: Any) -> Dict[str, 
     output_dict = deepcopy(event)
     request = CreateModelRequest.validate(event)
 
-    prepared_event = {}
-
     def camelize_object(o):  # type: ignore[no-untyped-def]
         o2 = {}
         for k in o:
@@ -118,7 +127,7 @@ def handle_start_create_stack(event: Dict[str, Any], context: Any) -> Dict[str, 
         return o2
 
     prepared_event = camelize_object(event)
-    prepared_event["containerConfig"]["environment"] = event["ContainerConfig"]["Environment"]
+    prepared_event["containerConfig"]["environment"] = event["containerConfig"]["environment"]
     prepared_event["containerConfig"]["image"] = {
         "repositoryArn": os.environ["ECR_REPOSITORY_ARN"],
         "tag": event["image_info"]["image_tag"],
@@ -140,9 +149,14 @@ def handle_start_create_stack(event: Dict[str, Any], context: Any) -> Dict[str, 
     output_dict["stack_arn"] = stack_arn
 
     model_table.update_item(
-        Key={"model_id": request.ModelId},
-        UpdateExpression="SET StackName = :stack_name, StackArn = :stack_arn",
-        ExpressionAttributeValues={":stack_name": {"S": stack_name}, ":stack_arn": {"S": stack_arn}},
+        Key={"model_id": request.modelId},
+        UpdateExpression="SET #csn = :stack_name, #csa = :stack_arn, last_modified_date = :lm",
+        ExpressionAttributeNames={"#csn": "cloudformation_stack_name", "#csa": "cloudformation_stack_arn"},
+        ExpressionAttributeValues={
+            ":stack_name": stack_name,
+            ":stack_arn": stack_arn,
+            ":lm": int(datetime.utcnow().timestamp()),
+        },
     )
 
     output_dict["remaining_polls_stack"] = 30
@@ -153,9 +167,13 @@ def handle_start_create_stack(event: Dict[str, Any], context: Any) -> Dict[str, 
 def handle_poll_create_stack(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """Check that model infrastructure creation has completed or not."""
     output_dict = deepcopy(event)
-    response = cfnClient.describe_stacks(StackName=event["stack_name"])
-    stackStatus = response["Stacks"][0]["StackStatus"]
+    stack = cfnClient.describe_stacks(StackName=event["stack_name"])["Stacks"][0]
+    stackStatus = stack["StackStatus"]
     if stackStatus in ["CREATE_COMPLETE", "UPDATE_COMPLETE"]:
+        outputs = stack["Outputs"]
+        for output in outputs:
+            if output["OutputKey"] == "modelEndpointUrl":
+                output_dict["modelUrl"] = output["OutputValue"]
         output_dict["continue_polling_stack"] = False
         return output_dict
     elif stackStatus in ["CREATE_IN_PROGRESS", "UPDATE_IN_PROGRESS"]:
@@ -171,4 +189,35 @@ def handle_poll_create_stack(event: Dict[str, Any], context: Any) -> Dict[str, A
 def handle_add_model_to_litellm(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """Add model to LiteLLM once it is created."""
     output_dict = deepcopy(event)
+    is_lisa_managed = event["create_infra"]
+
+    litellm_params = {
+        "api_key": "ignored"  # pragma: allowlist-secret not a real key, but needed for LiteLLM to be happy
+    }
+
+    if is_lisa_managed:
+        # get load balancer from cloudformation stack
+        litellm_params["model"] = f'openai/{event["modelName"]}'
+        litellm_params["api_base"] = f"http://{event['modelUrl']}/v1"  # model's OpenAI-compliant route
+    else:
+        litellm_params["model"] = event["modelName"]
+
+    litellm_response = litellm_client.add_model(
+        model_name=event["modelId"],
+        litellm_params=litellm_params,
+    )
+    litellm_id = litellm_response["model_info"]["id"]
+    output_dict["litellm_id"] = litellm_id
+
+    model_table.update_item(
+        Key={"model_id": event["modelId"]},
+        UpdateExpression="SET model_status = :ms, litellm_id = :lid, last_modified_date = :lm, model_url = :mu",
+        ExpressionAttributeValues={
+            ":ms": ModelStatus.IN_SERVICE,
+            ":lid": litellm_id,
+            ":lm": int(datetime.utcnow().timestamp()),
+            ":mu": litellm_params.get("api_base", "")
+        },
+    )
+
     return output_dict

--- a/lib/models/model-api.ts
+++ b/lib/models/model-api.ts
@@ -323,6 +323,7 @@ export class ModelsApi extends Construct {
                     effect: Effect.ALLOW,
                     actions: [
                         'dynamodb:GetItem',
+                        'dynamodb:Scan',
                     ],
                     resources: [
                         modelTable.tableArn,

--- a/lib/models/model-api.ts
+++ b/lib/models/model-api.ts
@@ -181,7 +181,16 @@ export class ModelsApi extends Construct {
                             conditions: {
                                 'StringEquals': {'aws:ResourceTag/lisa_temporary_instance': 'true'}
                             }
-                        })
+                        }),
+                        new PolicyStatement({
+                            effect: Effect.ALLOW,
+                            actions: [
+                                'ssm:GetParameter'
+                            ],
+                            resources: [
+                                lisaServeEndpointUrlPs.parameterArn
+                            ],
+                        }),
                     ]
                 }),
             }
@@ -196,7 +205,8 @@ export class ModelsApi extends Construct {
             securityGroups: securityGroups,
             dockerImageBuilderFnArn: dockerImageBuilder.dockerImageBuilderFn.functionArn,
             ecsModelDeployerFnArn: ecsModelDeployer.ecsModelDeployerFn.functionArn,
-            ecsModelImageRepository: ecsModelImages.repo
+            ecsModelImageRepository: ecsModelImages.repo,
+            restApiContainerEndpointPs: lisaServeEndpointUrlPs,
         });
 
         const deleteModelStateMachine = new DeleteModelStateMachine(this, 'DeleteModelWorkflow', {
@@ -206,6 +216,7 @@ export class ModelsApi extends Construct {
             role: stateMachinesLambdaRole,
             vpc: vpc.vpc,
             securityGroups: securityGroups,
+            restApiContainerEndpointPs: lisaServeEndpointUrlPs,
         });
 
         const environment = {

--- a/lib/models/state-machine/delete-model.ts
+++ b/lib/models/state-machine/delete-model.ts
@@ -31,6 +31,7 @@ import { IRole } from 'aws-cdk-lib/aws-iam';
 import { ISecurityGroup, IVpc } from 'aws-cdk-lib/aws-ec2';
 import { ITable } from 'aws-cdk-lib/aws-dynamodb';
 import { LAMBDA_MEMORY, LAMBDA_TIMEOUT, OUTPUT_PATH, POLLING_TIMEOUT } from './constants';
+import { IStringParameter } from 'aws-cdk-lib/aws-ssm';
 
 type DeleteModelStateMachineProps = BaseProps & {
     modelTable: ITable,
@@ -38,6 +39,7 @@ type DeleteModelStateMachineProps = BaseProps & {
     role?: IRole,
     vpc?: IVpc,
     securityGroups?: ISecurityGroup[];
+    restApiContainerEndpointPs: IStringParameter;
 };
 
 
@@ -50,7 +52,13 @@ export class DeleteModelStateMachine extends Construct {
     constructor (scope: Construct, id: string, props: DeleteModelStateMachineProps) {
         super(scope, id);
 
-        const { config, modelTable, lambdaLayers, role, vpc, securityGroups } = props;
+        const { config, modelTable, lambdaLayers, role, vpc, securityGroups, restApiContainerEndpointPs } = props;
+
+        const environment = {  // Environment variables to set in all Lambda functions
+            MODEL_TABLE_NAME: modelTable.tableName,
+            LISA_API_URL_PS_NAME: restApiContainerEndpointPs.parameterName,
+            REST_API_VERSION: config.restApiConfig.apiVersion,
+        };
 
         // Needs to return if model has a stack to delete or if it is only in LiteLLM. Updates model state to DELETING.
         // Input payload to state machine contains the model name that we want to delete.
@@ -65,9 +73,7 @@ export class DeleteModelStateMachine extends Construct {
                 vpc: vpc,
                 securityGroups: securityGroups,
                 layers: lambdaLayers,
-                environment: {
-                    MODEL_TABLE_NAME: modelTable.tableName,
-                },
+                environment: environment,
             }),
             outputPath: OUTPUT_PATH,
         });
@@ -83,9 +89,7 @@ export class DeleteModelStateMachine extends Construct {
                 vpc: vpc,
                 securityGroups: securityGroups,
                 layers: lambdaLayers,
-                environment: {
-                    MODEL_TABLE_NAME: modelTable.tableName,
-                },
+                environment: environment,
             }),
             outputPath: OUTPUT_PATH,
         });
@@ -101,9 +105,7 @@ export class DeleteModelStateMachine extends Construct {
                 vpc: vpc,
                 securityGroups: securityGroups,
                 layers: lambdaLayers,
-                environment: {
-                    MODEL_TABLE_NAME: modelTable.tableName,
-                },
+                environment: environment,
             }),
             outputPath: OUTPUT_PATH,
         });
@@ -119,9 +121,7 @@ export class DeleteModelStateMachine extends Construct {
                 vpc: vpc,
                 securityGroups: securityGroups,
                 layers: lambdaLayers,
-                environment: {
-                    MODEL_TABLE_NAME: modelTable.tableName,
-                },
+                environment: environment,
             }),
             outputPath: OUTPUT_PATH,
         });
@@ -137,9 +137,7 @@ export class DeleteModelStateMachine extends Construct {
                 vpc: vpc,
                 securityGroups: securityGroups,
                 layers: lambdaLayers,
-                environment: {
-                    MODEL_TABLE_NAME: modelTable.tableName,
-                },
+                environment: environment,
             }),
             outputPath: OUTPUT_PATH,
         });

--- a/lib/user-interface/react/src/components/model-management/ModelManagementActions.tsx
+++ b/lib/user-interface/react/src/components/model-management/ModelManagementActions.tsx
@@ -75,7 +75,7 @@ function ModelActionButton (dispatch: ThunkDispatch<any, any, Action>, notificat
 
     useEffect(() => {
         if (!isDeleteLoading && isDeleteSuccess && selectedModel) {
-            notificationService.generateNotification(`Successfully deleted model: ${selectedModel.ModelId}`, 'success');
+            notificationService.generateNotification(`Successfully deleted model: ${selectedModel.modelId}`, 'success');
             props.setSelectedItems([]);
         } else if (!isDeleteLoading && isDeleteError && selectedModel) {
             notificationService.generateNotification(`Error deleting model: ${deleteError.data?.message ?? deleteError.data}`, 'error');
@@ -86,7 +86,7 @@ function ModelActionButton (dispatch: ThunkDispatch<any, any, Action>, notificat
 
     useEffect(() => {
         if (!isStopLoading && isStopSuccess && selectedModel) {
-            notificationService.generateNotification(`Successfully stopped model: ${selectedModel.ModelId}`, 'success');
+            notificationService.generateNotification(`Successfully stopped model: ${selectedModel.modelId}`, 'success');
             props.setSelectedItems([]);
         } else if (!isStopLoading && isStopError && selectedModel) {
             notificationService.generateNotification(`Error stopping model: ${stopError.data?.message ?? stopError.data}`, 'error');
@@ -97,7 +97,7 @@ function ModelActionButton (dispatch: ThunkDispatch<any, any, Action>, notificat
 
     useEffect(() => {
         if (!isStartLoading && isStartSuccess && selectedModel) {
-            notificationService.generateNotification(`Successfully started model: ${selectedModel.ModelId}`, 'success');
+            notificationService.generateNotification(`Successfully started model: ${selectedModel.modelId}`, 'success');
             props.setSelectedItems([]);
         } else if (!isStartLoading && isStartError && selectedModel) {
             notificationService.generateNotification(`Error starting model: ${startError.data?.message ?? startError.data}`, 'error');
@@ -157,8 +157,8 @@ const ModelActionHandler = async (
                 setConfirmationModal({
                     action: 'Start',
                     resourceName: 'Model',
-                    onConfirm: () => startMutation(selectedModel.ModelId),
-                    description: `This will start the following model: ${selectedModel.ModelId}.`
+                    onConfirm: () => startMutation(selectedModel.modelId),
+                    description: `This will start the following model: ${selectedModel.modelId}.`
                 })
             );
             break;
@@ -167,8 +167,8 @@ const ModelActionHandler = async (
                 setConfirmationModal({
                     action: 'Stop',
                     resourceName: 'Model',
-                    onConfirm: () => stopMutation(selectedModel.ModelId),
-                    description: `This will stop the following model: ${selectedModel.ModelId}.`
+                    onConfirm: () => stopMutation(selectedModel.modelId),
+                    description: `This will stop the following model: ${selectedModel.modelId}.`
                 })
             );
             break;
@@ -181,8 +181,8 @@ const ModelActionHandler = async (
                 setConfirmationModal({
                     action: 'Delete',
                     resourceName: 'Model',
-                    onConfirm: () => deleteMutation(selectedModel.ModelId),
-                    description: `This will delete the following model: ${selectedModel.ModelId}.`
+                    onConfirm: () => deleteMutation(selectedModel.modelId),
+                    description: `This will delete the following model: ${selectedModel.modelId}.`
                 })
             );
             break;

--- a/lib/user-interface/react/src/components/model-management/ModelManagementComponent.tsx
+++ b/lib/user-interface/react/src/components/model-management/ModelManagementComponent.tsx
@@ -67,7 +67,7 @@ export function ModelManagementComponent () : ReactElement {
                 onSelectionChange={({ detail }) => setSelectedItems(detail?.selectedItems ?? [])}
                 selectedItems={selectedItems}
                 ariaLabels={{
-                    itemSelectionLabel: (e, t) => `select ${t.ModelName}`,
+                    itemSelectionLabel: (e, t) => `select ${t.modelName}`,
                     selectionGroupLabel: 'Model selection',
                 }}
                 cardDefinition={CARD_DEFINITIONS}
@@ -75,7 +75,7 @@ export function ModelManagementComponent () : ReactElement {
                 loadingText='Loading models'
                 items={matchedModels}
                 selectionType='single' // single | multi
-                trackBy='ModelId'
+                trackBy='modelId'
                 variant='full-page'
                 loading={fetchingModels}
                 cardsPerRow={[{ cards: 3 }]}

--- a/lib/user-interface/react/src/components/model-management/ModelManagementUtils.tsx
+++ b/lib/user-interface/react/src/components/model-management/ModelManagementUtils.tsx
@@ -47,7 +47,7 @@ export const CARD_DEFINITIONS = {
         {
             id: 'modelUrl',
             header: 'URL',
-            content: (model: IModel) => model.modelUrl ?? 'Model URL not defined',
+            content: (model: IModel) => model.modelUrl ? 'Model URL not defined' : model.modelUrl,
         },
         {
             id: 'streaming',
@@ -62,7 +62,7 @@ export const CARD_DEFINITIONS = {
         {
             id: 'instanceType',
             header: 'Instance Type',
-            content: (model: IModel) => model.instanceType ?? 'Instance Type not defined',
+            content: (model: IModel) => model.instanceType ? 'Instance Type not defined' : model.instanceType,
         },
         {
             id: 'modelStatus',

--- a/lib/user-interface/react/src/components/model-management/ModelManagementUtils.tsx
+++ b/lib/user-interface/react/src/components/model-management/ModelManagementUtils.tsx
@@ -32,12 +32,12 @@ export const MODEL_STATUS_LOOKUP: EnumDictionary<ModelStatus, StatusIndicatorPro
 };
 
 export const CARD_DEFINITIONS = {
-    header: (model: IModel) => <div>{model.modelName}</div>,
+    header: (model: IModel) => <div>{model.modelId}</div>,
     sections: [
         {
-            id: 'modelId',
-            header: 'ID',
-            content: (model: IModel) => model.modelId,
+            id: 'modelName',
+            header: 'Name',
+            content: (model: IModel) => model.modelName,
         },
         {
             id: 'modelType',
@@ -83,14 +83,14 @@ export const PAGE_SIZE_OPTIONS = [
 
 export const DEFAULT_PREFERENCES = {
     pageSize: 12,
-    visibleContent: ['modelId', 'modelType', 'modelUrl', 'streaming', 'hosting', 'instanceType', 'modelStatus'],
+    visibleContent: ['modelName', 'modelType', 'modelUrl', 'streaming', 'hosting', 'instanceType', 'modelStatus'],
 };
 
 export const VISIBLE_CONTENT_OPTIONS = [
     {
         label: 'Displayed Properties',
         options: [
-            { id: 'modelId', label: 'ID' },
+            { id: 'modelName', label: 'Name' },
             { id: 'modelType', label: 'Type' },
             { id: 'modelUrl', label: 'URL' },
             { id: 'streaming', label: 'Streaming' },

--- a/lib/user-interface/react/src/components/model-management/ModelManagementUtils.tsx
+++ b/lib/user-interface/react/src/components/model-management/ModelManagementUtils.tsx
@@ -57,7 +57,7 @@ export const CARD_DEFINITIONS = {
         {
             id: 'hosting',
             header: 'Hosted in LISA',
-            content: (model: IModel) => String(model.containerConfig === null && model.autoScalingConfig === null && model.loadBalancerConfig === null),
+            content: (model: IModel) => String(model.containerConfig !== null && model.autoScalingConfig !== null && model.loadBalancerConfig !== null),
         },
         {
             id: 'instanceType',

--- a/lib/user-interface/react/src/components/model-management/ModelManagementUtils.tsx
+++ b/lib/user-interface/react/src/components/model-management/ModelManagementUtils.tsx
@@ -32,43 +32,43 @@ export const MODEL_STATUS_LOOKUP: EnumDictionary<ModelStatus, StatusIndicatorPro
 };
 
 export const CARD_DEFINITIONS = {
-    header: (model: IModel) => <div>{model.ModelName}</div>,
+    header: (model: IModel) => <div>{model.modelName}</div>,
     sections: [
         {
-            id: 'ModelId',
+            id: 'modelId',
             header: 'ID',
-            content: (model: IModel) => model.ModelId,
+            content: (model: IModel) => model.modelId,
         },
         {
-            id: 'ModelType',
+            id: 'modelType',
             header: 'Type',
-            content: (model: IModel) => model.ModelType,
+            content: (model: IModel) => model.modelType,
         },
         {
-            id: 'ModelUrl',
+            id: 'modelUrl',
             header: 'URL',
-            content: (model: IModel) => model.ModelUrl ?? 'Model URL not defined',
+            content: (model: IModel) => model.modelUrl ?? 'Model URL not defined',
         },
         {
-            id: 'Streaming',
+            id: 'streaming',
             header: 'Streaming',
-            content: (model: IModel) => String(model.Streaming),
+            content: (model: IModel) => String(model.streaming),
         },
         {
-            id: 'Hosting',
+            id: 'hosting',
             header: 'Hosted in LISA',
-            content: (model: IModel) => String(model.ContainerConfig === null && model.AutoScalingConfig === null && model.LoadBalancerConfig === null),
+            content: (model: IModel) => String(model.containerConfig === null && model.autoScalingConfig === null && model.loadBalancerConfig === null),
         },
         {
-            id: 'InstanceType',
+            id: 'instanceType',
             header: 'Instance Type',
-            content: (model: IModel) => model.InstanceType ?? 'Instance Type not defined',
+            content: (model: IModel) => model.instanceType ?? 'Instance Type not defined',
         },
         {
-            id: 'ModelStatus',
+            id: 'modelStatus',
             header: 'Status',
             content: (model: IModel) => (
-                <StatusIndicator type={MODEL_STATUS_LOOKUP[model.Status]}>{model.Status}</StatusIndicator>
+                <StatusIndicator type={MODEL_STATUS_LOOKUP[model.status]}>{model.status}</StatusIndicator>
             ),
         },
     ],
@@ -83,20 +83,20 @@ export const PAGE_SIZE_OPTIONS = [
 
 export const DEFAULT_PREFERENCES = {
     pageSize: 12,
-    visibleContent: ['ModelId', 'ModelType', 'ModelUrl', 'Streaming', 'Hosting', 'InstanceType', 'ModelStatus'],
+    visibleContent: ['modelId', 'modelType', 'modelUrl', 'streaming', 'hosting', 'instanceType', 'modelStatus'],
 };
 
 export const VISIBLE_CONTENT_OPTIONS = [
     {
         label: 'Displayed Properties',
         options: [
-            { id: 'ModelId', label: 'ID' },
-            { id: 'ModelType', label: 'Type' },
-            { id: 'ModelUrl', label: 'URL' },
-            { id: 'Streaming', label: 'Streaming' },
-            { id: 'Hosting', label: 'LISA-Hosted Infrastructure' },
-            { id: 'InstanceType', label: 'Instance Type' },
-            { id: 'ModelStatus', label: 'Status' },
+            { id: 'modelId', label: 'ID' },
+            { id: 'modelType', label: 'Type' },
+            { id: 'modelUrl', label: 'URL' },
+            { id: 'streaming', label: 'Streaming' },
+            { id: 'hosting', label: 'LISA-Hosted Infrastructure' },
+            { id: 'instanceType', label: 'Instance Type' },
+            { id: 'modelStatus', label: 'Status' },
         ],
     },
 ];

--- a/lib/user-interface/react/src/components/model-management/ModelManagementUtils.tsx
+++ b/lib/user-interface/react/src/components/model-management/ModelManagementUtils.tsx
@@ -47,7 +47,7 @@ export const CARD_DEFINITIONS = {
         {
             id: 'modelUrl',
             header: 'URL',
-            content: (model: IModel) => model.modelUrl ? 'Model URL not defined' : model.modelUrl,
+            content: (model: IModel) => model.modelUrl ? model.modelUrl : 'Model URL not defined',
         },
         {
             id: 'streaming',
@@ -62,7 +62,7 @@ export const CARD_DEFINITIONS = {
         {
             id: 'instanceType',
             header: 'Instance Type',
-            content: (model: IModel) => model.instanceType ? 'Instance Type not defined' : model.instanceType,
+            content: (model: IModel) => model.instanceType ?  model.instanceType : 'Instance Type not defined',
         },
         {
             id: 'modelStatus',

--- a/lib/user-interface/react/src/components/model-management/create-model/AutoScalingConfig.tsx
+++ b/lib/user-interface/react/src/components/model-management/create-model/AutoScalingConfig.tsx
@@ -31,24 +31,24 @@ export function AutoScalingConfig (props: FormProps<IAutoScalingConfig>) : React
                     <Header variant='h3'>Auto Scaling Capacity</Header>
                 }
             >
-                <FormField label='Min Capacity' errorText={props.formErrors?.AutoScalingConfig?.MinCapacity}>
-                    <Input value={props.item.MinCapacity.toString()} inputMode='numeric' onBlur={() => props.touchFields(['AutoScalingConfig.MinCapacity'])} onChange={({ detail }) => {
-                        props.setFields({ 'AutoScalingConfig.MinCapacity': Number(detail.value) });
+                <FormField label='Min Capacity' errorText={props.formErrors?.autoScalingConfig?.minCapacity}>
+                    <Input value={props.item.minCapacity.toString()} inputMode='numeric' onBlur={() => props.touchFields(['autoScalingConfig.minCapacity'])} onChange={({ detail }) => {
+                        props.setFields({ 'autoScalingConfig.minCapacity': Number(detail.value) });
                     }}/>
                 </FormField>
-                <FormField label='Max Capacity' errorText={props.formErrors?.AutoScalingConfig?.MaxCapacity}>
-                    <Input value={props.item.MaxCapacity.toString()} inputMode='numeric' onBlur={() => props.touchFields(['AutoScalingConfig.MaxCapacity'])} onChange={({ detail }) => {
-                        props.setFields({ 'AutoScalingConfig.MaxCapacity': Number(detail.value) });
+                <FormField label='Max Capacity' errorText={props.formErrors?.autoScalingConfig?.maxCapacity}>
+                    <Input value={props.item.maxCapacity.toString()} inputMode='numeric' onBlur={() => props.touchFields(['autoScalingConfig.maxCapacity'])} onChange={({ detail }) => {
+                        props.setFields({ 'autoScalingConfig.maxCapacity': Number(detail.value) });
                     }}/>
                 </FormField>
-                <FormField label='Cooldown' errorText={props.formErrors?.AutoScalingConfig?.Cooldown}>
-                    <Input value={props.item.Cooldown.toString()} inputMode='numeric' onBlur={() => props.touchFields(['AutoScalingConfig.Cooldown'])} onChange={({ detail }) => {
-                        props.setFields({ 'AutoScalingConfig.Cooldown': Number(detail.value) });
+                <FormField label='Cooldown' errorText={props.formErrors?.autoScalingConfig?.cooldown}>
+                    <Input value={props.item.cooldown.toString()} inputMode='numeric' onBlur={() => props.touchFields(['autoScalingConfig.cooldown'])} onChange={({ detail }) => {
+                        props.setFields({ 'autoScalingConfig.Cooldown': Number(detail.value) });
                     }}/>
                 </FormField>
-                <FormField label='Default Instance Warmup' errorText={props.formErrors?.AutoScalingConfig?.DefaultInstanceWarmup}>
-                    <Input value={props.item.DefaultInstanceWarmup.toString()} inputMode='numeric' onBlur={() => props.touchFields(['AutoScalingConfig.DefaultInstanceWarmup'])} onChange={({ detail }) => {
-                        props.setFields({ 'AutoScalingConfig.DefaultInstanceWarmup': Number(detail.value) });
+                <FormField label='Default Instance Warmup' errorText={props.formErrors?.autoScalingConfig?.defaultInstanceWarmup}>
+                    <Input value={props.item.defaultInstanceWarmup.toString()} inputMode='numeric' onBlur={() => props.touchFields(['autoScalingConfig.defaultInstanceWarmup'])} onChange={({ detail }) => {
+                        props.setFields({ 'autoScalingConfig.defaultInstanceWarmup': Number(detail.value) });
                     }}/>
                 </FormField>
             </Container>
@@ -58,24 +58,24 @@ export function AutoScalingConfig (props: FormProps<IAutoScalingConfig>) : React
                 }
             >
                 <SpaceBetween size={'s'}>
-                    <FormField label='ALB Metric Name' errorText={props.formErrors?.AutoScalingConfig?.MetricConfig?.AlbMetricName}>
-                        <Input value={props.item.MetricConfig.AlbMetricName} inputMode='text' onBlur={() => props.touchFields(['AutoScalingConfig.MetricConfig.AlbMetricName'])} onChange={({ detail }) => {
-                            props.setFields({ 'AutoScalingConfig.MetricConfig.AlbMetricName': detail.value });
+                    <FormField label='ALB Metric Name' errorText={props.formErrors?.autoScalingConfig?.metricConfig?.albMetricName}>
+                        <Input value={props.item.metricConfig.albMetricName} inputMode='text' onBlur={() => props.touchFields(['autoScalingConfig.metricConfig.albMetricName'])} onChange={({ detail }) => {
+                            props.setFields({ 'autoScalingConfig.metricConfig.albMetricName': detail.value });
                         }}/>
                     </FormField>
-                    <FormField label='Target Value' errorText={props.formErrors?.AutoScalingConfig?.MetricConfig?.TargetValue}>
-                        <Input value={props.item.MetricConfig.TargetValue.toString()} inputMode='numeric' onBlur={() => props.touchFields(['AutoScalingConfig.MetricConfig.TargetValue'])} onChange={({ detail }) => {
-                            props.setFields({ 'AutoScalingConfig.MetricConfig.TargetValue': Number(detail.value) });
+                    <FormField label='Target Value' errorText={props.formErrors?.autoScalingConfig?.metricConfig?.targetValue}>
+                        <Input value={props.item.metricConfig.targetValue.toString()} inputMode='numeric' onBlur={() => props.touchFields(['autoScalingConfig.metricConfig.targetValue'])} onChange={({ detail }) => {
+                            props.setFields({ 'autoScalingConfig.metricConfig.targetValue': Number(detail.value) });
                         }}/>
                     </FormField>
-                    <FormField label='Duration' errorText={props.formErrors?.AutoScalingConfig?.MetricConfig?.Duration}>
-                        <Input value={props.item.MetricConfig.Duration.toString()} inputMode='numeric' onBlur={() => props.touchFields(['AutoScalingConfig.MetricConfig.Duration'])} onChange={({ detail }) => {
-                            props.setFields({ 'AutoScalingConfig.MetricConfig.Duration': Number(detail.value) });
+                    <FormField label='Duration' errorText={props.formErrors?.autoScalingConfig?.metricConfig?.duration}>
+                        <Input value={props.item.metricConfig.duration.toString()} inputMode='numeric' onBlur={() => props.touchFields(['autoScalingConfig.metricConfig.duration'])} onChange={({ detail }) => {
+                            props.setFields({ 'autoScalingConfig.metricConfig.duration': Number(detail.value) });
                         }}/>
                     </FormField>
-                    <FormField label='Estimated Instance Warmup' errorText={props.formErrors?.AutoScalingConfig?.MetricConfig?.EstimatedInstanceWarmup}>
-                        <Input value={props.item.MetricConfig.EstimatedInstanceWarmup.toString()} inputMode='numeric' onBlur={() => props.touchFields(['AutoScalingConfig.MetricConfig.EstimatedInstanceWarmup'])} onChange={({ detail }) => {
-                            props.setFields({ 'AutoScalingConfig.MetricConfig.EstimatedInstanceWarmup': Number(detail.value) });
+                    <FormField label='Estimated Instance Warmup' errorText={props.formErrors?.autoScalingConfig?.metricConfig?.estimatedInstanceWarmup}>
+                        <Input value={props.item.metricConfig.estimatedInstanceWarmup.toString()} inputMode='numeric' onBlur={() => props.touchFields(['autoScalingConfig.metricConfig.estimatedInstanceWarmup'])} onChange={({ detail }) => {
+                            props.setFields({ 'autoScalingConfig.metricConfig.estimatedInstanceWarmup': Number(detail.value) });
                         }}/>
                     </FormField>
                 </SpaceBetween>

--- a/lib/user-interface/react/src/components/model-management/create-model/BaseModelConfig.tsx
+++ b/lib/user-interface/react/src/components/model-management/create-model/BaseModelConfig.tsx
@@ -30,75 +30,74 @@ export type BaseModelConfigCustomProps = {
 export function BaseModelConfig (props: FormProps<IModelRequest> & BaseModelConfigCustomProps) : ReactElement {
     return (
         <SpaceBetween size={'s'}>
-            <FormField label='Model ID' errorText={props.formErrors?.ModelId}>
-                <Input value={props.item.ModelId} inputMode='text' onBlur={() => props.touchFields(['ModelId'])} onChange={({ detail }) => {
-                    props.setFields({ 'ModelId': detail.value });
+            <FormField label='Model ID' errorText={props.formErrors?.modelId}>
+                <Input value={props.item.modelId} inputMode='text' onBlur={() => props.touchFields(['modelId'])} onChange={({ detail }) => {
+                    props.setFields({ 'modelId': detail.value });
                 }} disabled={props.isEdit}/>
             </FormField>
-            <FormField label='Model Name' errorText={props.formErrors?.ModelName}>
-                <Input value={props.item.ModelName} inputMode='text' onBlur={() => props.touchFields(['ModelName'])} onChange={({ detail }) => {
-                    props.setFields({ 'ModelName': detail.value });
+            <FormField label='Model Name' errorText={props.formErrors?.modelName}>
+                <Input value={props.item.modelName} inputMode='text' onBlur={() => props.touchFields(['modelName'])} onChange={({ detail }) => {
+                    props.setFields({ 'modelName': detail.value });
                 }}/>
             </FormField>
-            <FormField label='Model URL' errorText={props.formErrors?.ModelUrl}>
-                <Input value={props.item.ModelUrl} inputMode='text' onBlur={() => props.touchFields(['ModelUrl'])} onChange={({ detail }) => {
-                    props.setFields({ 'ModelUrl': detail.value });
+            <FormField label='Model URL' errorText={props.formErrors?.modelUrl}>
+                <Input value={props.item.modelUrl} inputMode='text' onBlur={() => props.touchFields(['modelUrl'])} onChange={({ detail }) => {
+                    props.setFields({ 'modelUrl': detail.value });
                 }}/>
             </FormField>
-            <FormField label='Model Type' errorText={props.formErrors?.ModelType}>
+            <FormField label='Model Type' errorText={props.formErrors?.modelType}>
                 <Select
-                    selectedOption={{label: props.item.ModelType.toUpperCase(), value: props.item.ModelType}}
+                    selectedOption={{label: props.item.modelType.toUpperCase(), value: props.item.modelType}}
                     onChange={({ detail }) =>
                         props.setFields({
-                            'ModelType': detail.selectedOption.value,
+                            'modelType': detail.selectedOption.value,
                         })
                     }
-                    onBlur={() => props.touchFields(['ModelType'])}
+                    onBlur={() => props.touchFields(['modelType'])}
                     options={[
                         { label: 'TEXTGEN', value: ModelType.textgen },
                         { label: 'EMBEDDING', value: ModelType.embedding },
                     ]}
                 />
             </FormField>
-            <FormField label='Instance Type' errorText={props.formErrors?.InstanceType}>
-                <Input value={props.item.InstanceType} inputMode='text' onBlur={() => props.touchFields(['InstanceType'])} onChange={({ detail }) => {
-                    props.setFields({ 'InstanceType': detail.value });
+            <FormField label='Instance Type' errorText={props.formErrors?.instanceType}>
+                <Input value={props.item.instanceType} inputMode='text' onBlur={() => props.touchFields(['instanceType'])} onChange={({ detail }) => {
+                    props.setFields({ 'instanceType': detail.value });
                 }}/>
             </FormField>
-            <FormField label='Inference Container' errorText={props.formErrors?.InferenceContainer}>
+            <FormField label='Inference Container' errorText={props.formErrors?.inferenceContainer}>
                 <Select
-                    selectedOption={{label: props.item.InferenceContainer?.toUpperCase(), value: props.item.InferenceContainer}}
-                    onBlur={() => props.touchFields(['InferenceContainer'])}
+                    selectedOption={{label: props.item.inferenceContainer?.toUpperCase(), value: props.item.inferenceContainer}}
+                    onBlur={() => props.touchFields(['inferenceContainer'])}
                     onChange={({ detail }) =>
                         props.setFields({
-                            'InferenceContainer': detail.selectedOption.value,
+                            'inferenceContainer': detail.selectedOption.value,
                         })
                     }
                     options={[
                         { label: 'TGI', value: InferenceContainer.TGI },
                         { label: 'TEI', value: InferenceContainer.TEI },
                         { label: 'VLLM', value: InferenceContainer.VLLM },
-                        { label: 'INSTRUCTOR', value: InferenceContainer.INSTRUCTOR },
                     ]}
                 />
             </FormField>
             <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
-                <FormField label='LISA Hosted Model' errorText={props.formErrors?.LisaHostedModel}>
+                <FormField label='LISA Hosted Model' errorText={props.formErrors?.lisaHostedModel}>
                     <Toggle
                         onChange={({ detail }) =>
-                            props.setFields({'LisaHostedModel': detail.checked})
+                            props.setFields({'lisaHostedModel': detail.checked})
                         }
-                        onBlur={() => props.touchFields(['LisaHostedModel'])}
-                        checked={props.item.LisaHostedModel}
+                        onBlur={() => props.touchFields(['lisaHostedModel'])}
+                        checked={props.item.lisaHostedModel}
                     />
                 </FormField>
-                <FormField label='Streaming' errorText={props.formErrors?.Streaming}>
+                <FormField label='Streaming' errorText={props.formErrors?.streaming}>
                     <Toggle
                         onChange={({ detail }) =>
-                            props.setFields({'Streaming': detail.checked})
+                            props.setFields({'streaming': detail.checked})
                         }
-                        onBlur={() => props.touchFields(['Streaming'])}
-                        checked={props.item.Streaming}
+                        onBlur={() => props.touchFields(['streaming'])}
+                        checked={props.item.streaming}
                     />
                 </FormField>
             </Grid>

--- a/lib/user-interface/react/src/components/model-management/create-model/ContainerConfig.tsx
+++ b/lib/user-interface/react/src/components/model-management/create-model/ContainerConfig.tsx
@@ -32,24 +32,24 @@ export function ContainerConfig (props: FormProps<IContainerConfig>) : ReactElem
                 }
             >
                 <SpaceBetween size={'s'}>
-                    <FormField label='Shared Memory Size' errorText={props.formErrors?.ContainerConfig?.SharedMemorySize}>
-                        <Input value={props.item.SharedMemorySize.toString()} inputMode='numeric' onBlur={() => props.touchFields(['ContainerConfig.SharedMemorySize'])} onChange={({ detail }) => {
-                            props.setFields({ 'ContainerConfig.SharedMemorySize': Number(detail.value) });
+                    <FormField label='Shared Memory Size' errorText={props.formErrors?.containerConfig?.sharedMemorySize}>
+                        <Input value={props.item.sharedMemorySize.toString()} inputMode='numeric' onBlur={() => props.touchFields(['containerConfig.sharedMemorySize'])} onChange={({ detail }) => {
+                            props.setFields({ 'containerConfig.sharedMemorySize': Number(detail.value) });
                         }}/>
                     </FormField>
-                    <FormField label='Base Image' errorText={props.formErrors?.ContainerConfig?.BaseImage?.BaseImage}>
-                        <Input value={props.item.BaseImage.BaseImage} inputMode='text' onBlur={() => props.touchFields(['ContainerConfig.BaseImage.BaseImage'])} onChange={({ detail }) => {
-                            props.setFields({ 'ContainerConfig.BaseImage.BaseImage': detail.value });
+                    <FormField label='Base Image' errorText={props.formErrors?.containerConfig?.baseImage?.baseImage}>
+                        <Input value={props.item.baseImage.baseImage} inputMode='text' onBlur={() => props.touchFields(['containerConfig.baseImage.baseImage'])} onChange={({ detail }) => {
+                            props.setFields({ 'containerConfig.baseImage.baseImage': detail.value });
                         }}/>
                     </FormField>
-                    <FormField label='Path' errorText={props.formErrors?.ContainerConfig?.BaseImage?.Path}>
-                        <Input value={props.item.BaseImage.Path} inputMode='text' onBlur={() => props.touchFields(['ContainerConfig.BaseImage.Path'])} onChange={({ detail }) => {
-                            props.setFields({ 'ContainerConfig.BaseImage.Path': detail.value });
+                    <FormField label='Path' errorText={props.formErrors?.containerConfig?.baseImage?.path}>
+                        <Input value={props.item.baseImage.path} inputMode='text' onBlur={() => props.touchFields(['containerConfig.baseImage.path'])} onChange={({ detail }) => {
+                            props.setFields({ 'containerConfig.baseImage.path': detail.value });
                         }}/>
                     </FormField>
-                    <FormField label='Type' errorText={props.formErrors?.ContainerConfig?.BaseImage?.Type}>
-                        <Input value={props.item.BaseImage.Type} inputMode='text' onBlur={() => props.touchFields(['ContainerConfig.BaseImage.Type'])} onChange={({ detail }) => {
-                            props.setFields({ 'ContainerConfig.BaseImage.Type': detail.value });
+                    <FormField label='Type' errorText={props.formErrors?.containerConfig?.baseImage?.type}>
+                        <Input value={props.item.baseImage.type} inputMode='text' onBlur={() => props.touchFields(['containerConfig.baseImage.type'])} onChange={({ detail }) => {
+                            props.setFields({ 'containerConfig.baseImage.type': detail.value });
                         }}/>
                     </FormField>
                 </SpaceBetween>
@@ -60,19 +60,19 @@ export function ContainerConfig (props: FormProps<IContainerConfig>) : ReactElem
                 }
             >
                 <SpaceBetween size={'s'}>
-                    <FormField label='Command' errorText={props.formErrors?.ContainerConfig?.HealthCheckConfig?.Command}>
+                    <FormField label='Command' errorText={props.formErrors?.containerConfig?.healthCheckConfig?.command}>
                         <SpaceBetween size={'s'}>
-                            {props.item.HealthCheckConfig.Command.map((item, index) =>
+                            {props.item.healthCheckConfig.command.map((item, index) =>
                                 <Grid gridDefinition={[{ colspan: 10 }, { colspan: 2 }]} key={`health-check-config-command-${index}-grid`}>
-                                    <Input value={item} inputMode='text' key={`health-check-config-command-${index}`} onBlur={() => props.touchFields(['ContainerConfig.HealthCheckConfig.Command'])} onChange={({ detail }) => {
-                                        props.setFields({ 'ContainerConfig.HealthCheckConfig.Command' : props.item.HealthCheckConfig.Command.map((item, i) => i === index ? detail.value : item) });
+                                    <Input value={item} inputMode='text' key={`health-check-config-command-${index}`} onBlur={() => props.touchFields(['containerConfig.healthCheckConfig.command'])} onChange={({ detail }) => {
+                                        props.setFields({ 'containerConfig.healthCheckConfig.command' : props.item.healthCheckConfig.command.map((item, i) => i === index ? detail.value : item) });
                                     }}/>
                                     <Button
                                         key={`health-check-config-command-${index}-remove-button`}
                                         onClick={() => {
-                                            props.touchFields(['ContainerConfig.HealthCheckConfig.Command']);
-                                            props.item.HealthCheckConfig.Command.splice(index, 1);
-                                            props.setFields({'ContainerConfig.HealthCheckConfig.Command': props.item.HealthCheckConfig.Command });
+                                            props.touchFields(['containerConfig.healthCheckConfig.command']);
+                                            props.item.healthCheckConfig.command.splice(index, 1);
+                                            props.setFields({'containerConfig.healthCheckConfig.command': props.item.healthCheckConfig.command });
                                         }}
                                         ariaLabel={'Remove command element'}
                                     >
@@ -82,8 +82,8 @@ export function ContainerConfig (props: FormProps<IContainerConfig>) : ReactElem
                             )}
                             <Button
                                 onClick={() => {
-                                    props.setFields({'ContainerConfig.HealthCheckConfig.Command': [...props.item.HealthCheckConfig.Command, '']});
-                                    props.touchFields(['ContainerConfig.HealthCheckConfig.Command']);
+                                    props.setFields({'containerConfig.healthCheckConfig.command': [...props.item.healthCheckConfig.command, '']});
+                                    props.touchFields(['containerConfig.healthCheckConfig.command']);
                                 }}
                                 ariaLabel={'Add command element'}
                             >
@@ -91,24 +91,24 @@ export function ContainerConfig (props: FormProps<IContainerConfig>) : ReactElem
                             </Button>
                         </SpaceBetween>
                     </FormField>
-                    <FormField label='Interval' errorText={props.formErrors?.ContainerConfig?.HealthCheckConfig?.Interval}>
-                        <Input value={props.item.HealthCheckConfig.Interval.toString()} inputMode='numeric' onBlur={() => props.touchFields(['ContainerConfig.HealthCheckConfig.Interval'])} onChange={({ detail }) => {
-                            props.setFields({ 'ContainerConfig.HealthCheckConfig.Interval': Number(detail.value) });
+                    <FormField label='Interval' errorText={props.formErrors?.containerConfig?.healthCheckConfig?.interval}>
+                        <Input value={props.item.healthCheckConfig.interval.toString()} inputMode='numeric' onBlur={() => props.touchFields(['containerConfig.healthCheckConfig.interval'])} onChange={({ detail }) => {
+                            props.setFields({ 'containerConfig.healthCheckConfig.interval': Number(detail.value) });
                         }}/>
                     </FormField>
-                    <FormField label='Start Period' errorText={props.formErrors?.ContainerConfig?.HealthCheckConfig?.StartPeriod}>
-                        <Input value={props.item.HealthCheckConfig.StartPeriod.toString()} inputMode='numeric' onBlur={() => props.touchFields(['ContainerConfig.HealthCheckConfig.StartPeriod'])} onChange={({ detail }) => {
-                            props.setFields({ 'ContainerConfig.HealthCheckConfig.StartPeriod': Number(detail.value) });
+                    <FormField label='Start Period' errorText={props.formErrors?.containerConfig?.healthCheckConfig?.startPeriod}>
+                        <Input value={props.item.healthCheckConfig.startPeriod.toString()} inputMode='numeric' onBlur={() => props.touchFields(['containerConfig.healthCheckConfig.startPeriod'])} onChange={({ detail }) => {
+                            props.setFields({ 'containerConfig.healthCheckConfig.startPeriod': Number(detail.value) });
                         }}/>
                     </FormField>
-                    <FormField label='Timeout' errorText={props.formErrors?.ContainerConfig?.HealthCheckConfig?.Timeout}>
-                        <Input value={props.item.HealthCheckConfig.Timeout.toString()} inputMode='numeric' onBlur={() => props.touchFields(['ContainerConfig.HealthCheckConfig.Timeout'])} onChange={({ detail }) => {
-                            props.setFields({ 'ContainerConfig.HealthCheckConfig.Timeout': Number(detail.value) });
+                    <FormField label='Timeout' errorText={props.formErrors?.containerConfig?.healthCheckConfig?.timeout}>
+                        <Input value={props.item.healthCheckConfig.timeout.toString()} inputMode='numeric' onBlur={() => props.touchFields(['containerConfig.healthCheckConfig.timeout'])} onChange={({ detail }) => {
+                            props.setFields({ 'containerConfig.healthCheckConfig.timeout': Number(detail.value) });
                         }}/>
                     </FormField>
-                    <FormField label='Retries' errorText={props.formErrors?.ContainerConfig?.HealthCheckConfig?.Retries}>
-                        <Input value={props.item.HealthCheckConfig.Retries.toString()} inputMode='numeric' onBlur={() => props.touchFields(['ContainerConfig.HealthCheckConfig.Retries'])} onChange={({ detail }) => {
-                            props.setFields({ 'ContainerConfig.HealthCheckConfig.Retries': Number(detail.value) });
+                    <FormField label='Retries' errorText={props.formErrors?.containerConfig?.healthCheckConfig?.retries}>
+                        <Input value={props.item.healthCheckConfig.retries.toString()} inputMode='numeric' onBlur={() => props.touchFields(['containerConfig.healthCheckConfig.retries'])} onChange={({ detail }) => {
+                            props.setFields({ 'containerConfig.healthCheckConfig.retries': Number(detail.value) });
                         }}/>
                     </FormField>
                 </SpaceBetween>
@@ -119,7 +119,7 @@ export function ContainerConfig (props: FormProps<IContainerConfig>) : ReactElem
                 }
             >
                 <SpaceBetween size={'s'}>
-                    <EnvironmentVariables item={props.item} setFields={props.setFields} touchFields={props.touchFields} formErrors={props.formErrors} propertyPath={['ContainerConfig', 'Environment']}/>
+                    <EnvironmentVariables item={props.item} setFields={props.setFields} touchFields={props.touchFields} formErrors={props.formErrors} propertyPath={['containerConfig', 'environment']}/>
                 </SpaceBetween>
             </Container>
         </SpaceBetween>

--- a/lib/user-interface/react/src/components/model-management/create-model/CreateModelModal.tsx
+++ b/lib/user-interface/react/src/components/model-management/create-model/CreateModelModal.tsx
@@ -122,13 +122,17 @@ export function CreateModelModal (props: CreateModelModalProps) : ReactElement {
     function handleSubmit () {
         const submittedObject : IModelRequest = {
             ...state.form,
-            ContainerConfig: (state.form.LisaHostedModel ? {
-                ...state.form.ContainerConfig,
-                Environment: Object.fromEntries(Object.entries(state.form.ContainerConfig.Environment || {}).filter((entry: any) => !!entry.key))
-            } : null),
-            LoadBalancerConfig: (state.form.LisaHostedModel ? state.form.LoadBalancerConfig : null),
-            AutoScalingConfig: (state.form.LisaHostedModel ? state.form.AutoScalingConfig : null)
+            containerConfig: (state.form.lisaHostedModel ? ({
+                ...state.form.containerConfig,
+                environment: state.form.containerConfig.environment.reduce((r,{key,value}) => (r[key] = value,r), {})
+            }) : null),
+            loadBalancerConfig: (state.form.lisaHostedModel ? state.form.loadBalancerConfig : null),
+            autoScalingConfig: (state.form.lisaHostedModel ? state.form.autoScalingConfig : null),
+            inferenceContainer: state.form.inferenceContainer ?? null,
+            instanceType: state.form.instanceType ? state.form.instanceType : null,
+            modelUrl: state.form.modelUrl ? state.form.modelUrl : null
         };
+        delete submittedObject.lisaHostedModel;
         if (isValid && !props.isEdit) {
             createModelMutation(submittedObject);
         } else if (isValid && props.isEdit) {
@@ -143,11 +147,11 @@ export function CreateModelModal (props: CreateModelModalProps) : ReactElement {
                 ...state,
                 form: {
                     ...parsedValue,
-                    ContainerConfig: {
+                    containerConfig: {
                         ...parsedValue,
-                        Environment: props.selectedItems[0].ContainerConfig?.Environment ? Object.entries(props.selectedItems[0].ContainerConfig?.Environment).map(([key, value]) => ({ key, value })) : [],
+                        environment: props.selectedItems[0].containerConfig?.environment ? Object.entries(props.selectedItems[0].containerConfig?.environment).map(([key, value]) => ({ key, value })) : [],
                     },
-                    LisaHostedModel: props.selectedItems[0].ContainerConfig || props.selectedItems[0].AutoScalingConfig || props.selectedItems[0].LoadBalancerConfig
+                    lisaHostedModel: props.selectedItems[0].containerConfig || props.selectedItems[0].autoScalingConfig || props.selectedItems[0].loadBalancerConfig
                 }
             });
         }
@@ -156,7 +160,7 @@ export function CreateModelModal (props: CreateModelModalProps) : ReactElement {
 
     useEffect(() => {
         if (!isCreating && isCreateSuccess) {
-            notificationService.generateNotification(`Successfully created model: ${state.form.ModelId}`, 'success');
+            notificationService.generateNotification(`Successfully created model: ${state.form.modelId}`, 'success');
             props.setVisible(false);
             props.setIsEdit(false);
             resetState();
@@ -168,7 +172,7 @@ export function CreateModelModal (props: CreateModelModalProps) : ReactElement {
 
     useEffect(() => {
         if (!isUpdating && isUpdateSuccess) {
-            notificationService.generateNotification(`Successfully updated model: ${state.form.ModelId}`, 'success');
+            notificationService.generateNotification(`Successfully updated model: ${state.form.modelId}`, 'success');
             props.setVisible(false);
             props.setIsEdit(false);
             resetState();
@@ -241,21 +245,21 @@ export function CreateModelModal (props: CreateModelModalProps) : ReactElement {
                     {
                         title: 'Container Configuration',
                         content: (
-                            <ContainerConfig item={state.form.ContainerConfig} setFields={setFields} touchFields={touchFields} formErrors={errors} />
+                            <ContainerConfig item={state.form.containerConfig} setFields={setFields} touchFields={touchFields} formErrors={errors} />
                         ),
                         isOptional: true
                     },
                     {
                         title: 'Auto Scaling Configuration',
                         content: (
-                            <AutoScalingConfig item={state.form.AutoScalingConfig} setFields={setFields} touchFields={touchFields} formErrors={errors} />
+                            <AutoScalingConfig item={state.form.autoScalingConfig} setFields={setFields} touchFields={touchFields} formErrors={errors} />
                         ),
                         isOptional: true
                     },
                     {
                         title: 'Load Balancer Configuration',
                         content: (
-                            <LoadBalancerConfig item={state.form.LoadBalancerConfig} setFields={setFields} touchFields={touchFields} formErrors={errors} />
+                            <LoadBalancerConfig item={state.form.loadBalancerConfig} setFields={setFields} touchFields={touchFields} formErrors={errors} />
                         ),
                         isOptional: true
                     },

--- a/lib/user-interface/react/src/components/model-management/create-model/LoadBalancerConfig.tsx
+++ b/lib/user-interface/react/src/components/model-management/create-model/LoadBalancerConfig.tsx
@@ -30,29 +30,29 @@ export function LoadBalancerConfig (props: FormProps<ILoadBalancerConfig>) : Rea
                     <Header variant='h2'>Health Check Config</Header>
                 }
             >
-                <FormField label='Path' errorText={props.formErrors?.LoadBalancerConfig?.HealthCheckConfig?.Path}>
-                    <Input value={props.item.HealthCheckConfig.Path} inputMode='text' onBlur={() => props.touchFields(['LoadBalancerConfig.HealthCheckConfig.Path'])} onChange={({ detail }) => {
-                        props.setFields({ 'LoadBalancerConfig.HealthCheckConfig.Path': detail.value });
+                <FormField label='Path' errorText={props.formErrors?.loadBalancerConfig?.healthCheckConfig?.path}>
+                    <Input value={props.item.healthCheckConfig.path} inputMode='text' onBlur={() => props.touchFields(['loadBalancerConfig.healthCheckConfig.path'])} onChange={({ detail }) => {
+                        props.setFields({ 'loadBalancerConfig.healthCheckConfig.path': detail.value });
                     }}/>
                 </FormField>
-                <FormField label='Interval' errorText={props.formErrors?.LoadBalancerConfig?.HealthCheckConfig?.Interval}>
-                    <Input value={props.item.HealthCheckConfig.Interval.toString()} inputMode='numeric' onBlur={() => props.touchFields(['LoadBalancerConfig.HealthCheckConfig.Interval'])} onChange={({ detail }) => {
-                        props.setFields({ 'LoadBalancerConfig.HealthCheckConfig.Interval': Number(detail.value) });
+                <FormField label='Interval' errorText={props.formErrors?.loadBalancerConfig?.healthCheckConfig?.interval}>
+                    <Input value={props.item.healthCheckConfig.interval.toString()} inputMode='numeric' onBlur={() => props.touchFields(['loadBalancerConfig.healthCheckConfig.interval'])} onChange={({ detail }) => {
+                        props.setFields({ 'loadBalancerConfig.healthCheckConfig.interval': Number(detail.value) });
                     }}/>
                 </FormField>
-                <FormField label='Timeout' errorText={props.formErrors?.LoadBalancerConfig?.HealthCheckConfig?.Timeout}>
-                    <Input value={props.item.HealthCheckConfig.Timeout.toString()} inputMode='numeric' onBlur={() => props.touchFields(['LoadBalancerConfig.HealthCheckConfig.Timeout'])} onChange={({ detail }) => {
-                        props.setFields({ 'LoadBalancerConfig.HealthCheckConfig.Timeout': Number(detail.value) });
+                <FormField label='Timeout' errorText={props.formErrors?.loadBalancerConfig?.healthCheckConfig?.timeout}>
+                    <Input value={props.item.healthCheckConfig.timeout.toString()} inputMode='numeric' onBlur={() => props.touchFields(['loadBalancerConfig.healthCheckConfig.timeout'])} onChange={({ detail }) => {
+                        props.setFields({ 'loadBalancerConfig.healthCheckConfig.yimeout': Number(detail.value) });
                     }}/>
                 </FormField>
-                <FormField label='Healthy Threshold Count' errorText={props.formErrors?.LoadBalancerConfig?.HealthCheckConfig?.HealthyThresholdCount}>
-                    <Input value={props.item.HealthCheckConfig.HealthyThresholdCount.toString()} inputMode='numeric' onBlur={() => props.touchFields(['LoadBalancerConfig.HealthCheckConfig.HealthyThresholdCount'])} onChange={({ detail }) => {
-                        props.setFields({ 'LoadBalancerConfig.HealthCheckConfig.HealthyThresholdCount': Number(detail.value) });
+                <FormField label='Healthy Threshold Count' errorText={props.formErrors?.loadBalancerConfig?.healthCheckConfig?.healthyThresholdCount}>
+                    <Input value={props.item.healthCheckConfig.healthyThresholdCount.toString()} inputMode='numeric' onBlur={() => props.touchFields(['loadBalancerConfig.healthCheckConfig.healthyThresholdCount'])} onChange={({ detail }) => {
+                        props.setFields({ 'loadBalancerConfig.healthCheckConfig.healthyThresholdCount': Number(detail.value) });
                     }}/>
                 </FormField>
-                <FormField label='Unhealthy Threshold Count' errorText={props.formErrors?.LoadBalancerConfig?.HealthCheckConfig?.UnhealthyThresholdCount}>
-                    <Input value={props.item.HealthCheckConfig.UnhealthyThresholdCount.toString()} inputMode='numeric' onBlur={() => props.touchFields(['LoadBalancerConfig.HealthCheckConfig.UnhealthyThresholdCount'])} onChange={({ detail }) => {
-                        props.setFields({ 'LoadBalancerConfig.HealthCheckConfig.UnhealthyThresholdCount': Number(detail.value) });
+                <FormField label='Unhealthy Threshold Count' errorText={props.formErrors?.loadBalancerConfig?.healthCheckConfig?.unhealthyThresholdCount}>
+                    <Input value={props.item.healthCheckConfig.unhealthyThresholdCount.toString()} inputMode='numeric' onBlur={() => props.touchFields(['loadBalancerConfig.healthCheckConfig.unhealthyThresholdCount'])} onChange={({ detail }) => {
+                        props.setFields({ 'loadBalancerConfig.healthCheckConfig.unhealthyThresholdCount': Number(detail.value) });
                     }}/>
                 </FormField>
             </Container>

--- a/lib/user-interface/react/src/components/model-management/create-model/LoadBalancerConfig.tsx
+++ b/lib/user-interface/react/src/components/model-management/create-model/LoadBalancerConfig.tsx
@@ -42,7 +42,7 @@ export function LoadBalancerConfig (props: FormProps<ILoadBalancerConfig>) : Rea
                 </FormField>
                 <FormField label='Timeout' errorText={props.formErrors?.loadBalancerConfig?.healthCheckConfig?.timeout}>
                     <Input value={props.item.healthCheckConfig.timeout.toString()} inputMode='numeric' onBlur={() => props.touchFields(['loadBalancerConfig.healthCheckConfig.timeout'])} onChange={({ detail }) => {
-                        props.setFields({ 'loadBalancerConfig.healthCheckConfig.yimeout': Number(detail.value) });
+                        props.setFields({ 'loadBalancerConfig.healthCheckConfig.timeout': Number(detail.value) });
                     }}/>
                 </FormField>
                 <FormField label='Healthy Threshold Count' errorText={props.formErrors?.loadBalancerConfig?.healthCheckConfig?.healthyThresholdCount}>

--- a/lib/user-interface/react/src/shared/form/environment-variables.tsx
+++ b/lib/user-interface/react/src/shared/form/environment-variables.tsx
@@ -44,7 +44,7 @@ export type EnvironmentVariablesProps = {
 
 export function EnvironmentVariables (props: FormProps<Readonly<any>> & EnvironmentVariablesProps): ReactElement {
     const { item, setFields, touchFields, formErrors, propertyPath } = props;
-    const property = props.propertyPath ? propertyPath?.join('.') : 'Environment';
+    const property = props.propertyPath ? propertyPath?.join('.') : 'environment';
 
     function findProperty (obj, path) {
         const parts = path.split('.');
@@ -70,7 +70,7 @@ export function EnvironmentVariables (props: FormProps<Readonly<any>> & Environm
                 <FormField label='' description=''>
                     <AttributeEditor
                         onAddButtonClick={() => {
-                            setFields({ [property]: (item.Environment || []).concat({
+                            setFields({ [property]: (item.environment || []).concat({
                                 key: '',
                                 value: '',
                             })});
@@ -80,7 +80,7 @@ export function EnvironmentVariables (props: FormProps<Readonly<any>> & Environm
                             toRemove[`${property}[${itemIndex}]`] = true;
                             setFields(toRemove, ModifyMethod.Unset);
                         }}
-                        items={item.Environment}
+                        items={item.environment}
                         addButtonText='Add environment variable'
                         definition={[
                             {

--- a/lib/user-interface/react/src/shared/model/model-management.model.ts
+++ b/lib/user-interface/react/src/shared/model/model-management.model.ts
@@ -39,143 +39,143 @@ export enum InferenceContainer {
 }
 
 export type IContainerHealthCheckConfig = {
-    Command: string[];
-    Interval: number;
-    StartPeriod: number;
-    Timeout: number;
-    Retries: number;
+    command: string[];
+    interval: number;
+    startPeriod: number;
+    timeout: number;
+    retries: number;
 };
 
 export type IContainerConfigImage = {
-    BaseImage: string;
-    Path: string;
-    Type: string;
+    baseImage: string;
+    path: string;
+    type: string;
 };
 
 export type IMetricConfig = {
-    AlbMetricName: string;
-    TargetValue: number;
-    Duration: number;
-    EstimatedInstanceWarmup: number;
+    albMetricName: string;
+    targetValue: number;
+    duration: number;
+    estimatedInstanceWarmup: number;
 };
 
 export type ILoadBalancerHealthCheckConfig = {
-    Path: string;
-    Interval: number;
-    Timeout: number;
-    HealthyThresholdCount: number;
-    UnhealthyThresholdCount: number;
+    path: string;
+    interval: number;
+    timeout: number;
+    healthyThresholdCount: number;
+    unhealthyThresholdCount: number;
 };
 
 export type ILoadBalancerConfig = {
-    HealthCheckConfig: ILoadBalancerHealthCheckConfig
+    healthCheckConfig: ILoadBalancerHealthCheckConfig
 };
 
 export type IAutoScalingConfig = {
-    MinCapacity: number;
-    MaxCapacity: number;
-    Cooldown: number;
-    DefaultInstanceWarmup: number;
-    MetricConfig: IMetricConfig;
+    minCapacity: number;
+    maxCapacity: number;
+    cooldown: number;
+    defaultInstanceWarmup: number;
+    metricConfig: IMetricConfig;
 };
 
 export type IContainerConfig = {
-    BaseImage: IContainerConfigImage;
-    SharedMemorySize: number;
-    HealthCheckConfig: IContainerHealthCheckConfig;
-    Environment?: Record<string, string>[];
+    baseImage: IContainerConfigImage;
+    sharedMemorySize: number;
+    healthCheckConfig: IContainerHealthCheckConfig;
+    environment?: Record<string, string>[];
 };
 
 export type IModel = {
-    ModelId: string;
-    ModelName: string;
-    ModelUrl: string;
-    Streaming: boolean;
-    ModelType: ModelType;
-    InstanceType: string;
-    InferenceContainer: InferenceContainer;
-    ContainerConfig: IContainerConfig;
-    AutoScalingConfig: IAutoScalingConfig;
-    LoadBalancerConfig: ILoadBalancerConfig;
+    modelId: string;
+    modelName: string;
+    modelUrl: string;
+    streaming: boolean;
+    modelType: ModelType;
+    instanceType: string;
+    inferenceContainer: InferenceContainer;
+    containerConfig: IContainerConfig;
+    autoScalingConfig: IAutoScalingConfig;
+    loadBalancerConfig: ILoadBalancerConfig;
 };
 
 export type IModelListResponse = {
-    Models: IModel[];
+    models: IModel[];
 };
 
 export type IModelRequest = {
-    ModelId: string;
-    ModelName: string;
-    ModelUrl: string;
-    Streaming: boolean;
-    ModelType: ModelType;
-    InstanceType: string;
-    InferenceContainer: InferenceContainer;
-    ContainerConfig: IContainerConfig;
-    AutoScalingConfig: IAutoScalingConfig;
-    LoadBalancerConfig: ILoadBalancerConfig;
-    LisaHostedModel: boolean;
+    modelId: string;
+    modelName: string;
+    modelUrl: string;
+    streaming: boolean;
+    modelType: ModelType;
+    instanceType: string;
+    inferenceContainer: InferenceContainer;
+    containerConfig: IContainerConfig;
+    autoScalingConfig: IAutoScalingConfig;
+    loadBalancerConfig: ILoadBalancerConfig;
+    lisaHostedModel: boolean;
 };
 
 const containerHealthCheckConfigSchema = z.object({
-    Command: z.array(z.string()).default(['CMD-SHELL', 'exit 0']),
-    Interval: z.number().default(10),
-    StartPeriod: z.number().default(30),
-    Timeout: z.number().default(5),
-    Retries: z.number().default(2),
+    command: z.array(z.string()).default(['CMD-SHELL', 'exit 0']),
+    interval: z.number().default(10),
+    startPeriod: z.number().default(30),
+    timeout: z.number().default(5),
+    retries: z.number().default(2),
 });
 
 
 const containerConfigImageSchema = z.object({
-    BaseImage: z.string().default(''),
-    Path: z.string().default(''),
-    Type: z.string().default(''),
+    baseImage: z.string().default(''),
+    path: z.string().default(''),
+    type: z.string().default(''),
 });
 
 export const metricConfigSchema = z.object({
-    AlbMetricName: z.string().default(''),
-    TargetValue: z.number().default(0),
-    Duration: z.number().default(60),
-    EstimatedInstanceWarmup: z.number().default(180),
+    albMetricName: z.string().default(''),
+    targetValue: z.number().default(0),
+    duration: z.number().default(60),
+    estimatedInstanceWarmup: z.number().default(180),
 });
 
 export const loadBalancerHealthCheckConfigSchema = z.object({
-    Path: z.string().default(''),
-    Interval: z.number().default(10),
-    Timeout: z.number().default(5),
-    HealthyThresholdCount: z.number().default(1),
-    UnhealthyThresholdCount: z.number().default(1),
+    path: z.string().default(''),
+    interval: z.number().default(10),
+    timeout: z.number().default(5),
+    healthyThresholdCount: z.number().default(1),
+    unhealthyThresholdCount: z.number().default(1),
 });
 
 export const loadBalancerConfigSchema = z.object({
-    HealthCheckConfig: loadBalancerHealthCheckConfigSchema.default(loadBalancerHealthCheckConfigSchema.parse({})),
+    healthCheckConfig: loadBalancerHealthCheckConfigSchema.default(loadBalancerHealthCheckConfigSchema.parse({})),
 });
 
 export const autoScalingConfigSchema = z.object({
-    MinCapacity: z.number().min(1).default(1),
-    MaxCapacity: z.number().min(1).default(2),
-    Cooldown: z.number().min(1).default(420),
-    DefaultInstanceWarmup: z.number().default(180),
-    MetricConfig: metricConfigSchema.default(metricConfigSchema.parse({})),
+    minCapacity: z.number().min(1).default(1),
+    maxCapacity: z.number().min(1).default(2),
+    cooldown: z.number().min(1).default(420),
+    defaultInstanceWarmup: z.number().default(180),
+    metricConfig: metricConfigSchema.default(metricConfigSchema.parse({})),
 });
 
 export const containerConfigSchema = z.object({
-    BaseImage: containerConfigImageSchema.default(containerConfigImageSchema.parse({})),
-    SharedMemorySize: z.number().min(0).default(0),
-    HealthCheckConfig: containerHealthCheckConfigSchema.default(containerHealthCheckConfigSchema.parse({})),
-    Environment: AttributeEditorSchema,
+    baseImage: containerConfigImageSchema.default(containerConfigImageSchema.parse({})),
+    sharedMemorySize: z.number().min(0).default(0),
+    healthCheckConfig: containerHealthCheckConfigSchema.default(containerHealthCheckConfigSchema.parse({})),
+    environment: AttributeEditorSchema,
 });
 
 export const ModelRequestSchema = z.object({
-    ModelId: z.string().default(''),
-    ModelName: z.string().default(''),
-    ModelUrl: z.string().default(''),
-    Streaming: z.boolean().default(true),
-    LisaHostedModel: z.boolean().default(false),
-    ModelType: z.nativeEnum(ModelType).default(ModelType.textgen),
-    InstanceType: z.string().default(''),
-    InferenceContainer: z.nativeEnum(InferenceContainer).optional(),
-    ContainerConfig: containerConfigSchema.default(containerConfigSchema.parse({})),
-    AutoScalingConfig: autoScalingConfigSchema.default(autoScalingConfigSchema.parse({})),
-    LoadBalancerConfig: loadBalancerConfigSchema.default(loadBalancerConfigSchema.parse({})),
+    modelId: z.string().default(''),
+    modelName: z.string().default(''),
+    modelUrl: z.string().default(''),
+    streaming: z.boolean().default(true),
+    lisaHostedModel: z.boolean().default(false),
+    modelType: z.nativeEnum(ModelType).default(ModelType.textgen),
+    instanceType: z.string().default(''),
+    inferenceContainer: z.nativeEnum(InferenceContainer).optional(),
+    containerConfig: containerConfigSchema.default(containerConfigSchema.parse({})),
+    autoScalingConfig: autoScalingConfigSchema.default(autoScalingConfigSchema.parse({})),
+    loadBalancerConfig: loadBalancerConfigSchema.default(loadBalancerConfigSchema.parse({})),
 });

--- a/lib/user-interface/react/src/shared/reducers/model-management.reducer.ts
+++ b/lib/user-interface/react/src/shared/reducers/model-management.reducer.ts
@@ -26,7 +26,7 @@ export const modelManagementApi = createApi({
             query: () => ({
                 url: '/models',
             }),
-            transformResponse: (response) => response.Models,
+            transformResponse: (response) => response.models,
             providesTags:['models'],
         }),
         deleteModel: builder.mutation<IModel, string>({
@@ -60,7 +60,7 @@ export const modelManagementApi = createApi({
         }),
         updateModel: builder.mutation<IModel, IModelRequest>({
             query: (modelRequest) => ({
-                url: `/models/${modelRequest.ModelId}`,
+                url: `/models/${modelRequest.modelId}`,
                 method: 'PUT',
                 data: modelRequest
             }),


### PR DESCRIPTION
This set of changes migrates from using the LiteLLM db to store state to the DynamoDB table that we're creating for this purpose. This allows us to store data before the model is fully finished, and lets us add any additional information that we'll need for debugging or investigation later.

Primary set of changes:
* API model refactor for camelcase to avoid Pydantic errors on truly optional parameters
* API handlers updated to accommodate the model refactor
* Relevant info now stored in DDB
* UI updates (from @estohlmann ) to work with API model update
* LiteLLM client no longer handles auth because traffic is all within VPC

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
