### PR TITLE
Fixing set revision for linux based system

### DIFF
--- a/lib/user-interface/react/scripts/set-revision-info.mjs
+++ b/lib/user-interface/react/scripts/set-revision-info.mjs
@@ -15,9 +15,8 @@
 */
 import getRepoInfo from 'git-repo-info';
 import fs from 'fs';
-import packageFile from '../package.json' with { type: 'json' };
 
-
+const packageFile = JSON.parse(fs.readFileSync('./package.json', 'utf-8'));
 const info = getRepoInfo();
 console.log('Git Revision Info:');
 console.log('Version:', packageFile.version);


### PR DESCRIPTION
Revision info wasn't working on my cloud desktop, went with an approach that will work on both systems.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
