### PR TITLE
Remove deprecated v1 routes

### DIFF
--- a/lib/serve/rest-api/src/api/routes.py
+++ b/lib/serve/rest-api/src/api/routes.py
@@ -19,7 +19,6 @@ import logging
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
-from .endpoints.v1 import embeddings, generation, models
 from .endpoints.v2 import litellm_passthrough
 
 logger = logging.getLogger(__name__)
@@ -27,9 +26,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-router.include_router(models.router, prefix="/v1", tags=["models"], deprecated=True)
-router.include_router(embeddings.router, prefix="/v1", tags=["embeddings"], deprecated=True)
-router.include_router(generation.router, prefix="/v1", tags=["generation"], deprecated=True)
 router.include_router(litellm_passthrough.router, prefix="/v2/serve", tags=["litellm_passthrough"])
 
 


### PR DESCRIPTION
Removes the v1 routes because the will no longer work with the model management API. v1 routes depended on the creation of models from the config.yaml file

We have not done a comprehensive review of all code this affects, so instead of removing seemingly unused code and having it break because there was a reference elsewhere, I am opting to just remove the routes to avoid customers accidentally finding them, and we can clean up the unused code later.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
