### PR TITLE
ECS Config Refactor in config.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ installTypeScriptRequirements:
 
 ## Make sure Docker is running
 dockerCheck:
-	@cmd_output=$$(finch ps); \
+	@cmd_output=$$(docker ps); \
 	if \
 		[ $$? != 0 ]; \
 		then \
@@ -225,11 +225,11 @@ cleanMisc:
 dockerLogin: dockerCheck
 ifdef PROFILE
 	@$(foreach ACCOUNT,$(ACCOUNT_NUMBERS_ECR), \
-		aws ecr get-login-password --region ${REGION} --profile ${PROFILE} | finch login --username AWS --password-stdin $(ACCOUNT).dkr.ecr.${REGION}.${URL_SUFFIX} >/dev/null 2>&1; \
+		aws ecr get-login-password --region ${REGION} --profile ${PROFILE} | docker login --username AWS --password-stdin $(ACCOUNT).dkr.ecr.${REGION}.${URL_SUFFIX} >/dev/null 2>&1; \
 	)
 else
 	@$(foreach ACCOUNT,$(ACCOUNT_NUMBERS_ECR), \
-		aws ecr get-login-password --region ${REGION} | finch login --username AWS --password-stdin $(ACCOUNT).dkr.ecr.${REGION}.${URL_SUFFIX} >/dev/null 2>&1; \
+		aws ecr get-login-password --region ${REGION} | docker login --username AWS --password-stdin $(ACCOUNT).dkr.ecr.${REGION}.${URL_SUFFIX} >/dev/null 2>&1; \
 	)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ installTypeScriptRequirements:
 
 ## Make sure Docker is running
 dockerCheck:
-	@cmd_output=$$(docker ps); \
+	@cmd_output=$$(finch ps); \
 	if \
 		[ $$? != 0 ]; \
 		then \
@@ -225,11 +225,11 @@ cleanMisc:
 dockerLogin: dockerCheck
 ifdef PROFILE
 	@$(foreach ACCOUNT,$(ACCOUNT_NUMBERS_ECR), \
-		aws ecr get-login-password --region ${REGION} --profile ${PROFILE} | docker login --username AWS --password-stdin $(ACCOUNT).dkr.ecr.${REGION}.${URL_SUFFIX} >/dev/null 2>&1; \
+		aws ecr get-login-password --region ${REGION} --profile ${PROFILE} | finch login --username AWS --password-stdin $(ACCOUNT).dkr.ecr.${REGION}.${URL_SUFFIX} >/dev/null 2>&1; \
 	)
 else
 	@$(foreach ACCOUNT,$(ACCOUNT_NUMBERS_ECR), \
-		aws ecr get-login-password --region ${REGION} | docker login --username AWS --password-stdin $(ACCOUNT).dkr.ecr.${REGION}.${URL_SUFFIX} >/dev/null 2>&1; \
+		aws ecr get-login-password --region ${REGION} | finch login --username AWS --password-stdin $(ACCOUNT).dkr.ecr.${REGION}.${URL_SUFFIX} >/dev/null 2>&1; \
 	)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ modelCheck:
 						echo "What is your huggingface access token? "; \
 						read -s access_token; \
 						echo "Converting and uploading safetensors for model: $(MODEL_ID)"; \
-						tgiImage=$$(yq '[.$(ENV).ecsModels[] | select(.inferenceContainer == "tgi") | .containerConfig.image.baseImage] | first' $(PROJECT_DIR)/config.yaml | sed "s/^['\"]//;s/['\"]$$//"); \
+						tgiImage=$$(yq '[.$(ENV).ecsModels[] | select(.inferenceContainer == "tgi") | .baseImage] | first' $(PROJECT_DIR)/config.yaml | sed "s/^['\"]//;s/['\"]$$//"); \
 						echo $$tgiImage; \
 						$(PROJECT_DIR)/scripts/convert-and-upload-model.sh -m $(MODEL_ID) -s $(MODEL_BUCKET) -a $$access_token -t $$tgiImage -d $$localModelDir; \
 				fi; \

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ modelCheck:
 						echo "What is your huggingface access token? "; \
 						read -s access_token; \
 						echo "Converting and uploading safetensors for model: $(MODEL_ID)"; \
