### PR TITLE
Implement UpdateModel backend workflow

### DIFF
--- a/lambda/models/domain_objects.py
+++ b/lambda/models/domain_objects.py
@@ -18,7 +18,8 @@ from enum import Enum
 from typing import Annotated, List, Optional, Union
 
 from pydantic import BaseModel
-from pydantic.functional_validators import AfterValidator, field_validator
+from pydantic.functional_validators import AfterValidator, field_validator, model_validator
+from typing_extensions import Self
 from utilities.validators import validate_instance_type
 
 
@@ -166,6 +167,14 @@ class CreateModelRequest(BaseModel):
     modelUrl: Optional[str] = None
     streaming: Optional[bool] = False
 
+    @model_validator(mode="after")  # type: ignore
+    def validate_create_model_request(self) -> Self:
+        """Validate whole request object."""
+        # Validate that an embedding model cannot be set as streaming-enabled
+        if self.modelType == ModelType.EMBEDDING and self.streaming:
+            raise ValueError("Embedding model cannot be set with streaming enabled.")
+        return self
+
 
 class CreateModelResponse(ApiResponseBase):
     """Response object when creating a model."""
@@ -193,6 +202,27 @@ class UpdateModelRequest(BaseModel):
     modelType: Optional[ModelType] = None
     streaming: Optional[bool] = None
 
+    @model_validator(mode="after")  # type: ignore
+    def validate_update_model_request(self) -> Self:
+        """Validate whole request object."""
+        fields = (
+            self.autoScalingInstanceConfig,
+            self.enabled,
+            self.modelType,
+            self.streaming,
+        )
+        # Validate that at minimum one field is defined, otherwise there's no action to take in this update
+        if all((field is None for field in fields)):
+            raise ValueError(
+                "At least one field out of 'autoScalingInstanceConfig', 'enabled', 'modelType', or "
+                "'streaming' must be defined in request payload."
+            )
+
+        # Validate that an embedding model cannot be set as streaming-enabled
+        if self.modelType == ModelType.EMBEDDING and self.streaming:
+            raise ValueError("Embedding model cannot be set with streaming enabled.")
+        return self
+
     @field_validator("autoScalingInstanceConfig")  # type: ignore
     @classmethod
     def validate_autoscaling_instance_config(cls, config: AutoScalingInstanceConfig) -> AutoScalingInstanceConfig:
@@ -202,8 +232,15 @@ class UpdateModelRequest(BaseModel):
         config_fields = (config.minCapacity, config.maxCapacity, config.desiredCapacity)
         if all((field is None for field in config_fields)):
             raise ValueError("At least one option of autoScalingInstanceConfig must be defined.")
-        if any((isinstance(field, int) and field < 0 for field in config_fields)):
-            raise ValueError("All autoScalingInstanceConfig fields must be >= 0.")
+        if any((isinstance(field, int) and field < 1 for field in config_fields)):
+            raise ValueError("All autoScalingInstanceConfig fields must be >= 1.")
+        # if desired and max are greater than 1, and desired is greater than requested max, throw error
+        if config.desiredCapacity and config.maxCapacity and config.desiredCapacity > config.maxCapacity:
+            raise ValueError("Desired capacity must be <= max capacity.")
+        # if desired and min are 0 or more, and desired is less than requested min, throw error
+        if isinstance(config.desiredCapacity, int) and isinstance(config.minCapacity, int):
+            if config.desiredCapacity < config.minCapacity:
+                raise ValueError("Desired capacity must be >= min capacity.")
         return config
 
 

--- a/lambda/models/domain_objects.py
+++ b/lambda/models/domain_objects.py
@@ -44,6 +44,7 @@ class ModelStatus(str, Enum):
 
     CREATING = "Creating"
     IN_SERVICE = "InService"
+    STARTING = "Starting"
     STOPPING = "Stopping"
     STOPPED = "Stopped"
     UPDATING = "Updating"

