### PR TITLE
Update Start/Stop api calls from UI

### DIFF
--- a/lib/user-interface/react/src/components/model-management/ModelManagementActions.tsx
+++ b/lib/user-interface/react/src/components/model-management/ModelManagementActions.tsx
@@ -149,9 +149,9 @@ const ModelActionHandler = async (
                     action: 'Start',
                     resourceName: 'Model',
                     onConfirm: () => updateMutation({
-                            modelId: selectedModel.modelId,
-                            enabled: true
-                        }),
+                        modelId: selectedModel.modelId,
+                        enabled: true
+                    }),
                     description: `This will start the following model: ${selectedModel.modelId}.`
                 })
             );

--- a/lib/user-interface/react/src/shared/model/model-management.model.ts
+++ b/lib/user-interface/react/src/shared/model/model-management.model.ts
@@ -117,6 +117,14 @@ export type IModelRequest = {
     lisaHostedModel: boolean;
 };
 
+export type IModelUpdateRequest = {
+    modelId: string;
+    streaming?: boolean;
+    enabled?: boolean;
+    modelType?: ModelType;
+    autoScalingConfig?: IAutoScalingConfig;
+};
+
 const containerHealthCheckConfigSchema = z.object({
     command: z.array(z.string()).default(['CMD-SHELL', 'exit 0']),
     interval: z.number().default(10),

--- a/lib/user-interface/react/src/shared/reducers/model-management.reducer.ts
+++ b/lib/user-interface/react/src/shared/reducers/model-management.reducer.ts
@@ -16,7 +16,7 @@
 
 import { createApi } from '@reduxjs/toolkit/query/react';
 import { lisaBaseQuery } from './reducer.utils';
-import { IModel, IModelListResponse, IModelRequest } from '../model/model-management.model';
+import { IModel, IModelListResponse, IModelRequest, IModelUpdateRequest } from '../model/model-management.model';
 
 export const modelManagementApi = createApi({
     reducerPath: 'models',
@@ -36,20 +36,6 @@ export const modelManagementApi = createApi({
             }),
             invalidatesTags: ['models'],
         }),
-        startModel: builder.mutation<IModel, string>({
-            query: (modelId) => ({
-                url: `/models/${modelId}/start`,
-                method: 'PUT',
-            }),
-            invalidatesTags: ['models'],
-        }),
-        stopModel: builder.mutation<IModel, string>({
-            query: (modelId) => ({
-                url: `/models/${modelId}/stop`,
-                method: 'PUT',
-            }),
-            invalidatesTags: ['models'],
-        }),
         createModel: builder.mutation<IModel, IModelRequest>({
             query: (modelRequest) => ({
                 url: '/models',
@@ -58,7 +44,7 @@ export const modelManagementApi = createApi({
             }),
             invalidatesTags: ['models'],
         }),
-        updateModel: builder.mutation<IModel, IModelRequest>({
+        updateModel: builder.mutation<IModel, IModelUpdateRequest>({
             query: (modelRequest) => ({
                 url: `/models/${modelRequest.modelId}`,
                 method: 'PUT',
@@ -69,5 +55,5 @@ export const modelManagementApi = createApi({
     }),
 });
 
-export const { useGetAllModelsQuery, useDeleteModelMutation, useStopModelMutation, useStartModelMutation, useCreateModelMutation, useUpdateModelMutation } =
+export const { useGetAllModelsQuery, useDeleteModelMutation, useCreateModelMutation, useUpdateModelMutation } =
   modelManagementApi;


### PR DESCRIPTION
*Description of changes:*

Updating to enable the start and stop APIs. This also removes the stand alone apis for calling the update API and passing the enabled flag. Added logic to enable these options only for LISA hosted models in the correct status.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
