### PR TITLE
Add enabled field to UpdateModel for start and stop operations

### DIFF
--- a/lambda/models/domain_objects.py
+++ b/lambda/models/domain_objects.py
@@ -189,6 +189,7 @@ class UpdateModelRequest(BaseModel):
     """Request object when updating a model."""
 
     autoScalingInstanceConfig: Optional[AutoScalingInstanceConfig] = None
+    enabled: Optional[bool] = None
     modelType: Optional[ModelType] = None
     streaming: Optional[bool] = None
 


### PR DESCRIPTION
Adds an "enabled" field to the UpdateModel API so that we can easily start or stop a model from the UI or from the CLI.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
