### PR TITLE
Make it so LISA hosted models prop doesn't show up in diff calculations

### DIFF
--- a/lib/user-interface/react/src/components/model-management/create-model/CreateModelModal.tsx
+++ b/lib/user-interface/react/src/components/model-management/create-model/CreateModelModal.tsx
@@ -168,7 +168,11 @@ export function CreateModelModal (props: CreateModelModalProps) : ReactElement {
     }
 
     const changesDiff = useMemo(() => {
-        return props.isEdit ? getJsonDifference(props.selectedItems[0], toSubmit) : getJsonDifference({}, toSubmit);
+        return props.isEdit ? getJsonDifference({
+            ...props.selectedItems[0],
+            lisaHostedModel: Boolean(props.selectedItems[0].containerConfig || props.selectedItems[0].autoScalingConfig || props.selectedItems[0].loadBalancerConfig)
+        }, toSubmit) :
+            getJsonDifference({}, toSubmit);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [toSubmit, initialForm, props.isEdit]);
 


### PR DESCRIPTION


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