-						tgiImage=$$(yq '[.$(ENV).ecsModels[] | select(.inferenceContainer == "tgi") | .baseImage] | first' $(PROJECT_DIR)/config.yaml | sed "s/^['\"]//;s/['\"]$$//"); \
+						tgiImage=$$(yq '[.$(ENV).ecsModels[] | select(.inferenceContainer == "tgi") | .baseImage] | first' $(PROJECT_DIR)/config.yaml); \
 						echo $$tgiImage; \
 						$(PROJECT_DIR)/scripts/convert-and-upload-model.sh -m $(MODEL_ID) -s $(MODEL_BUCKET) -a $$access_token -t $$tgiImage -d $$localModelDir; \
 				fi; \

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ modelCheck:
 						echo "What is your huggingface access token? "; \
 						read -s access_token; \
 						echo "Converting and uploading safetensors for model: $(MODEL_ID)"; \
-						tgiImage=$$(yq '[.$(ENV).ecsModels[] | select(.inferenceContainer == "tgi") | .baseImage] | first' $(PROJECT_DIR)/config.yaml); \
+						tgiImage=$$(yq -r '[.$(ENV).ecsModels[] | select(.inferenceContainer == "tgi") | .baseImage] | first' $(PROJECT_DIR)/config.yaml); \
 						echo $$tgiImage; \
 						$(PROJECT_DIR)/scripts/convert-and-upload-model.sh -m $(MODEL_ID) -s $(MODEL_BUCKET) -a $$access_token -t $$tgiImage -d $$localModelDir; \
 				fi; \

--- a/README.md
+++ b/README.md
@@ -842,7 +842,7 @@ you can do so.
       ```yaml
       ecsModels:
         - modelName: your-model-name
-          inferenceContainer: tgi 
+          inferenceContainer: tgi
           baseImage: ghcr.io/huggingface/text-generation-inference:2.0.1
       ```
 - If you are deploying the LISA Chat User Interface you can optionally specify the path to the pre-built

--- a/README.md
+++ b/README.md
@@ -372,15 +372,15 @@ restApiConfig:
 
 In the `ecsModels` section of `config.yaml`, allow our deployment process to pull the model weights for you.
 
-During the deployment proces, lisa will optionally attempt to download your model weights if you specify an optional`ecsModels`
-array, this will only work in non ADC regions. Specifically, see the `ecsModels` section of the [config.yaml](./config.yaml) file.
+During the deployment process, LISA will optionally attempt to download your model weights if you specify an optional `ecsModels`
+array, this will only work in non ADC regions. Specifically, see the `ecsModels` section of the [example_config.yaml](./example_config.yaml) file.
 Here we define the model name, inference container, and baseImage:
 
 ```yaml
 ecsModels:
   - modelName: your-model-name
     inferenceContainer: tgi
-    baseImage: ghcr.io/huggingface/text-generation-inference:1.0.2
+    baseImage: ghcr.io/huggingface/text-generation-inference:2.0.1
 ```
 
 ---
@@ -842,8 +842,8 @@ you can do so.
       ```yaml
       ecsModels:
         - modelName: your-model-name
-          inferenceContainer: tgi # vLLM-specific config
-          baseImage: ghcr.io/huggingface/text-generation-inference:1.0.2 # vLLM-specific config
+          inferenceContainer: tgi 
+          baseImage: ghcr.io/huggingface/text-generation-inference:2.0.1
       ```
 - If you are deploying the LISA Chat User Interface you can optionally specify the path to the pre-built
   website assets using the top level `webAppAssetsPath` parameter in `config.yaml`. Specifying this path

--- a/README.md
+++ b/README.md
@@ -370,34 +370,18 @@ restApiConfig:
 
 ## Step 9: Customize Model Deployment
 
-In the `ecsModels` section of `config.yaml`, configure the models you want to deploy.
+In the `ecsModels` section of `config.yaml`, allow our deployment process to pull the model weights for you.
 
