### PR TITLE
non lisa model update

### DIFF
--- a/lib/user-interface/react/src/components/model-management/create-model/CreateModelModal.tsx
+++ b/lib/user-interface/react/src/components/model-management/create-model/CreateModelModal.tsx
@@ -197,7 +197,7 @@ export function CreateModelModal (props: CreateModelModalProps) : ReactElement {
 
     useEffect(() => {
         const parsedValue = _.mergeWith({}, initialForm, props.selectedItems[0], (a: IModelRequest, b: IModelRequest) => b === null ? a : undefined);
-        if(parsedValue.inferenceContainer === null){
+        if (parsedValue.inferenceContainer === null){
             delete parsedValue.inferenceContainer;
         }
         if (props.isEdit) {

--- a/lib/user-interface/react/src/components/model-management/create-model/CreateModelModal.tsx
+++ b/lib/user-interface/react/src/components/model-management/create-model/CreateModelModal.tsx
@@ -197,6 +197,9 @@ export function CreateModelModal (props: CreateModelModalProps) : ReactElement {
 
     useEffect(() => {
         const parsedValue = _.mergeWith({}, initialForm, props.selectedItems[0], (a: IModelRequest, b: IModelRequest) => b === null ? a : undefined);
+        if(parsedValue.inferenceContainer === null){
+            delete parsedValue.inferenceContainer;
+        }
         if (props.isEdit) {
             setState({
                 ...state,


### PR DESCRIPTION
Adding inference config in the model response caused non-LISA hosted models to not be undateable due to null value. This was causing the form to be in an error state. Parsed out the field if value is null when submitting the value to the form state.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
