### PR TITLE
Model Management: Enable update form

### DIFF
--- a/lib/user-interface/react/src/components/model-management/ModelManagementActions.tsx
+++ b/lib/user-interface/react/src/components/model-management/ModelManagementActions.tsx
@@ -113,8 +113,8 @@ function ModelActionButton (dispatch: ThunkDispatch<any, any, Action>, notificat
         items.push({
             text: 'Update',
             id: 'editModel',
-            disabled: true,
-            disabledReason: 'This action will be available with LISA release 3.0.1',
+            disabled: !selectedModel,
+            disabledReason: 'No model selected.',
         });
     }
 

--- a/lib/user-interface/react/src/components/model-management/create-model/AutoScalingConfig.tsx
+++ b/lib/user-interface/react/src/components/model-management/create-model/AutoScalingConfig.tsx
@@ -23,7 +23,11 @@ import { IAutoScalingConfig } from '../../../shared/model/model-management.model
 import { Grid, Header, SpaceBetween } from '@cloudscape-design/components';
 import Container from '@cloudscape-design/components/container';
 
-export function AutoScalingConfig (props: FormProps<IAutoScalingConfig>) : ReactElement {
+type AutoScalingConfigProps = FormProps<IAutoScalingConfig> & {
+    isEdit: boolean
+};
+
+export function AutoScalingConfig (props: AutoScalingConfigProps) : ReactElement {
     return (
         <SpaceBetween size={'s'}>
             <Container
@@ -47,11 +51,21 @@ export function AutoScalingConfig (props: FormProps<IAutoScalingConfig>) : React
                         <span style={{lineHeight: '2.5em', paddingLeft: '0.5em'}}>instances</span>
                     </Grid>
                 </FormField>
+                { props.isEdit &&
+                    <FormField label='Desired Capacity' errorText={props.formErrors?.autoScalingConfig?.desiredCapacity}>
+                        <Grid gridDefinition={[{colspan: 10}, {colspan: 2}]} disableGutters={true}>
+                            <Input value={String(props.item.desiredCapacity)} type='number' inputMode='numeric' onBlur={() => props.touchFields(['autoScalingConfig.desiredCapacity'])} onChange={({ detail }) => {
+                                props.setFields({ 'autoScalingConfig.desiredCapacity': detail.value.trim().length > 0 ? Number(detail.value) : undefined });
+                            }}/>
+                            <span style={{lineHeight: '2.5em', paddingLeft: '0.5em'}}>instances</span>
+                        </Grid>
+                    </FormField>
+                }
                 <FormField label='Cooldown' errorText={props.formErrors?.autoScalingConfig?.cooldown}>
                     <Grid gridDefinition={[{colspan: 10}, {colspan: 2}]} disableGutters={true}>
                         <Input value={props.item.cooldown.toString()} type='number' inputMode='numeric' onBlur={() => props.touchFields(['autoScalingConfig.cooldown'])} onChange={({ detail }) => {
                             props.setFields({ 'autoScalingConfig.Cooldown': Number(detail.value) });
-                        }}/>
+                        }} disabled={props.isEdit}/>
                         <span style={{lineHeight: '2.5em', paddingLeft: '0.5em'}}>seconds</span>
                     </Grid>
                 </FormField>
@@ -59,12 +73,13 @@ export function AutoScalingConfig (props: FormProps<IAutoScalingConfig>) : React
                     <Grid gridDefinition={[{colspan: 10}, {colspan: 2}]} disableGutters={true}>
                         <Input value={props.item.defaultInstanceWarmup.toString()} type='number' inputMode='numeric' onBlur={() => props.touchFields(['autoScalingConfig.defaultInstanceWarmup'])} onChange={({ detail }) => {
                             props.setFields({ 'autoScalingConfig.defaultInstanceWarmup': Number(detail.value) });
-                        }}/>
+                        }} disabled={props.isEdit}/>
                         <span style={{lineHeight: '2.5em', paddingLeft: '0.5em'}}>seconds</span>
                     </Grid>
                 </FormField>
             </Container>
-            <Container
+
+            { !props.isEdit && <Container
                 header={
                     <Header variant='h3'>Metric Config</Header>
                 }
@@ -97,7 +112,7 @@ export function AutoScalingConfig (props: FormProps<IAutoScalingConfig>) : React
                         </Grid>
                     </FormField>
                 </SpaceBetween>
-            </Container>
+            </Container>}
         </SpaceBetween>
     );
 }