-The configuration file will determine which models are deployed. In order to deploy an additional model or a
-different model the only required change is to the configuration file, as long as it is compatible with the inference
-container. Specifically, see the `ecsModels` section of the [config.yaml](./config.yaml) file.
-Here we define the model name, if we want to deploy, the type of instance we want to deploy to, the type of model
-(textgen or embedding), the inference container and then the containerConfig. There are many more parameters for the
-ecs models, many for autoscaling and health checks. However, let's focus on the model specific ones:
+During the deployment proces, lisa will optionally attempt to download your model weights if you specify an optional`ecsModels`
+array, this will only work in non ADC regions. Specifically, see the `ecsModels` section of the [config.yaml](./config.yaml) file.
+Here we define the model name, inference container, and baseImage:
 
 ```yaml
 ecsModels:
   - modelName: your-model-name
-    deploy: false
-    instanceType: g4dn.12xlarge
-    modelType: textgen
     inferenceContainer: tgi
-    containerConfig:
-      baseImage: ghcr.io/huggingface/text-generation-inference:1.0.2
-      environment:
-        QUANTIZE: bitsandbytes-nf4
-        MAX_CONCURRENT_REQUESTS: 128
-        MAX_INPUT_LENGTH: 1024
-        MAX_TOTAL_TOKENS: 2048
+    baseImage: ghcr.io/huggingface/text-generation-inference:1.0.2
 ```
