### PR TITLE
Fix deployment issues with S3, permissions boundary, API deployment

### DIFF
--- a/lib/rag/index.ts
+++ b/lib/rag/index.ts
@@ -79,7 +79,7 @@ export class LisaRagStack extends Stack {
             StringParameter.valueForStringParameter(this, `${config.deploymentPrefix}/layerVersion/common`),
         );
 
-        const bucketName = `${config.deploymentName}-lisaragdocs-${config.accountNumber}`;
+        const bucketName = `${config.deploymentName}-lisaragdocs-${config.accountNumber}`.toLowerCase();
         const bucket = new Bucket(this, createCdkId(['LISA', 'RAG', config.deploymentName, config.deploymentStage]), {
             bucketName,
             cors: [

--- a/lib/stages.ts
+++ b/lib/stages.ts
@@ -150,6 +150,8 @@ export class LisaServeApplicationStage extends Stage {
 
         const apiDeploymentStack = new LisaApiDeploymentStack(this, 'LisaApiDeployment', {
             ...baseStackProps,
+            description: `LISA-api-deployment: ${config.deploymentName}-${config.deploymentStage}`,
+            stackName: createCdkId([config.deploymentName, config.appName, 'api-deployment', config.deploymentStage]),
             restApiId: apiBaseStack.restApiId,
         });
         apiDeploymentStack.addDependency(apiBaseStack);

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "devDependencies": {
         "@aws-cdk/aws-lambda-python-alpha": "2.125.0-alpha.0",
         "@aws-sdk/client-iam": "^3.490.0",
-        "@cdklabs/cdk-enterprise-iac": "^0.0.400",
+        "@cdklabs/cdk-enterprise-iac": "^0.0.512",
         "@stylistic/eslint-plugin": "^2.7.2",
         "@types/jest": "^29.5.12",
         "@types/js-yaml": "^4.0.5",
@@ -1241,13 +1241,14 @@
       "dev": true
     },
     "node_modules/@cdklabs/cdk-enterprise-iac": {
-      "version": "0.0.400",
-      "resolved": "https://registry.npmjs.org/@cdklabs/cdk-enterprise-iac/-/cdk-enterprise-iac-0.0.400.tgz",
-      "integrity": "sha512-K3NO0k6/Rvf4fnjXNf35YtOgSEUb37sptFtkhu8xLti948G3fNK5tlRgrcDLulqZT4Sfuxtlql5AnDyMV4BkDQ==",
+      "version": "0.0.512",
+      "resolved": "https://registry.npmjs.org/@cdklabs/cdk-enterprise-iac/-/cdk-enterprise-iac-0.0.512.tgz",
+      "integrity": "sha512-1jlONxgrZwBocGOarx3NZxvniXRBkHj9ws+eqaJ4hQO+4Pb9ah5U/C6Oc87Cu3kvSiI+cf1rhbHEqtymjG2MMQ==",
       "bundleDependencies": [
         "aws-sdk"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "aws-sdk": "^2.1230.0"
       },
@@ -1272,7 +1273,7 @@
       }
     },
     "node_modules/@cdklabs/cdk-enterprise-iac/node_modules/aws-sdk": {
-      "version": "2.1576.0",
+      "version": "2.1687.0",
       "dev": true,
       "hasInstallScript": true,
       "inBundle": true,
@@ -1718,7 +1719,7 @@
       }
     },
     "node_modules/@cdklabs/cdk-enterprise-iac/node_modules/xml2js/node_modules/sax": {
-      "version": "1.3.0",
+      "version": "1.4.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@aws-cdk/aws-lambda-python-alpha": "2.125.0-alpha.0",
     "@aws-sdk/client-iam": "^3.490.0",
-    "@cdklabs/cdk-enterprise-iac": "^0.0.400",
+    "@cdklabs/cdk-enterprise-iac": "^0.0.512",
     "@stylistic/eslint-plugin": "^2.7.2",
     "@types/jest": "^29.5.12",
     "@types/js-yaml": "^4.0.5",


### PR DESCRIPTION
This set of changes allows customers to use capitalized deployment names by not failing on S3 Bucket naming in the RAG stack. This set of changes updates the API Deployment stack so that it follows the same naming convention as other stacks, enabling multiple deployments to the same region and account. Last, this version bumps to the CDK Labs IAC package so that we benefit from its name uniqueness fixes.

This will create a new "api-deployment" stack, and then the old LisaApiDeployment stack can be safely removed. This now enables deploying multiple "deployments" in the same account and region with isolated resources.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
