### PR TITLE
Bug: Removed superfluous retain policy for management secret

### DIFF
--- a/lib/serve/index.ts
+++ b/lib/serve/index.ts
@@ -17,7 +17,7 @@
 // LISA-serve Stack.
 import path from 'path';
 
-import { RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { AttributeType, BillingMode, Table, TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
 import { Peer, Port, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import { Credentials, DatabaseInstance, DatabaseInstanceEngine } from 'aws-cdk-lib/aws-rds';
@@ -91,7 +91,6 @@ export class LisaServeApplicationStack extends Stack {
                 excludePunctuation: true,
                 passwordLength: 16
             },
-            removalPolicy: RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE
         });
 
         // const commonLambdaLayer = LayerVersion.fromLayerVersionArn(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A previous left in an unnecessary retain policy that would leave old secrets around. This fixes that issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