-
-Adjust these parameters based on your specific model requirements and performance needs. These parameters will
-be used when the model endpoint is deployed and are likely to change with different model types. For more information
-on these parameters please see the [inference container documentation](https://github.com/huggingface/text-generation-inference/tree/main).
 
 ---
 
@@ -857,17 +841,9 @@ you can do so.
       but this list is expected to grow over time as vLLM updates.
       ```yaml
       ecsModels:
-        - modelName: mistralai/Mistral-7B-Instruct-v0.2
-          modelId: mistral7b-vllm
-          deploy: false
-          modelType: textgen # can also be 'embedding'
-          streaming: true # remove option if modelType is 'embedding'
-          instanceType: g5.xlarge
-          inferenceContainer: vllm # vLLM-specific config
-          containerConfig:
-            image:
-              baseImage: vllm/vllm-openai:v0.5.0 # vLLM-specific config
-              path: lib/serve/ecs-model/vllm # vLLM-specific config
+        - modelName: your-model-name
+          inferenceContainer: tgi # vLLM-specific config
+          baseImage: ghcr.io/huggingface/text-generation-inference:1.0.2 # vLLM-specific config
       ```
 - If you are deploying the LISA Chat User Interface you can optionally specify the path to the pre-built
   website assets using the top level `webAppAssetsPath` parameter in `config.yaml`. Specifying this path

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -121,124 +121,14 @@ dev:
     chunkOverlap: 51
   ecsModels:
     - modelName: mistralai/Mistral-7B-Instruct-v0.2
-      modelId: mistral7b
-      deploy: false
-      streaming: true
-      modelType: textgen
-      instanceType: g5.xlarge
       inferenceContainer: tgi
-      containerConfig:
-        image:
-          baseImage: ghcr.io/huggingface/text-generation-inference:2.0.1
-          path: lib/serve/ecs-model/textgen/tgi
-          type: asset
-        sharedMemorySize: 2048
-        healthCheckConfig:
-          command: ["CMD-SHELL", "exit 0"]
-          interval: 10
-          startPeriod: 30
-          timeout: 5
-          retries: 3
-        environment:
-          MAX_CONCURRENT_REQUESTS: 128
-          MAX_INPUT_LENGTH: 1024
-          MAX_TOTAL_TOKENS: 2048
-      autoScalingConfig:
-        minCapacity: 1
-        maxCapacity: 1
-        defaultInstanceWarmup: 180
-        cooldown: 420
-        metricConfig:
-          AlbMetricName: RequestCountPerTarget
-          targetValue: 30
-          duration: 60
-          estimatedInstanceWarmup: 330
-      loadBalancerConfig:
-        healthCheckConfig:
-          path: /health
-          interval: 60
-          timeout: 30
-          healthyThresholdCount: 2
-          unhealthyThresholdCount: 10
+      baseImage: ghcr.io/huggingface/text-generation-inference:2.0.1
     - modelName: intfloat/e5-large-v2
-      modelId: e5v2
-      deploy: false
-      modelType: embedding
-      instanceType: g5.xlarge
       inferenceContainer: tei
-      containerConfig:
-        image:
-          baseImage: ghcr.io/huggingface/text-embeddings-inference:1.2.3
-          path: lib/serve/ecs-model/embedding/tei
-          type: asset
-        sharedMemorySize: 2048
-        healthCheckConfig:
-          command: ["CMD-SHELL", "exit 0"]
-          interval: 10
-          startPeriod: 30
-          timeout: 5
-          retries: 3
-        environment:
-          MAX_CONCURRENT_REQUESTS: 512
-          MAX_CLIENT_BATCH_SIZE: 1024
-          MAX_BATCH_TOKENS: 16384
-      autoScalingConfig:
-        minCapacity: 1
-        maxCapacity: 1
-        cooldown: 420
-        defaultInstanceWarmup: 180
-        metricConfig:
-          AlbMetricName: RequestCountPerTarget
-          targetValue: 60
-          duration: 60
-          estimatedInstanceWarmup: 330
-      loadBalancerConfig:
-        healthCheckConfig:
-          path: /health
-          interval: 30
-          timeout: 10
-          healthyThresholdCount: 2
-          unhealthyThresholdCount: 10
+      baseImage: ghcr.io/huggingface/text-embeddings-inference:1.2.3
     # - modelName: mistralai/Mixtral-8x7B-Instruct-v0.1
-    #   deploy: false
-    #   streaming: true
-    #   modelType: textgen
-    #   instanceType: g5.12xlarge
     #   inferenceContainer: tgi
-    #   containerConfig:
-    #     image:
-    #       baseImage: ghcr.io/huggingface/text-generation-inference:2.0.1
-    #       path: lib/serve/ecs-model/textgen/tgi
-    #       type: asset
-    #     sharedMemorySize: 2048
-    #     healthCheckConfig:
-    #       command: ["CMD-SHELL", "exit 0"]
-    #       interval: 10
-    #       startPeriod: 30
-    #       timeout: 5
-    #       retries: 3
-    #     environment:
-    #       QUANTIZE: bitsandbytes-nf4
-    #       MAX_CONCURRENT_REQUESTS: 128
-    #       MAX_INPUT_LENGTH: 1024
-    #       MAX_TOTAL_TOKENS: 2048
-    #   autoScalingConfig:
-    #     minCapacity: 1
-    #     maxCapacity: 1
-    #     defaultInstanceWarmup: 180
-    #     cooldown: 420
-    #     metricConfig:
-    #       AlbMetricName: RequestCountPerTarget
-    #       targetValue: 30
-    #       duration: 60
-    #       estimatedInstanceWarmup: 330
-    #   loadBalancerConfig:
-    #     healthCheckConfig:
-    #       path: /health
-    #       interval: 60
-    #       timeout: 30
-    #       healthyThresholdCount: 2
-    #       unhealthyThresholdCount: 10
+    #   baseImage: ghcr.io/huggingface/text-generation-inference:2.0.1
   # LiteLLM Config options found here: https://litellm.vercel.app/docs/proxy/configs#all-settings
   # Anything within this config is copied to a configuration for starting LiteLLM in the REST API container.
   # It is suggested to put an "ignored" API key so that calls to locally hosted models don't fail on OpenAI calls

--- a/lib/core/utils.ts
+++ b/lib/core/utils.ts
@@ -21,7 +21,7 @@ import * as path from 'path';
 import * as cdk from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
 
-import { Config, ModelConfig } from '../schema';
+import { Config } from '../schema';
 
 const IAM_DIR = path.join(__dirname, 'iam');
 

--- a/lib/core/utils.ts
+++ b/lib/core/utils.ts
@@ -88,15 +88,3 @@ export function createCdkId (idParts: string[], maxLength: number = 64, truncati
 
     return cdkId;
 }
-
-/**
- * Creates a "normalized" identifier based on the provided model config. If a modelId has been
- * defined the id will be used otherwise the model name will be used. This normalized identifier
- * strips all non alpha numeric characters.
- *
- * @param {string} modelConfig model config
- * @returns {string} normalized model name for use in CDK identifiers/resource names
- */
-export function getModelIdentifier (modelConfig: ModelConfig): string {
-    return (modelConfig.modelId || modelConfig.modelName).replace(/[^a-zA-Z0-9]/g, '');
-}

--- a/lib/iam_stack.ts
+++ b/lib/iam_stack.ts
@@ -116,14 +116,6 @@ export class LisaServeIAMStack extends Stack {
                 type: ECSTaskType.API,
             },
         ];
