### PR TITLE
Update Model UI fixes

### DIFF
--- a/lib/user-interface/react/src/components/chatbot/Chat.tsx
+++ b/lib/user-interface/react/src/components/chatbot/Chat.tsx
@@ -61,7 +61,7 @@ import RagControls, { RagConfig } from './RagOptions';
 import { ContextUploadModal, RagUploadModal } from './FileUploadModals';
 import { ChatOpenAI } from '@langchain/openai';
 import { useGetAllModelsQuery } from '../../shared/reducers/model-management.reducer';
-import { IModel, ModelType } from '../../shared/model/model-management.model';
+import { IModel, ModelStatus, ModelType } from '../../shared/model/model-management.model';
 
 export default function Chat ({ sessionId }) {
     const [userPrompt, setUserPrompt] = useState('');
@@ -79,7 +79,7 @@ export default function Chat ({ sessionId }) {
 
     const { data: allModels, isFetching: isFetchingModels } = useGetAllModelsQuery(undefined, {selectFromResult: (state) => ({
         isFetching: state.isFetching,
-        data: (state.data || []).filter((model) => model.modelType === ModelType.textgen),
+        data: (state.data || []).filter((model) => model.modelType === ModelType.textgen && model.status === ModelStatus.InService),
     })});
     const modelsOptions = useMemo(() => allModels.map((model) => ({ label: model.modelId, value: model.modelId })), [allModels]);
     const [modelConfig, setModelConfig] = useState<ModelConfig>();

--- a/lib/user-interface/react/src/components/chatbot/RagOptions.tsx
+++ b/lib/user-interface/react/src/components/chatbot/RagOptions.tsx
@@ -19,7 +19,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { listRagRepositories } from '../utils';
 import { AuthContextProps } from 'react-oidc-context';
 import { useGetAllModelsQuery } from '../../shared/reducers/model-management.reducer';
-import { IModel, ModelType } from '../../shared/model/model-management.model';
+import { IModel, ModelStatus, ModelType } from '../../shared/model/model-management.model';
 
 export type RagConfig = {
     embeddingModel: IModel;
@@ -42,7 +42,7 @@ export default function RagControls ({ auth, isRunning, setUseRag, setRagConfig 
     const [repositoryMap, setRepositoryMap] = useState(new Map());
     const { data: allModels, isFetching: isFetchingModels } = useGetAllModelsQuery(undefined, {selectFromResult: (state) => ({
         isFetching: state.isFetching,
-        data: (state.data || []).filter((model) => model.modelType === ModelType.embedding),
+        data: (state.data || []).filter((model) => model.modelType === ModelType.embedding && model.status === ModelStatus.InService),
     })});
     const embeddingOptions = useMemo(() => {
         return allModels?.map((model) => ({value: model.modelId})) || [];

--- a/lib/user-interface/react/src/components/model-management/ModelManagementActions.tsx
+++ b/lib/user-interface/react/src/components/model-management/ModelManagementActions.tsx
@@ -100,6 +100,8 @@ function ModelActionButton (dispatch: ThunkDispatch<any, any, Action>, notificat
         items.push({
             text: 'Delete',
             id: 'deleteModel',
+            disabled: (![ModelStatus.InService, ModelStatus.Stopped, ModelStatus.Failed].includes(selectedModel.status)),
+            disabledReason: selectedModel.status !== ModelStatus.InService ? 'Unable to delete a model that is in a pending state' : '',
         });
         items.push({
             text: 'Start',
@@ -116,8 +118,8 @@ function ModelActionButton (dispatch: ThunkDispatch<any, any, Action>, notificat
         items.push({
             text: 'Update',
             id: 'editModel',
-            disabled: !selectedModel,
-            disabledReason: 'No model selected.',
+            disabled: (![ModelStatus.InService, ModelStatus.Stopped, ModelStatus.Failed].includes(selectedModel.status)),
+            disabledReason: selectedModel.status !== ModelStatus.InService ? 'Unable to delete a model that is in a pending state' : '',
         });
     }
 

--- a/lib/user-interface/react/src/components/model-management/ModelManagementActions.tsx
+++ b/lib/user-interface/react/src/components/model-management/ModelManagementActions.tsx
@@ -100,8 +100,8 @@ function ModelActionButton (dispatch: ThunkDispatch<any, any, Action>, notificat
         items.push({
             text: 'Delete',
             id: 'deleteModel',
-            disabled: (![ModelStatus.InService, ModelStatus.Stopped, ModelStatus.Failed].includes(selectedModel.status)),
-            disabledReason: selectedModel.status !== ModelStatus.InService ? 'Unable to delete a model that is in a pending state' : '',
+            disabled: ![ModelStatus.InService, ModelStatus.Stopped, ModelStatus.Failed].includes(selectedModel.status),
+            disabledReason: ![ModelStatus.InService, ModelStatus.Stopped, ModelStatus.Failed].includes(selectedModel.status) ? 'Unable to delete a model that is in a pending state' : '',
         });
         items.push({
             text: 'Start',
@@ -118,8 +118,8 @@ function ModelActionButton (dispatch: ThunkDispatch<any, any, Action>, notificat
         items.push({
             text: 'Update',
             id: 'editModel',
-            disabled: (![ModelStatus.InService, ModelStatus.Stopped, ModelStatus.Failed].includes(selectedModel.status)),
-            disabledReason: selectedModel.status !== ModelStatus.InService ? 'Unable to delete a model that is in a pending state' : '',
+            disabled: ![ModelStatus.InService, ModelStatus.Stopped, ModelStatus.Failed].includes(selectedModel.status),
+            disabledReason: ![ModelStatus.InService, ModelStatus.Stopped, ModelStatus.Failed].includes(selectedModel.status) ? 'Unable to delete a model that is in a pending state' : '',
         });
     }
 

--- a/lib/user-interface/react/src/components/model-management/ModelManagementActions.tsx
+++ b/lib/user-interface/react/src/components/model-management/ModelManagementActions.tsx
@@ -49,7 +49,10 @@ function ModelActions (props: ModelActionProps): ReactElement {
                 New Model
             </Button>
             <Button
-                onClick={() => dispatch(modelManagementApi.util.invalidateTags(['models']))}
+                onClick={() => {
+                    props.setSelectedItems([]);
+                    dispatch(modelManagementApi.util.invalidateTags(['models']));
+                }}
                 ariaLabel={'Refresh models cards'}
             >
                 <Icon name='refresh' />

--- a/lib/user-interface/react/src/components/model-management/ModelManagementUtils.tsx
+++ b/lib/user-interface/react/src/components/model-management/ModelManagementUtils.tsx
@@ -25,6 +25,7 @@ export const MODEL_STATUS_LOOKUP: EnumDictionary<ModelStatus, StatusIndicatorPro
     [ModelStatus.Creating]: 'in-progress',
     [ModelStatus.InService]: 'success',
     [ModelStatus.Stopping]: 'in-progress',
+    [ModelStatus.Starting]: 'in-progress',
     [ModelStatus.Stopped]: 'stopped',
     [ModelStatus.Updating]: 'in-progress',
     [ModelStatus.Deleting]: 'in-progress',

--- a/lib/user-interface/react/src/components/model-management/create-model/CreateModelModal.tsx
+++ b/lib/user-interface/react/src/components/model-management/create-model/CreateModelModal.tsx
@@ -16,7 +16,11 @@
 
 import _ from 'lodash';
 import { Modal, Wizard } from '@cloudscape-design/components';
-import { IModel, IModelRequest, ModelRequestSchema } from '../../../shared/model/model-management.model';
+import {
+    IModel,
+    IModelRequest,
+    ModelRequestSchema
+} from '../../../shared/model/model-management.model';
 import { ReactElement, useEffect, useMemo } from 'react';
 import { scrollToInvalid, useValidationReducer } from '../../../shared/validation';
 import { BaseModelConfig } from './BaseModelConfig';
@@ -179,7 +183,8 @@ export function CreateModelModal (props: CreateModelModalProps) : ReactElement {
                 'enabled',
                 'modelType',
                 'autoScalingConfig.minCapacity',
-                'autoScalingConfig.maxCapacity'
+                'autoScalingConfig.maxCapacity',
+                'autoScalingConfig.desiredCapacity'
             ]), (value: any, key: string) => {
                 if (key === 'autoScalingConfig') return 'autoScalingInstanceConfig';
                 return key;

--- a/lib/user-interface/react/src/components/model-management/create-model/CreateModelModal.tsx
+++ b/lib/user-interface/react/src/components/model-management/create-model/CreateModelModal.tsx
@@ -173,14 +173,17 @@ export function CreateModelModal (props: CreateModelModalProps) : ReactElement {
             createModelMutation(toSubmit);
         } else if (isValid && props.isEdit) {
             // pick only the values we care about
-            updateModelMutation(_.pick({...changesDiff, modelId: props.selectedItems[0].modelId}, [
+            updateModelMutation(_.mapKeys(_.pick({...changesDiff, modelId: props.selectedItems[0].modelId}, [
                 'modelId',
                 'streaming',
                 'enabled',
                 'modelType',
                 'autoScalingConfig.minCapacity',
                 'autoScalingConfig.maxCapacity'
-            ]));
+            ]), (value: any, key: string) => {
+                if (key === 'autoScalingConfig') return 'autoScalingInstanceConfig';
+                return key;
+            }));
         }
     }
 

--- a/lib/user-interface/react/src/shared/model/model-management.model.ts
+++ b/lib/user-interface/react/src/shared/model/model-management.model.ts
@@ -20,6 +20,7 @@ export enum ModelStatus {
     Creating = 'Creating',
     InService = 'InService',
     Stopping = 'Stopping',
+    Starting = 'Starting',
     Stopped = 'Stopped',
     Updating = 'Updating',
     Deleting = 'Deleting',
@@ -88,6 +89,7 @@ export type IContainerConfig = {
 };
 
 export type IModel = {
+    status?: ModelStatus;
     modelId: string;
     modelName: string;
     modelUrl: string;
@@ -123,7 +125,7 @@ export type IModelUpdateRequest = {
     streaming?: boolean;
     enabled?: boolean;
     modelType?: ModelType;
-    autoScalingConfig?: IAutoScalingConfig;
+    autoScalingInstanceConfig?: IAutoScalingConfig;
 };
 
 const containerHealthCheckConfigSchema = z.object({


### PR DESCRIPTION
*Description of changes:*

- Stopped models still show in the UI, which will cause 5xx issues because the model isn't in LiteLLM
- Cannot set a model to streaming or textgen from the UI. The payload doesn't include them
- Payload for UpdateModel needs to be called autoScalingInstanceConfig instead of autoScalingConfig
- Models that were just stopped in the UI cannot be started unless I refresh my page, even after the model shows as Stopped

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
