### PR TITLE
Fix: define model ALB correctly in CFN output

### DIFF
--- a/lambda/models/state_machine/create_model.py
+++ b/lambda/models/state_machine/create_model.py
@@ -210,7 +210,7 @@ def handle_add_model_to_litellm(event: Dict[str, Any], context: Any) -> Dict[str
     if is_lisa_managed:
         # get load balancer from cloudformation stack
         litellm_params["model"] = f'openai/{event["modelName"]}'
-        litellm_params["api_base"] = f"http://{event['modelUrl']}/v1"  # model's OpenAI-compliant route
+        litellm_params["api_base"] = f"{event['modelUrl']}/v1"  # model's OpenAI-compliant route
     else:
         litellm_params["model"] = event["modelName"]
 


### PR DESCRIPTION
All ECS-hosted models are expected to be frontend by ALBs with no certificate on them, listening on port 80 because they are within the VPC and the external traffic API handlers have already terminated SSL at the load balancer level. No models are expected to have a cert on them.

Publishing to document the changes that I expect to work, but I have not been able to test them yet because of imports on cross-stack exports and I needed to completely delete my models stack, which is taking a long time because Lambda functions take very long to delete. Once those finish, I can attempt deploying to test the changes again.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