--- a/lambda/models/exception/__init__.py
+++ b/lambda/models/exception/__init__.py
@@ -15,7 +15,13 @@
 """Exception definitions for model management APIs."""
 
 
-# LiteLLM errors
+# Synchronous API errors
+
+
+class InvalidStateTransitionError(ValueError):
+    """Error to raise when a modification is requested but cannot be processed due to current model state."""
+
+    pass
 
 
 class ModelNotFoundError(LookupError):

--- a/lambda/models/handler/base_handler.py
+++ b/lambda/models/handler/base_handler.py
@@ -23,10 +23,12 @@ class BaseApiHandler:
 
     def __init__(
         self,
+        autoscaling_client: Any,
         stepfunctions_client: Any,
         model_table_resource: Any,
     ):
         """Make all clients available for use in any handler class."""
+        self._autoscaling = autoscaling_client
         self._stepfunctions = stepfunctions_client
         self._model_table = model_table_resource
 

--- a/lambda/models/handler/update_model_handler.py
+++ b/lambda/models/handler/update_model_handler.py
@@ -17,8 +17,8 @@
 import json
 import os
 
-from ..domain_objects import UpdateModelRequest, UpdateModelResponse
-from ..exception import ModelNotFoundError
+from ..domain_objects import ModelStatus, UpdateModelRequest, UpdateModelResponse
+from ..exception import InvalidStateTransitionError, ModelNotFoundError
 from .base_handler import BaseApiHandler
 from .utils import to_lisa_model
 
@@ -31,6 +31,64 @@ class UpdateModelHandler(BaseApiHandler):
         ddb_item = self._model_table.get_item(Key={"model_id": model_id}).get("Item", None)
         if not ddb_item:
             raise ModelNotFoundError(f"Model '{model_id}' was not found.")
+
+        model_status = ddb_item["model_status"]
+
+        # Validations
+
+        # Validate model is not actively mutating or failed before starting
+        if model_status not in (ModelStatus.IN_SERVICE, ModelStatus.STOPPED):
+            raise InvalidStateTransitionError(
+                f"Model cannot be updated when it is not in the '{ModelStatus.IN_SERVICE}' or "
+                f"'{ModelStatus.STOPPED}' states"
+            )
+
+        # Validate model mutations while enabling/disabling option is enabled
+        if update_request.enabled is not None:
+            # Force capacity changes and enable/disable operations to happen in separate requests
+            if update_request.autoScalingInstanceConfig is not None:
+                raise ValueError("Start or Stop operations and AutoScaling changes must happen in separate requests.")
+            # Model cannot be enabled if it isn't already stopped
+            if update_request.enabled and not model_status == ModelStatus.STOPPED:
+                raise InvalidStateTransitionError(
+                    f"Model cannot be enabled when it is not in the '{ModelStatus.STOPPED}' state."
+                )
+            # Model cannot be stopped if it isn't already in service
+            elif not update_request.enabled and not model_status == ModelStatus.IN_SERVICE:
+                raise InvalidStateTransitionError(
+                    f"Model cannot be stopped when it is not in the '{ModelStatus.IN_SERVICE}' state."
+                )
+
+        # Validate values relative to current ASG. All conflicting request values have been validated as part of the
+        # AutoScalingInstanceConfig model validations, so those are not duplicated here.
+        if update_request.autoScalingInstanceConfig is not None:
+            current_asg = ddb_item.get("auto_scaling_group", "")
+            if not current_asg:
+                raise ValueError("Cannot update AutoScaling Config for model not hosted in LISA infrastructure.")
+            asg_config = update_request.autoScalingInstanceConfig
+            model_asg_resp = self._autoscaling.describe_auto_scaling_groups(AutoScalingGroupNames=[current_asg])
+            model_asg = model_asg_resp["AutoScalingGroups"][0]
+
+            # Desired capacity cannot be less than min or greater than max on deployed ASG
+            if asg_config.desiredCapacity is not None:
+                if asg_config.maxCapacity is None and asg_config.desiredCapacity > model_asg["MaxSize"]:
+                    raise ValueError(f"Desired capacity cannot exceed ASG max of {model_asg['MaxSize']}.")
+                if asg_config.minCapacity is None and asg_config.desiredCapacity < model_asg["MinSize"]:
+                    raise ValueError(f"Desired capacity cannot be less than ASG min of {model_asg['MinSize']}.")
+
+            # Min capacity can't be greater than the deployed ASG's max capacity
+            if asg_config.minCapacity is not None:
+                if asg_config.minCapacity > model_asg["MaxSize"]:
+                    raise ValueError(f"Min capacity cannot exceed ASG max of {model_asg['MaxSize']}.")
+                # Note: there is explicitly not a validation for minSize > existing desiredCapacity because
+                # setting the min will update desired capacity if needed if the request is valid.
+
+            # Max capacity can't be less than the deployed ASG's min capacity
+            if asg_config.maxCapacity is not None:
+                if asg_config.maxCapacity < model_asg["MinSize"]:
+                    raise ValueError(f"Max capacity cannot be less than ASG min of {model_asg['MinSize']}.")
+
+        # Post-validation. Send work to state machine.
 
         # package model ID and request payload into single payload for step functions
         state_machine_payload = {"model_id": model_id, "update_payload": update_request.model_dump()}

