### PR TITLE
Bug: Fixed CDK stack dependency for secret management key

### DIFF
--- a/lib/serve/index.ts
+++ b/lib/serve/index.ts
@@ -17,7 +17,7 @@
 // LISA-serve Stack.
 import path from 'path';
 
-import { Stack, StackProps } from 'aws-cdk-lib';
+import { RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
 import { AttributeType, BillingMode, Table, TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
 import { Peer, Port, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import { Credentials, DatabaseInstance, DatabaseInstanceEngine } from 'aws-cdk-lib/aws-rds';
@@ -91,6 +91,7 @@ export class LisaServeApplicationStack extends Stack {
                 excludePunctuation: true,
                 passwordLength: 16
             },
+            removalPolicy: RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE
         });
 
         // const commonLambdaLayer = LayerVersion.fromLayerVersionArn(

--- a/lib/stages.ts
+++ b/lib/stages.ts
@@ -145,6 +145,7 @@ export class LisaServeApplicationStage extends Stage {
             vpc: networkingStack.vpc.vpc,
         });
         apiBaseStack.addDependency(coreStack);
+        apiBaseStack.addDependency(serveStack);
         stacks.push(apiBaseStack);
 
         const apiDeploymentStack = new LisaApiDeploymentStack(this, 'LisaApiDeployment', {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
With the latest changes to pull the secret management key into the APIGW Authorizer we now need to make sure that the Serve stack is created before API Base stack or else brand new deployments can fail. This change addresses that issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
