### PR TITLE
Adds new authentication method for model management API

### DIFF
--- a/lambda/authorizer/lambda_functions.py
+++ b/lambda/authorizer/lambda_functions.py
@@ -28,7 +28,7 @@ from utilities.common_functions import authorization_wrapper, get_id_token, retr
 
 logger = logging.getLogger(__name__)
 
-secrets_manager = boto3.client("secretsmanager", config=retry_config)
+secrets_manager = boto3.client("secretsmanager", region_name=os.environ["AWS_REGION"], config=retry_config)
 
 
 @authorization_wrapper

--- a/lambda/authorizer/lambda_functions.py
+++ b/lambda/authorizer/lambda_functions.py
@@ -152,16 +152,14 @@ def get_management_tokens() -> list[str]:
     secret_tokens: list[str] = []
     secret_id = os.environ.get("MANAGEMENT_KEY_NAME")
 
-    if len(secret_tokens) == 0:
-        try:
-            secret_tokens.append(
-                secrets_manager.get_secret_value(SecretId=secret_id, VersionStage="AWSCURRENT")["SecretString"]
-            )
-            secret_tokens.append(
-                secrets_manager.get_secret_value(SecretId=secret_id, VersionStage="AWSPREVIOUS")["SecretString"]
-            )
-        except ClientError as e:
-            logger.warn(f"Unable to fetch {secret_id}. {e.response['Error']['Code']}: {e.response['Error']['Message']}")
-            return []
+    try:
+        secret_tokens.append(
+            secrets_manager.get_secret_value(SecretId=secret_id, VersionStage="AWSCURRENT")["SecretString"]
+        )
+        secret_tokens.append(
+            secrets_manager.get_secret_value(SecretId=secret_id, VersionStage="AWSPREVIOUS")["SecretString"]
+        )
+    except ClientError as e:
+        logger.warn(f"Unable to fetch {secret_id}. {e.response['Error']['Code']}: {e.response['Error']['Message']}")
 
     return secret_tokens

--- a/lambda/utilities/common_functions.py
+++ b/lambda/utilities/common_functions.py
@@ -18,7 +18,6 @@ import functools
 import json
 import logging
 import os
-import re
 import tempfile
 from contextvars import ContextVar
 from functools import cache
@@ -287,7 +286,7 @@ def get_id_token(event: dict) -> str:
         raise ValueError("Missing authorization token.")
 
     # remove bearer token prefix if present
-    return re.sub(r"Bearer ", "", str(auth_header), flags=re.I).strip()
+    return str(auth_header).removeprefix("Bearer ").removeprefix("bearer ").strip()
 
 
 @cache

--- a/lambda/utilities/common_functions.py
+++ b/lambda/utilities/common_functions.py
@@ -285,8 +285,12 @@ def get_id_token(event: dict) -> str:
     else:
         raise ValueError("Missing authorization token.")
 
-    token = auth_header[1]
-    return str(token)
+    if len(auth_header) == 1:
+        # secret management token won't be split into multiple segments
+        return str(auth_header[0])
+    else:
+        # Bearer tokens will have the token in the second segment
+        return str(auth_header[1])
 
 
 @cache

--- a/lambda/utilities/common_functions.py
+++ b/lambda/utilities/common_functions.py
@@ -18,6 +18,7 @@ import functools
 import json
 import logging
 import os
+import re
 import tempfile
 from contextvars import ContextVar
 from functools import cache
@@ -279,18 +280,14 @@ def get_id_token(event: dict) -> str:
     auth_header = None
 
     if "authorization" in event["headers"]:
-        auth_header = event["headers"]["authorization"].split(" ")
+        auth_header = event["headers"]["authorization"]
     elif "Authorization" in event["headers"]:
-        auth_header = event["headers"]["Authorization"].split(" ")
+        auth_header = event["headers"]["Authorization"]
     else:
         raise ValueError("Missing authorization token.")
 
-    if len(auth_header) == 1:
-        # secret management token won't be split into multiple segments
-        return str(auth_header[0])
-    else:
-        # Bearer tokens will have the token in the second segment
-        return str(auth_header[1])
+    # remove bearer token prefix if present
+    return re.sub(r"Bearer ", "", str(auth_header), flags=re.I).strip()
 
 
 @cache