--- a/lambda/models/handler/update_model_handler.py
+++ b/lambda/models/handler/update_model_handler.py
@@ -78,14 +78,14 @@ class UpdateModelHandler(BaseApiHandler):
 
             # Min capacity can't be greater than the deployed ASG's max capacity
             if asg_config.minCapacity is not None:
-                if asg_config.minCapacity > model_asg["MaxSize"]:
+                if asg_config.maxCapacity is None and asg_config.minCapacity > model_asg["MaxSize"]:
                     raise ValueError(f"Min capacity cannot exceed ASG max of {model_asg['MaxSize']}.")
                 # Note: there is explicitly not a validation for minSize > existing desiredCapacity because
                 # setting the min will update desired capacity if needed if the request is valid.
 
             # Max capacity can't be less than the deployed ASG's min capacity
             if asg_config.maxCapacity is not None:
-                if asg_config.maxCapacity < model_asg["MinSize"]:
+                if asg_config.minCapacity is None and asg_config.maxCapacity < model_asg["MinSize"]:
                     raise ValueError(f"Max capacity cannot be less than ASG min of {model_asg['MinSize']}.")
 
         # Post-validation. Send work to state machine.

--- a/lambda/models/state_machine/update_model.py
+++ b/lambda/models/state_machine/update_model.py
@@ -14,9 +14,36 @@
 
 """Lambda handlers for UpdateModel state machine."""
 
-
+import logging
+import os
 from copy import deepcopy
+from datetime import datetime
 from typing import Any, Dict
