### PR TITLE
Fix: add inferenceContainer to response payload

### DIFF
--- a/lambda/models/domain_objects.py
+++ b/lambda/models/domain_objects.py
@@ -138,8 +138,9 @@ class LISAModel(BaseModel):
 
     autoScalingConfig: Optional[AutoScalingConfig] = None
     containerConfig: Optional[ContainerConfig] = None
-    loadBalancerConfig: Optional[LoadBalancerConfig] = None
+    inferenceContainer: Optional[InferenceContainer] = None
     instanceType: Optional[Annotated[str, AfterValidator(validate_instance_type)]] = None
+    loadBalancerConfig: Optional[LoadBalancerConfig] = None
     modelId: str
     modelName: str
     modelType: ModelType


### PR DESCRIPTION
Fixes a bug where the UI could not progress if the inference container was not provided in the GetModel response payload. The data already exists in DDB, and the method to convert the blob back into a LISA model was already looking at (but ignoring) the field, so just adding to the model is sufficient for the field to show in response payloads now.

Example from inspecting network browser while listing models: (main line of note is `"inferenceContainer": "vllm",`)

```json
{
  "models": [
    {
      "autoScalingConfig": {
        "minCapacity": 1,
        "maxCapacity": 1,
        "cooldown": 420,
        "defaultInstanceWarmup": 180,
        "metricConfig": {
          "albMetricName": "RequestCountPerTarget",
          "targetValue": 30,
          "duration": 60,
          "estimatedInstanceWarmup": 330
        }
      },
      "containerConfig": {
        "baseImage": {
          "baseImage": "vllm/vllm-openai:latest",
          "path": "vllm",
          "type": "asset"
        },
        "sharedMemorySize": 2048,
        "healthCheckConfig": {
          "command": [
            "CMD-SHELL",
            "exit 0"
          ],
          "interval": 10,
          "startPeriod": 30,
          "timeout": 5,
          "retries": 3
        },
        "environment": {
          "MAX_TOTAL_TOKENS": "2048",
          "MAX_CONCURRENT_REQUESTS": "128",
          "MAX_INPUT_LENGTH": "1024"
        }
      },
      "inferenceContainer": "vllm",
      "instanceType": "g5.xlarge",
      "loadBalancerConfig": {
        "healthCheckConfig": {
          "path": "/health",
          "interval": 60,
          "timeout": 30,
          "healthyThresholdCount": 2,
          "unhealthyThresholdCount": 10
        }
      },
      "modelId": "mistral-vllm",
      "modelName": "mistralai/Mistral-7B-Instruct-v0.2",
      "modelType": "textgen",
      "modelUrl": null,
      "status": "Creating",
      "streaming": false
    }
  ]
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