-        for (const modelConfig of config.ecsModels) {
-            if (modelConfig.deploy) {
-                ecsRoles.push({
-                    id: getModelIdentifier(modelConfig),
-                    type: ECSTaskType.MODEL,
-                });
-            }
-        }
         ecsRoles.forEach((role) => {
             const roleName = createCdkId([config.deploymentName, role.id, 'Role']);
             const taskRole = new Role(this, createCdkId([role.id, 'Role']), {

--- a/lib/iam_stack.ts
+++ b/lib/iam_stack.ts
@@ -21,7 +21,7 @@ import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 
-import { createCdkId, getIamPolicyStatements, getModelIdentifier } from './core/utils';
+import { createCdkId, getIamPolicyStatements } from './core/utils';
 import { BaseProps } from './schema';
 
 /**
@@ -42,7 +42,6 @@ type RoleInfo = {
 
 enum ECSTaskType {
     API = 'API',
-    MODEL = 'model endpoint',
 }
 
 /**

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -508,41 +508,13 @@ export type ECSConfig = EcsBaseConfig;
 const EcsModelConfigSchema = z
     .object({
         modelName: z.string(),
-        modelId: z.string().optional(),
-        deploy: z.boolean().default(true),
-        streaming: z.boolean().nullable().default(null),
-        modelType: z.nativeEnum(ModelType),
-        instanceType: z.enum(VALID_INSTANCE_KEYS),
+        baseImage: z.string(),
         inferenceContainer: z
             .union([z.literal('tgi'), z.literal('tei'), z.literal('instructor'), z.literal('vllm')])
             .refine((data) => {
                 return !data.includes('.'); // string cannot contain a period
-            }),
-        containerConfig: ContainerConfigSchema,
-        autoScalingConfig: AutoScalingConfigSchema,
-        loadBalancerConfig: LoadBalancerConfigSchema,
-        localModelCode: z.string().default('/opt/model-code'),
-        modelHosting: z
-            .string()
-            .default('ecs')
-            .refine((data) => {
-                return !data.includes('.'); // string cannot contain a period
-            }),
-    })
-    .refine(
-        (data) => {
-            // 'textgen' type must have boolean streaming, 'embedding' type must have null streaming
-            const isValidForTextgen = data.modelType === 'textgen' && typeof data.streaming === 'boolean';
-            const isValidForEmbedding = data.modelType === 'embedding' && data.streaming === null;
-
-            return isValidForTextgen || isValidForEmbedding;
-        },
-        {
-            message: `For 'textgen' models, 'streaming' must be true or false.
-            For 'embedding' models, 'streaming' must not be set.`,
-            path: ['streaming'],
-        },
-    );
+            })
+    });
 
 /**
  * Type representing configuration for an ECS model.
@@ -898,7 +870,7 @@ const RawConfigSchema = z
         ragRepositories: z.array(RagRepositoryConfigSchema).default([]),
         ragFileProcessingConfig: RagFileProcessingConfigSchema.optional(),
         restApiConfig: FastApiContainerConfigSchema,
-        ecsModels: z.array(EcsModelConfigSchema),
+        ecsModels: z.array(EcsModelConfigSchema).optional(),
         apiGatewayConfig: ApiGatewayConfigSchema.optional(),
         nvmeHostMountPath: z.string().default('/nvme'),
         nvmeContainerMountPath: z.string().default('/nvme'),

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -492,18 +492,8 @@ export type ECSConfig = EcsBaseConfig;
  * Configuration schema for an ECS model.
  *
  * @property {string} modelName - Name of the model.
- * @property {string} modelId - An optional short id to use when creating cdk ids for model related
- *                              resources
- * @property {boolean} [deploy=true] - Whether to deploy model.
- * @property {boolean} [streaming=null] - Whether the model supports streaming.
- * @property {string} modelType - Type of model.
- * @property {string} instanceType - EC2 instance type for running the model.
+ * @property {string} baseImage - Base image for the container.
  * @property {string} inferenceContainer - Prebuilt inference container for serving model.
- * @property {ContainerConfig} containerConfig - Configuration for the container.
- * @property {AutoScalingConfigSchema} autoScalingConfig - Configuration for auto scaling settings.
- * @property {LoadBalancerConfig} loadBalancerConfig - Configuration for load balancer settings.
- * @property {string} [localModelCode='/opt/model-code'] - Path in container for local model code.
- * @property {string} [modelHosting='ecs'] - Model hosting.
  */
 const EcsModelConfigSchema = z
     .object({

--- a/lib/user-interface/index.ts
+++ b/lib/user-interface/index.ts
@@ -161,23 +161,8 @@ export class UserInterfaceStack extends Stack {
             },
         );
 
-        const ecsModels = config.ecsModels.map((modelConfig) => {
-            return {
-                model: modelConfig.modelId,
-                streaming: modelConfig.streaming,
-                modelType: modelConfig.modelType,
-            };
-        });
         const litellmModels = config.litellmConfig.model_list ? config.litellmConfig.model_list : [];
-        const modelsList = ecsModels.concat(
-            litellmModels.map((model) => {
-                return {
-                    model: model.model_name,
-                    streaming: model.lisa_params.streaming,
-                    modelType: model.lisa_params.model_type,
-                };
-            }),
-        );
+
 
         // Website bucket deployment
         // Copy auth and LISA-Serve info to UI deployment bucket
@@ -200,7 +185,7 @@ export class UserInterfaceStack extends Stack {
                 fontColor: config.systemBanner?.fontColor,
             },
             API_BASE_URL: config.apiGatewayConfig?.domainName ? '/' : `/${config.deploymentStage}/`,
-            MODELS: modelsList,
+            MODELS: litellmModels,
         };
 
         const appEnvSource = Source.data('env.js', `window.env = ${JSON.stringify(appEnvConfig)}`);

--- a/test/cdk/mocks/config.yaml
+++ b/test/cdk/mocks/config.yaml
@@ -116,124 +116,14 @@ dev:
     chunkOverlap: 51
   ecsModels:
     - modelName: mistralai/Mistral-7B-Instruct-v0.2
-      modelId: mistral7b
-      deploy: true
-      streaming: true
-      modelType: textgen
-      instanceType: g5.xlarge
       inferenceContainer: tgi
-      containerConfig:
-        image:
-          baseImage: ghcr.io/huggingface/text-generation-inference:2.0.1
-          path: lib/serve/ecs-model/textgen/tgi
-          type: asset
-        sharedMemorySize: 2048
-        healthCheckConfig:
-          command: ["CMD-SHELL", "exit 0"]
-          interval: 10
-          startPeriod: 30
-          timeout: 5
-          retries: 3
-        environment:
-          MAX_CONCURRENT_REQUESTS: 128
-          MAX_INPUT_LENGTH: 1024
-          MAX_TOTAL_TOKENS: 2048
-      autoScalingConfig:
-        minCapacity: 1
-        maxCapacity: 1
-        defaultInstanceWarmup: 180
-        cooldown: 420
-        metricConfig:
-          AlbMetricName: RequestCountPerTarget
-          targetValue: 30
-          duration: 60
-          estimatedInstanceWarmup: 330
-      loadBalancerConfig:
-        healthCheckConfig:
-          path: /health
-          interval: 60
-          timeout: 30
-          healthyThresholdCount: 2
-          unhealthyThresholdCount: 10
+      baseImage: ghcr.io/huggingface/text-generation-inference:2.0.1
     - modelName: intfloat/e5-large-v2
-      modelId: e5v2
-      deploy: true
-      modelType: embedding
-      instanceType: g5.xlarge
       inferenceContainer: tei
-      containerConfig:
-        image:
-          baseImage: ghcr.io/huggingface/text-embeddings-inference:1.2.3
-          path: lib/serve/ecs-model/embedding/tei
-          type: asset
-        sharedMemorySize: 2048
-        healthCheckConfig:
-          command: ["CMD-SHELL", "exit 0"]
-          interval: 10
-          startPeriod: 30
-          timeout: 5
-          retries: 3
-        environment:
-          MAX_CONCURRENT_REQUESTS: 512
-          MAX_CLIENT_BATCH_SIZE: 1024
-          MAX_BATCH_TOKENS: 16384
-      autoScalingConfig:
-        minCapacity: 1
-        maxCapacity: 1
-        cooldown: 420
-        defaultInstanceWarmup: 180
-        metricConfig:
-          AlbMetricName: RequestCountPerTarget
-          targetValue: 60
-          duration: 60
-          estimatedInstanceWarmup: 330
-      loadBalancerConfig:
-        healthCheckConfig:
-          path: /health
-          interval: 30
-          timeout: 10
-          healthyThresholdCount: 2
-          unhealthyThresholdCount: 10
+      baseImage: ghcr.io/huggingface/text-embeddings-inference:1.2.3
     # - modelName: mistralai/Mixtral-8x7B-Instruct-v0.1
-    #   deploy: true
-    #   streaming: true
-    #   modelType: textgen
-    #   instanceType: g5.12xlarge
     #   inferenceContainer: tgi
-    #   containerConfig:
-    #     image:
-    #       baseImage: ghcr.io/huggingface/text-generation-inference:2.0.1
-    #       path: lib/serve/ecs-model/textgen/tgi
-    #       type: asset
-    #     sharedMemorySize: 2048
-    #     healthCheckConfig:
-    #       command: ["CMD-SHELL", "exit 0"]
-    #       interval: 10
-    #       startPeriod: 30
-    #       timeout: 5
-    #       retries: 3
-    #     environment:
-    #       QUANTIZE: bitsandbytes-nf4
-    #       MAX_CONCURRENT_REQUESTS: 128
-    #       MAX_INPUT_LENGTH: 1024
-    #       MAX_TOTAL_TOKENS: 2048
-    #   autoScalingConfig:
-    #     minCapacity: 1
-    #     maxCapacity: 1
-    #     defaultInstanceWarmup: 180
-    #     cooldown: 420
-    #     metricConfig:
-    #       AlbMetricName: RequestCountPerTarget
-    #       targetValue: 30
-    #       duration: 60
-    #       estimatedInstanceWarmup: 330
-    #   loadBalancerConfig:
-    #     healthCheckConfig:
-    #       path: /health
-    #       interval: 60
-    #       timeout: 30
-    #       healthyThresholdCount: 2
-    #       unhealthyThresholdCount: 10
+    #   baseImage: ghcr.io/huggingface/text-generation-inference:2.0.1
   litellmConfig:
     general_settings:
       master_key: sk-012345


### PR DESCRIPTION
*Description of changes:*

When creating LISA 3.0 we removed the ability for users to define models and have them deployed at deploy time from the config file. Updating the schema to optionally provide the required fields to pull and validate model weights are present in the S3 bucket. Also redefined the schema structure to support the optional array and removed values. The new field will look like so:

```
  ecsModels:
    - modelName: meta-llama/Meta-Llama-3-8B
      baseImage: vllm/vllm-openai:v0.4.3
      inferenceContainer: vllm
    - modelName: mistralai/Mistral-7B-Instruct-v0.2
      baseImage: ghcr.io/huggingface/text-generation-inference:2.0.1
      inferenceContainer: tgi
    - modelName: e5-large-v2
      baseImage: ghcr.io/huggingface/text-generation-inference:2.0.1
      inferenceContainer: tei
    - modelName: google/flan-t5-xl
      baseImage: ghcr.io/huggingface/text-generation-inference:2.2.0
      inferenceContainer: tgi
```

Also prevented the roles for the models from automatically being created, as this will be done at deploy time through the model management UI/APIs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