+
+import boto3
+from models.clients.litellm_client import LiteLLMClient
+from models.domain_objects import ModelStatus
+from utilities.common_functions import get_cert_path, get_rest_api_container_endpoint, retry_config
+
+ddbResource = boto3.resource("dynamodb", region_name=os.environ["AWS_REGION"], config=retry_config)
+model_table = ddbResource.Table(os.environ["MODEL_TABLE_NAME"])
+autoscaling_client = boto3.client("autoscaling", region_name=os.environ["AWS_REGION"], config=retry_config)
+iam_client = boto3.client("iam", region_name=os.environ["AWS_REGION"], config=retry_config)
+secrets_manager = boto3.client("secretsmanager", region_name=os.environ["AWS_REGION"], config=retry_config)
+
+litellm_client = LiteLLMClient(
+    base_uri=get_rest_api_container_endpoint(),
+    verify=get_cert_path(iam_client),
+    headers={
+        "Authorization": secrets_manager.get_secret_value(
+            SecretId=os.environ.get("MANAGEMENT_KEY_NAME"), VersionStage="AWSCURRENT"
+        )["SecretString"],
+        "Content-Type": "application/json",
+    },
+)
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
 
 
 def handle_job_intake(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
@@ -34,7 +61,123 @@ def handle_job_intake(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     4. Commit changes to the database
     """
     output_dict = deepcopy(event)
-    output_dict["has_capacity_update"] = True
+
+    model_id = event["model_id"]
+    logger.info(f"Processing UpdateModel request for {model_id}")
+    model_key = {"model_id": model_id}
+    ddb_item = model_table.get_item(Key=model_key).get("Item", None)
+    if not ddb_item:
+        raise RuntimeError(f"Requested model '{model_id}' was not found in DynamoDB table.")
+
+    model_config = ddb_item["model_config"]  # all model creation params
+    model_status = ddb_item["model_status"]
+    model_asg = ddb_item["auto_scaling_group"]
+
+    output_dict["asg_name"] = model_asg  # add to event dict for convenience in later functions
+
+    # keep track of model wait time for model startup later. autoscaling marks instances as healthy even though the
+    # models have not fully stood up yet, so this is another protection to make sure that the model is actually
+    # running before users can run inference against it
+    output_dict["model_warmup_seconds"] = model_config["autoScalingConfig"]["metricConfig"]["estimatedInstanceWarmup"]
+
+    # Two checks for enabling: check that value was not omitted, then check that it was actually True.
+    is_activation_request = event["update_payload"].get("enabled", None) is not None
+    is_enable = event["update_payload"].get("enabled", False)
+    is_disable = is_activation_request and not is_enable
+
+    is_autoscaling_update = event["update_payload"].get("autoScalingInstanceConfig", None) is not None
+
+    if is_activation_request and is_autoscaling_update:
+        raise RuntimeError(
+            "Cannot request AutoScaling updates at the same time as an enable or disable operation. "
+            "Please perform those as two separate actions."
+        )
+
+    # set up DDB update expression to accumulate info as more options are processed
+    ddb_update_expression = "SET model_status = :ms, last_modified_date = :lm"
+    ddb_update_values = {
+        ":ms": ModelStatus.UPDATING,
+        ":lm": int(datetime.utcnow().timestamp()),
+    }
+
+    if is_activation_request:
+        logger.info(f"Detected enable or disable activity for {model_id}")
+        if is_enable:
+            previous_min = int(model_config["autoScalingConfig"]["minCapacity"])
+            previous_max = int(model_config["autoScalingConfig"]["maxCapacity"])
+            logger.info(f"Starting model {model_id} with min/max capacity of {previous_min}/{previous_max}.")
+            # Start ASG update with all 0/0/0 = min/max/desired to scale the model down to 0 instances
+            autoscaling_client.update_auto_scaling_group(
+                AutoScalingGroupName=model_asg,
+                MinSize=previous_min,
+                MaxSize=previous_max,
+            )
+        else:
+            # Only if we are deactivating a model, we remove from LiteLLM. It is already removed otherwise.
+            logger.info(f"Removing model {model_id} from LiteLLM because of 'disable' activity.")
+            # remove model from LiteLLM so users can't select a deactivating model
+            litellm_id = ddb_item["litellm_id"]
+            litellm_client.delete_model(identifier=litellm_id)
+            # remove ID from DDB as LiteLLM will no longer have this reference
+            ddb_update_expression += ", litellm_id = :li"
+            ddb_update_values[":li"] = None
+            # set status to Stopping instead of Updating to signify why it was removed from OpenAI endpoint
+            ddb_update_values[":ms"] = ModelStatus.STOPPING
+
+            # Start ASG update with all 0/0/0 = min/max/desired to scale the model down to 0 instances
+            autoscaling_client.update_auto_scaling_group(
+                AutoScalingGroupName=model_asg,
+                MinSize=0,
+                MaxSize=0,
+                DesiredCapacity=0,
+            )
+
+    if is_autoscaling_update:
+        asg_config = event["update_payload"]["autoScalingInstanceConfig"]
+        # Stage metadata updates regardless of immediate capacity changes or not
+        if minCapacity := asg_config.get("minCapacity", False):
+            model_config["autoScalingConfig"]["minCapacity"] = int(minCapacity)
+        if maxCapacity := asg_config.get("maxCapacity", False):
+            model_config["autoScalingConfig"]["maxCapacity"] = int(maxCapacity)
+        # If model is running, apply update immediately, else set metadata but don't apply until an 'enable' operation
+        if model_status == ModelStatus.IN_SERVICE:
+            asg_update_payload = {
+                "AutoScalingGroupName": model_asg,
+            }
+            if minCapacity:
+                asg_update_payload["MinSize"] = int(minCapacity)
+            if maxCapacity:
+                asg_update_payload["MaxSize"] = int(maxCapacity)
+            if desiredCapacity := asg_config.get("desiredCapacity", False):
+                asg_update_payload["DesiredCapacity"] = int(desiredCapacity)
+
+            # Start ASG update with known parameters. Because of model validations, at least one arg is guaranteed.
+            autoscaling_client.update_auto_scaling_group(**asg_update_payload)
+
+    # metadata updates
+    payload_model_type = event["update_payload"].get("modelType", None)
+    payload_streaming = event["update_payload"].get("streaming", None)
+    if payload_model_type or payload_streaming or is_autoscaling_update:
+        if payload_model_type:
+            logger.info(f"Setting type '{payload_model_type}' for model {model_id}")
+            model_config["modelType"] = payload_model_type
+        if payload_streaming:
+            logger.info(f"Setting streaming to {payload_streaming}' for model {model_id}")
+            model_config["streaming"] = payload_streaming
+
+        ddb_update_expression += ", model_config = :mc"
+        ddb_update_values[":mc"] = model_config
+
+    model_table.update_item(
+        Key=model_key,
+        UpdateExpression=ddb_update_expression,
+        ExpressionAttributeValues=ddb_update_values,
+    )
+
+    # We only need to poll for activation so that we know when to add the model back to LiteLLM
+    output_dict["has_capacity_update"] = is_enable
+    output_dict["is_disable"] = is_disable
+    output_dict["current_model_status"] = ddb_update_values[":ms"]  # for state machine debugging / visibility
     return output_dict
 
 
@@ -49,7 +192,23 @@ def handle_poll_capacity(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     3. If both the ASG and target group healthy instances match, then discontinue polling
     """
     output_dict = deepcopy(event)
-    output_dict["should_continue_capacity_polling"] = False
+    model_id = event["model_id"]
+    asg_name = event["asg_name"]
+    asg_info = autoscaling_client.describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name])["AutoScalingGroups"][0]
+    logger.info(asg_info)
+
+    desired_capacity = asg_info["DesiredCapacity"]
+    num_healthy_instances = sum([instance["HealthStatus"] == "Healthy" for instance in asg_info["Instances"]])
+
+    remaining_polls = event.get("remaining_capacity_polls", 30) - 1
+    if remaining_polls <= 0:
+        output_dict["polling_error"] = f"Model {model_id} did not spin up healthy instances in expected amount of time."
+
+    should_continue_polling = desired_capacity != num_healthy_instances and remaining_polls > 0
+
+    output_dict["should_continue_capacity_polling"] = should_continue_polling
+    event["remaining_capacity_polls"] = remaining_polls
+
     return output_dict
 
 