--- a/lib/serve/index.ts
+++ b/lib/serve/index.ts
@@ -46,8 +46,6 @@ export class LisaServeApplicationStack extends Stack {
     public readonly restApi: FastApiContainer;
     public readonly modelsPs: StringParameter;
     public readonly endpointUrl: StringParameter;
-    public readonly managementKeySecret: Secret;
-    public readonly managementKeySecretNameStringParameter: StringParameter;
 
     /**
    * @param {Construct} scope - The parent or owner of the construct.
@@ -86,7 +84,7 @@ export class LisaServeApplicationStack extends Stack {
             vpc: vpc.vpc,
         });
 
-        this.managementKeySecret = new Secret(this, createCdkId([id, 'managementKeySecret']), {
+        const managementKeySecret = new Secret(this, createCdkId([id, 'managementKeySecret']), {
             secretName: `lisa_management_key_secret-${Date.now()}`, // pragma: allowlist secret`
             description: 'This is a secret created with AWS CDK',
             generateSecretString: {
@@ -131,11 +129,11 @@ export class LisaServeApplicationStack extends Stack {
         //     description: 'The ARN of the secret',
         // });
 
-        this.managementKeySecretNameStringParameter = new StringParameter(this, createCdkId([id, 'ManagementKeySecretName']), {
+        const managementKeySecretNameStringParameter = new StringParameter(this, createCdkId(['ManagementKeySecretName']), {
             parameterName: `${config.deploymentPrefix}/managementKeySecretName`,
-            stringValue: this.managementKeySecret.secretName,
+            stringValue: managementKeySecret.secretName,
         });
-        restApi.container.addEnvironment('MANAGEMENT_KEY_NAME', this.managementKeySecretNameStringParameter.stringValue);
+        restApi.container.addEnvironment('MANAGEMENT_KEY_NAME', managementKeySecretNameStringParameter.stringValue);
 
         // LiteLLM requires a PostgreSQL database to support multiple-instance scaling with dynamic model management.
         const connectionParamName = 'LiteLLMDbConnectionInfo';

--- a/lib/serve/index.ts
+++ b/lib/serve/index.ts
@@ -131,7 +131,7 @@ export class LisaServeApplicationStack extends Stack {
         //     description: 'The ARN of the secret',
         // });
 
-        this.managementKeySecretNameStringParameter = new StringParameter(this, createCdkId(['ManagementKeySecretName']), {
+        this.managementKeySecretNameStringParameter = new StringParameter(this, createCdkId([id, 'ManagementKeySecretName']), {
             parameterName: `${config.deploymentPrefix}/managementKeySecretName`,
             stringValue: this.managementKeySecret.secretName,
         });

--- a/lib/serve/index.ts
+++ b/lib/serve/index.ts
@@ -46,6 +46,8 @@ export class LisaServeApplicationStack extends Stack {
     public readonly restApi: FastApiContainer;
     public readonly modelsPs: StringParameter;
     public readonly endpointUrl: StringParameter;
+    public readonly managementKeySecret: Secret;
+    public readonly managementKeySecretNameStringParameter: StringParameter;
 
     /**
    * @param {Construct} scope - The parent or owner of the construct.
@@ -84,7 +86,7 @@ export class LisaServeApplicationStack extends Stack {
             vpc: vpc.vpc,
         });
 
-        const managementKeySecret = new Secret(this, createCdkId([id, 'managementKeySecret']), {
+        this.managementKeySecret = new Secret(this, createCdkId([id, 'managementKeySecret']), {
             secretName: `lisa_management_key_secret-${Date.now()}`, // pragma: allowlist secret`
             description: 'This is a secret created with AWS CDK',
             generateSecretString: {
@@ -129,11 +131,11 @@ export class LisaServeApplicationStack extends Stack {
         //     description: 'The ARN of the secret',
         // });
 
-        const managementKeySecretNameStringParameter = new StringParameter(this, createCdkId(['ManagementKeySecretName']), {
+        this.managementKeySecretNameStringParameter = new StringParameter(this, createCdkId(['ManagementKeySecretName']), {
             parameterName: `${config.deploymentPrefix}/managementKeySecretName`,
-            stringValue: managementKeySecret.secretName,
+            stringValue: this.managementKeySecret.secretName,
         });
-        restApi.container.addEnvironment('MANAGEMENT_KEY_NAME', managementKeySecretNameStringParameter.stringValue);
+        restApi.container.addEnvironment('MANAGEMENT_KEY_NAME', this.managementKeySecretNameStringParameter.stringValue);
 
         // LiteLLM requires a PostgreSQL database to support multiple-instance scaling with dynamic model management.
         const connectionParamName = 'LiteLLMDbConnectionInfo';

--- a/lib/serve/rest-api/src/api/endpoints/v2/litellm_passthrough.py
+++ b/lib/serve/rest-api/src/api/endpoints/v2/litellm_passthrough.py
@@ -140,7 +140,7 @@ async def litellm_passthrough(request: Request, api_path: str) -> Response:
 
 
 def refresh_management_tokens() -> list[str]:
-    """Return DDB entry for token if it exists."""
+    """Return secret management tokens if they exist."""
     secret_tokens = []
 
     try:

--- a/lib/serve/rest-api/src/auth.py
+++ b/lib/serve/rest-api/src/auth.py
@@ -198,7 +198,7 @@ class ManagementTokenAuthorizer:
         self._last_run = 0
 
     def _refreshTokens(self) -> None:
-        """Return DDB entry for token if it exists."""
+        """Refresh secret management tokens."""
         current_time = int(time())
         if current_time - (self._last_run or 0) > 3600:
             secret_tokens = []

--- a/test/cdk/stacks/core-api-base.test.ts
+++ b/test/cdk/stacks/core-api-base.test.ts
@@ -112,6 +112,6 @@ describe.each(regions)('API Core Nag Pack Tests | Region Test: %s', (awsRegion) 
 
     test('NIST800.53r5 CDK NAG Errors', () => {
         const errors = Annotations.fromStack(stack).findError('*', Match.stringLikeRegexp('NIST.*'));
-        expect(errors.length).toBe(6);
+        expect(errors.length).toBe(7);
     });
 });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Starting with the 3.0 release, which introduced dynamic model management, we required admin authentication through an IdP to manage models. However, this approach doesn't work in certain scenarios. To address this, the PR introduces a new authentication method using the model management token secret.

*Testing:*
- I am able to create a model using the Model Management UI 
- I am able to create a model by submitting a POST request to the APIGW endpoint `/model` using the model management token
- I am not able create a model by submitting a POST request to the APIGW endpoint `/model` without the management token

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
