### PR TITLE
Fix: remove import/export dependency between stacks on management key

### DIFF
--- a/lib/models/index.ts
+++ b/lib/models/index.ts
@@ -24,7 +24,6 @@ import { Vpc } from '../networking/vpc';
 import { ModelsApi } from './model-api';
 import { BaseProps } from '../schema';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 
 type LisaModelsApiStackProps = BaseProps &
   StackProps & {
@@ -34,7 +33,6 @@ type LisaModelsApiStackProps = BaseProps &
       rootResourceId: string;
       securityGroups?: ISecurityGroup[];
       vpc: Vpc;
-      managementKeySecret: Secret;
   };
 
 /**
@@ -49,7 +47,7 @@ export class LisaModelsApiStack extends Stack {
     constructor (scope: Construct, id: string, props: LisaModelsApiStackProps) {
         super(scope, id, props);
 
-        const { authorizer, lisaServeEndpointUrlPs, config, restApiId, rootResourceId, securityGroups, vpc, managementKeySecret } = props;
+        const { authorizer, lisaServeEndpointUrlPs, config, restApiId, rootResourceId, securityGroups, vpc } = props;
 
         // Add REST API Lambdas to APIGW
         new ModelsApi(this, 'ModelsApi', {
@@ -60,7 +58,6 @@ export class LisaModelsApiStack extends Stack {
             rootResourceId,
             securityGroups,
             vpc,
-            managementKeySecret,
         });
     }
 }

--- a/lib/models/model-api.ts
+++ b/lib/models/model-api.ts
@@ -62,7 +62,6 @@ type ModelsApiProps = BaseProps & {
     rootResourceId: string;
     securityGroups?: ISecurityGroup[];
     vpc: Vpc;
-    managementKeySecret: Secret;
 };
 
 /**
@@ -72,7 +71,7 @@ export class ModelsApi extends Construct {
     constructor (scope: Construct, id: string, props: ModelsApiProps) {
         super(scope, id);
 
-        const { authorizer, config, lambdaExecutionRole, lisaServeEndpointUrlPs, restApiId, rootResourceId, securityGroups, vpc, managementKeySecret } = props;
+        const { authorizer, config, lambdaExecutionRole, lisaServeEndpointUrlPs, restApiId, rootResourceId, securityGroups, vpc } = props;
 
         // Get common layer based on arn from SSM due to issues with cross stack references
         const commonLambdaLayer = LayerVersion.fromLayerVersionArn(
@@ -123,6 +122,8 @@ export class ModelsApi extends Construct {
             ecrUri: ecsModelBuildRepo.repositoryUri,
             mountS3DebUrl: config.mountS3DebUrl!
         });
+
+        const managementKeyName = StringParameter.valueForStringParameter(this, `${config.deploymentPrefix}/managementKeySecretName`);
 
         const stateMachinesLambdaRole = new Role(this, 'ModelsSfnLambdaRole', {
             assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
@@ -197,14 +198,12 @@ export class ModelsApi extends Construct {
                             actions: [
                                 'secretsmanager:GetSecretValue'
                             ],
-                            resources: [managementKeySecret.secretArn],
+                            resources: [Secret.fromSecretNameV2(this, 'ManagementKeySecret', managementKeyName).secretArn],
                         }),
                     ]
                 }),
             }
         });
-
-        const managementKeyName = StringParameter.valueForStringParameter(this, `${config.deploymentPrefix}/managementKeySecretName`);
 
         const createModelStateMachine = new CreateModelStateMachine(this, 'CreateModelWorkflow', {
             config: config,

--- a/lib/models/model-api.ts
+++ b/lib/models/model-api.ts
@@ -198,7 +198,7 @@ export class ModelsApi extends Construct {
                             actions: [
                                 'secretsmanager:GetSecretValue'
                             ],
-                            resources: [Secret.fromSecretNameV2(this, 'ManagementKeySecret', managementKeyName).secretArn],
+                            resources: [`${Secret.fromSecretNameV2(this, 'ManagementKeySecret', managementKeyName).secretArn}-??????`],  // question marks required to resolve the ARN correctly
                         }),
                     ]
                 }),

--- a/lib/serve/index.ts
+++ b/lib/serve/index.ts
@@ -46,7 +46,6 @@ export class LisaServeApplicationStack extends Stack {
     public readonly restApi: FastApiContainer;
     public readonly modelsPs: StringParameter;
     public readonly endpointUrl: StringParameter;
-    public readonly managementKeySecret: Secret;
 
     /**
    * @param {Construct} scope - The parent or owner of the construct.
@@ -85,7 +84,7 @@ export class LisaServeApplicationStack extends Stack {
             vpc: vpc.vpc,
         });
 
-        this.managementKeySecret = new Secret(this, createCdkId([id, 'managementKeySecret']), {
+        const managementKeySecret = new Secret(this, createCdkId([id, 'managementKeySecret']), {
             secretName: `lisa_management_key_secret-${Date.now()}`, // pragma: allowlist secret`
             description: 'This is a secret created with AWS CDK',
             generateSecretString: {
@@ -132,7 +131,7 @@ export class LisaServeApplicationStack extends Stack {
 
         const managementKeySecretNameStringParameter = new StringParameter(this, createCdkId(['ManagementKeySecretName']), {
             parameterName: `${config.deploymentPrefix}/managementKeySecretName`,
-            stringValue: this.managementKeySecret.secretName,
+            stringValue: managementKeySecret.secretName,
         });
         restApi.container.addEnvironment('MANAGEMENT_KEY_NAME', managementKeySecretNameStringParameter.stringValue);
 

--- a/lib/stages.ts
+++ b/lib/stages.ts
@@ -162,7 +162,6 @@ export class LisaServeApplicationStage extends Stage {
             rootResourceId: apiBaseStack.rootResourceId,
             stackName: createCdkId([config.deploymentName, config.appName, 'models', config.deploymentStage]),
             vpc: networkingStack.vpc,
-            managementKeySecret: serveStack.managementKeySecret,
         });
         modelsApiDeploymentStack.addDependency(serveStack);
         apiDeploymentStack.addDependency(modelsApiDeploymentStack);


### PR DESCRIPTION
In 3.0.0 we introduced a secret key to allow for Lambda functions to make LiteLLM management calls while not explicitly being an admin user from the user's IdP. The way how we referenced it across different stacks caused an import/export dependency between stacks, which made the affected resources be immutable, which cannot happen for the sake of future CDK deployments. This set of changes removes the explicit dependency in favor of an SSM StringParameter reference, which lets us take on the dependency without CloudFormation having immutability issues with it.

Tested this by deploying my stack after deleting the `models` and `serve` stacks to get rid of any "import" dependencies. Afterwards, I ran `make deploy` one more time to validate that the secret key would get regenerated and not fail to redeploy. Validated that I could add a model and delete a model, indicating that the secret key was used in multiple Lambda functions across two different state machines.

Relevant link for the permissions fix on the SFN role: https://stackoverflow.com/questions/78232057/how-to-get-full-arn-when-writing-secret-based-iam-policy-in-aws-cdk


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