@@ -61,4 +220,55 @@ def handle_finish_update(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     2. If the model was disabled from the InService state, set status to Stopped
     3. Commit changes to DDB
     """
-    return event
+    output_dict = deepcopy(event)
+
+    model_id = event["model_id"]
+    model_key = {"model_id": model_id}
+    asg_name = event["asg_name"]
+    ddb_item = model_table.get_item(Key=model_key)["Item"]
+    model_url = ddb_item["model_url"]
+    litellm_params = {
+        "model": f"openai/{ddb_item['model_config']['modelName']}",
+        "api_base": model_url,
+        "api_key": "ignored",  # pragma: allowlist-secret not a real key, but needed for LiteLLM to be happy
+    }
+
+    ddb_update_expression = "SET model_status = :ms, last_modified_date = :lm"
+    ddb_update_values: Dict[str, Any] = {
+        ":lm": int(datetime.utcnow().timestamp()),
+    }
+
+    if polling_error := event.get("polling_error", None):
+        logger.error(f"{polling_error} Setting ASG back to 0 instances.")
+        autoscaling_client.update_auto_scaling_group(
+            AutoScalingGroupName=asg_name,
+            MinSize=0,
+            MaxSize=0,
+            DesiredCapacity=0,
+        )
+        ddb_update_values[":ms"] = ModelStatus.STOPPED
+    elif event["is_disable"]:
+        ddb_update_values[":ms"] = ModelStatus.STOPPED
+    elif event["has_capacity_update"]:
+        ddb_update_values[":ms"] = ModelStatus.IN_SERVICE
+        litellm_response = litellm_client.add_model(
+            model_name=model_id,
+            litellm_params=litellm_params,
+        )
+
+        litellm_id = litellm_response["model_info"]["id"]
+        output_dict["litellm_id"] = litellm_id
+
+        ddb_update_expression += ", litellm_id = :lid"
+        ddb_update_values[":lid"] = litellm_id
+    else:  # No polling error, not disabled, and no capacity update means this was a metadata update on a stopped model
+        ddb_update_values[":ms"] = ModelStatus.STOPPED
+    model_table.update_item(
+        Key=model_key,
+        UpdateExpression=ddb_update_expression,
+        ExpressionAttributeValues=ddb_update_values,
+    )
+
+    output_dict["current_model_status"] = ddb_update_values[":ms"]
+
+    return output_dict

--- a/lib/models/model-api.ts
+++ b/lib/models/model-api.ts
@@ -201,6 +201,14 @@ export class ModelsApi extends Construct {
                             ],
                             resources: [`${Secret.fromSecretNameV2(this, 'ManagementKeySecret', managementKeyName).secretArn}-??????`],  // question marks required to resolve the ARN correctly
                         }),
+                        new PolicyStatement({
+                            effect: Effect.ALLOW,
+                            actions: [
+                                'autoscaling:DescribeAutoScalingGroups',
+                                'autoscaling:UpdateAutoScalingGroup',
+                            ],
+                            resources: ['*'],  // We do not know the ASG names in advance
+                        }),
                     ]
                 }),
             }

--- a/lib/models/model-api.ts
+++ b/lib/models/model-api.ts
@@ -371,6 +371,13 @@ export class ModelsApi extends Construct {
                         `${modelTable.tableArn}/*`
                     ],
                 }),
+                new PolicyStatement({
+                    effect: Effect.ALLOW,
+                    actions: [
+                        'autoscaling:DescribeAutoScalingGroups',
+                    ],
+                    resources: ['*'],  // we do not know ASG names in advance
+                }),
             ]
         });
         lambdaFunction.role!.attachInlinePolicy(workflowPermissions);


### PR DESCRIPTION
Creates UpdateModel state machine implementation with frontend handler validations to force as many synchronous validations as possible before actually hitting the async workflow, which is a much user friendly experience, and easier to debug.

Model only polls for capacity between stopped and in-service states as the model is still functional in other scenarios. When starting a model, the state machine first waits for the desired number of instances to spin up, THEN it waits for the user-defined warmup time before adding the model to LiteLLM, that way customers can't try to make inference requires prior to the models actually spinning up. the model instances pop up healthy before the models are fully initialized, so this wait is necessary to ensure that the models are working before we open them back up to requests.

known issues:
* UI does not seem to send the correct payload for updating ASG configuration to the backend
    * UI is sending autoScalingConfig instead of autoScalingUpdateConfig
* UI cannot update from embedding to textgen or from non-streaming to streaming
* UI does not allow a user to start a stopped model without refreshing the page first if the model was stopped in that browser session


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