--- a/lib/user-interface/react/src/components/model-management/create-model/BaseModelConfig.tsx
+++ b/lib/user-interface/react/src/components/model-management/create-model/BaseModelConfig.tsx
@@ -48,11 +48,18 @@ export function BaseModelConfig (props: FormProps<IModelRequest> & BaseModelConf
             <FormField label='Model Type' errorText={props.formErrors?.modelType}>
                 <Select
                     selectedOption={{label: props.item.modelType.toUpperCase(), value: props.item.modelType}}
-                    onChange={({ detail }) =>
-                        props.setFields({
+                    onChange={({ detail }) => {
+                        const fields = {
                             'modelType': detail.selectedOption.value,
-                        })
-                    }
+                        };
+
+                        // turn off streaming for embedded models
+                        if (fields.modelType === ModelType.embedding) {
+                            fields['streaming'] = false;
+                        }
+
+                        props.setFields(fields);
+                    }}
                     onBlur={() => props.touchFields(['modelType'])}
                     options={[
                         { label: 'TEXTGEN', value: ModelType.textgen },
@@ -99,6 +106,7 @@ export function BaseModelConfig (props: FormProps<IModelRequest> & BaseModelConf
                             props.setFields({'streaming': detail.checked})
                         }
                         onBlur={() => props.touchFields(['streaming'])}
+                        disabled={props.item.modelType === ModelType.embedding}
                         checked={props.item.streaming}
                     />
                 </FormField>

--- a/lib/user-interface/react/src/components/model-management/create-model/BaseModelConfig.tsx
+++ b/lib/user-interface/react/src/components/model-management/create-model/BaseModelConfig.tsx
@@ -38,12 +38,12 @@ export function BaseModelConfig (props: FormProps<IModelRequest> & BaseModelConf
             <FormField label='Model Name' errorText={props.formErrors?.modelName}>
                 <Input value={props.item.modelName} inputMode='text' onBlur={() => props.touchFields(['modelName'])} onChange={({ detail }) => {
                     props.setFields({ 'modelName': detail.value });
-                }}/>
+                }} disabled={props.isEdit}/>
             </FormField>
             <FormField label='Model URL' errorText={props.formErrors?.modelUrl}>
                 <Input value={props.item.modelUrl} inputMode='text' onBlur={() => props.touchFields(['modelUrl'])} onChange={({ detail }) => {
                     props.setFields({ 'modelUrl': detail.value });
-                }}/>
+                }} disabled={props.isEdit}/>
             </FormField>
             <FormField label='Model Type' errorText={props.formErrors?.modelType}>
                 <Select
@@ -63,7 +63,7 @@ export function BaseModelConfig (props: FormProps<IModelRequest> & BaseModelConf
             <FormField label='Instance Type' errorText={props.formErrors?.instanceType}>
                 <Input value={props.item.instanceType} inputMode='text' onBlur={() => props.touchFields(['instanceType'])} onChange={({ detail }) => {
                     props.setFields({ 'instanceType': detail.value });
-                }}/>
+                }} disabled={props.isEdit}/>
             </FormField>
             <FormField label='Inference Container' errorText={props.formErrors?.inferenceContainer}>
                 <Select
@@ -79,6 +79,7 @@ export function BaseModelConfig (props: FormProps<IModelRequest> & BaseModelConf
                         { label: 'TEI', value: InferenceContainer.TEI },
                         { label: 'VLLM', value: InferenceContainer.VLLM },
                     ]}
+                    disabled={props.isEdit}
                 />
             </FormField>
             <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
@@ -89,6 +90,7 @@ export function BaseModelConfig (props: FormProps<IModelRequest> & BaseModelConf
                         }
                         onBlur={() => props.touchFields(['lisaHostedModel'])}
                         checked={props.item.lisaHostedModel}
+                        disabled={props.isEdit}
                     />
                 </FormField>
                 <FormField label='Streaming' errorText={props.formErrors?.streaming}>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
LISA 3.0 launched with model management but didn't have updating models enabled yet. This PR add the ability to configure a few model properties after launch.
- enable/disable streaming
- model type (textgen/embedding)
- auto scaling configuration (LISA hosted models only)

![Recording 2024-09-25 at 09 57 53](https://github.com/user-attachments/assets/34e755a9-1862-4fd5-a291-b6bfacdc9eaa)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
