### PR TITLE
Fix: add error catching to Create API, allow model Deletes when LiteLLM ID is not present

### DIFF
--- a/lambda/models/exception/__init__.py
+++ b/lambda/models/exception/__init__.py
@@ -15,6 +15,9 @@
 """Exception definitions for model management APIs."""
 
 
+# LiteLLM errors
+
+
 class ModelNotFoundError(LookupError):
     """Error to raise when a specified model cannot be found in the database."""
 
@@ -23,5 +26,26 @@ class ModelNotFoundError(LookupError):
 
 class ModelAlreadyExistsError(LookupError):
     """Error to raise when a specified model already exists in the database."""
+
+    pass
+
+
+# State machine exceptions
+
+
+class MaxPollsExceededException(Exception):
+    """Exception to indicate that polling for a state timed out."""
+
+    pass
+
+
+class StackFailedToCreateException(Exception):
+    """Exception to indicate that the CDK for creating a model stack failed."""
+
+    pass
+
+
+class UnexpectedCloudFormationStateException(Exception):
+    """Exception to indicate that the CloudFormation stack has transitioned to a non-healthy state."""
 
     pass

--- a/lambda/models/state_machine/delete_model.py
+++ b/lambda/models/state_machine/delete_model.py
@@ -62,7 +62,7 @@ def handle_set_model_to_deleting(event: Dict[str, Any], context: Any) -> Dict[st
     if not item:
         raise RuntimeError(f"Requested model '{model_id}' was not found in DynamoDB table.")
     output_dict[CFN_STACK_ARN] = item.get(CFN_STACK_ARN, None)
-    output_dict[LITELLM_ID] = item[LITELLM_ID]
+    output_dict[LITELLM_ID] = item.get(LITELLM_ID, None)
 
     ddb_table.update_item(
         Key=model_key,
@@ -77,7 +77,8 @@ def handle_set_model_to_deleting(event: Dict[str, Any], context: Any) -> Dict[st
 
 def handle_delete_from_litellm(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """Delete model reference from LiteLLM."""
-    litellm_client.delete_model(identifier=event[LITELLM_ID])
+    if event[LITELLM_ID]:  # if non-null ID
+        litellm_client.delete_model(identifier=event[LITELLM_ID])
     return event
 
 


### PR DESCRIPTION
Adds error catching to the Create workflow so that we properly set a model to Failed if we are unable to copy the Docker image or if we have issues with CloudFormation taking too long or failing parameter validation through CDK. The custom exception messages allow us to send the input dictionary (with all request metadata) to the exception handler, otherwise we'd *only* know the exception message but nothing unique about the model.

This also adds a fix on the Delete side where we were previously unable to delete a model if it didn't create correctly with a LiteLLM ID (common if the model fails creation before that point).

Tested with the following payloads to ensure that the models would fail in a controlled way and that we'd properly handle the failures (and then deleted all of them without any issues)

Paths are relative to my own S3 bucket and stored models, I have my APIGW endpoint and Bearer token in my environment variables:

```
## Valid (will work, assuming model artifacts in S3)
curl -X POST -H "Authorization: $token" -H 'Content-Type: application/json' ${endpoint}/models -d '{"modelId":"mistral-vllm-valid","modelName":"mistralai/Mistral-7B-Instruct-v0.2","modelUrl":null,"streaming":true,"modelType":"textgen","instanceType":"g5.xlarge","containerConfig":{"baseImage":{"baseImage":"vllm/vllm-openai:v0.5.0","path":"vllm","type":"asset"},"sharedMemorySize":2048,"healthCheckConfig":{"command":["CMD-SHELL","exit 0"],"interval":10,"startPeriod":30,"timeout":5,"retries":3},"environment":{"MAX_CONCURRENT_REQUESTS": "128", "MAX_INPUT_LENGTH": "1024", "MAX_TOTAL_TOKENS": "2048"}},"autoScalingConfig":{"minCapacity":1,"maxCapacity":1,"cooldown":420,"defaultInstanceWarmup":180,"metricConfig":{"albMetricName":"RequestCountPerTarget","targetValue":30,"duration":60,"estimatedInstanceWarmup":330}},"loadBalancerConfig":{"healthCheckConfig":{"path":"/health","interval":60,"timeout":30,"healthyThresholdCount":2,"unhealthyThresholdCount":10}},"inferenceContainer":"vllm"}'

## Bad image (fails in docker image polling because the image and path don't exist)
curl -X POST -H "Authorization: $token" -H 'Content-Type: application/json' ${endpoint}/models -d '{"modelId":"mistral-vllm-bad-image","modelName":"mistralai/Mistral-7B-Instruct-v0.2","modelUrl":null,"streaming":true,"modelType":"textgen","instanceType":"g5.xlarge","containerConfig":{"baseImage":{"baseImage":"notavalidimage:latest","path":"baddir/vllm","type":"asset"},"sharedMemorySize":2048,"healthCheckConfig":{"command":["CMD-SHELL","exit 0"],"interval":10,"startPeriod":30,"timeout":5,"retries":3},"environment":{"MAX_CONCURRENT_REQUESTS": "128", "MAX_INPUT_LENGTH": "1024", "MAX_TOTAL_TOKENS": "2048"}},"autoScalingConfig":{"minCapacity":1,"maxCapacity":1,"cooldown":420,"defaultInstanceWarmup":180,"metricConfig":{"albMetricName":"RequestCountPerTarget","targetValue":30,"duration":60,"estimatedInstanceWarmup":330}},"loadBalancerConfig":{"healthCheckConfig":{"path":"/health","interval":60,"timeout":30,"healthyThresholdCount":2,"unhealthyThresholdCount":10}},"inferenceContainer":"vllm"}'

## Bad cfn (fails in CFN polling because the healthCheckConfig command always returns 1)
curl -X POST -H "Authorization: $token" -H 'Content-Type: application/json' ${endpoint}/models -d '{"modelId":"mistral-vllm-bad-cfn","modelName":"mistralai/Mistral-7B-Instruct-v0.2","modelUrl":null,"streaming":true,"modelType":"textgen","instanceType":"g5.xlarge","containerConfig":{"baseImage":{"baseImage":"vllm/vllm-openai:v0.5.0","path":"vllm","type":"asset"},"sharedMemorySize":2048,"healthCheckConfig":{"command":["CMD-SHELL","exit 1"],"interval":10,"startPeriod":30,"timeout":5,"retries":1},"environment":{"MAX_CONCURRENT_REQUESTS": "128", "MAX_INPUT_LENGTH": "1024", "MAX_TOTAL_TOKENS": "2048"}},"autoScalingConfig":{"minCapacity":1,"maxCapacity":1,"cooldown":2,"defaultInstanceWarmup":2,"metricConfig":{"albMetricName":"RequestCountPerTarget","targetValue":30,"duration":60,"estimatedInstanceWarmup":330}},"loadBalancerConfig":{"healthCheckConfig":{"path":"/health","interval":60,"timeout":30,"healthyThresholdCount":2,"unhealthyThresholdCount":2}},"inferenceContainer":"vllm"}'

## bad param (fails in CFN parameter validation because timeout is less than 2 in the healthCheckConfig)
curl -X POST -H "Authorization: $token" -H 'Content-Type: application/json' ${endpoint}/models -d '{"modelId":"mistral-vllm-invalid-cfn-param","modelName":"mistralai/Mistral-7B-Instruct-v0.2","modelUrl":null,"streaming":true,"modelType":"textgen","instanceType":"g5.xlarge","containerConfig":{"baseImage":{"baseImage":"vllm/vllm-openai:v0.5.0","path":"vllm","type":"asset"},"sharedMemorySize":2048,"healthCheckConfig":{"command":["CMD-SHELL","exit 1"],"interval":1,"startPeriod":30,"timeout":1,"retries":1},"environment":{"MAX_CONCURRENT_REQUESTS": "128", "MAX_INPUT_LENGTH": "1024", "MAX_TOTAL_TOKENS": "2048"}},"autoScalingConfig":{"minCapacity":1,"maxCapacity":1,"cooldown":2,"defaultInstanceWarmup":2,"metricConfig":{"albMetricName":"RequestCountPerTarget","targetValue":30,"duration":60,"estimatedInstanceWarmup":330}},"loadBalancerConfig":{"healthCheckConfig":{"path":"/health","interval":60,"timeout":30,"healthyThresholdCount":2,"unhealthyThresholdCount":2}},"inferenceContainer":"vllm"}'
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
