### PR TITLE
Make CreateModel streaming param optional

### DIFF
--- a/lambda/models/domain_objects.py
+++ b/lambda/models/domain_objects.py
@@ -156,7 +156,7 @@ class CreateModelRequest(BaseModel):
     modelName: str
     modelType: ModelType
     modelUrl: Optional[str] = None
-    streaming: bool
+    streaming: Optional[bool] = False
 
 
 class CreateModelResponse(ApiResponseBase):


### PR DESCRIPTION
This sets the streaming parameter to be completely optional when making a CreateModel request. It will default to False if not specified, otherwise it takes on the value from the request. Our UI already mandates the field as a radio button, and since this was required from the start, this won't break any existing models.

Rationale for defaulting to False is that embedding models do not support streaming, and not all text generation models support streaming, so it is a more likely option to be set than True. Future APIs (UpdateModel), will be able to modify this flag later on.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
