### PR TITLE
Move ECS Policy into SSM param for model deployments

### DIFF
--- a/ecs_model_deployer/src/lib/ecsCluster.ts
+++ b/ecs_model_deployer/src/lib/ecsCluster.ts
@@ -181,7 +181,11 @@ export class ECSCluster extends Construct {
             environment.SSL_CERT_FILE = config.certificateAuthorityBundle;
         }
 
-        const taskPolicy = ManagedPolicy.fromManagedPolicyName(this, createCdkId([(config.permissionsBoundaryAspect?.policyPrefix ?? '') + config.deploymentName, 'ECSPolicy']), createCdkId([(config.permissionsBoundaryAspect?.policyPrefix ?? '') + config.deploymentName, 'ECSPolicy']));
+        const taskPolicyId = createCdkId([config.deploymentName, 'ECSPolicy']);
+        const taskPolicyStringParam = StringParameter.fromStringParameterName(this, 'taskPolicyStringParam',
+            `${config.deploymentPrefix}/policies/${taskPolicyId}`
+        );
+        const taskPolicy = ManagedPolicy.fromManagedPolicyArn(this, taskPolicyId, taskPolicyStringParam.stringValue);
         const role_id = ecsConfig.identifier;
         const roleName = createCdkId([config.deploymentName, role_id, 'Role']);
         const taskRole = new Role(this, createCdkId([role_id, 'Role']), {

--- a/lib/iam_stack.ts
+++ b/lib/iam_stack.ts
@@ -105,7 +105,8 @@ export class LisaServeIAMStack extends Stack {
      * specific roles
      */
         const statements = getIamPolicyStatements(config, 'ecs');
-        const taskPolicy = new ManagedPolicy(this, createCdkId([config.deploymentName, 'ECSPolicy']), {
+        const taskPolicyId = createCdkId([config.deploymentName, 'ECSPolicy']);
+        const taskPolicy = new ManagedPolicy(this, taskPolicyId, {
             managedPolicyName: createCdkId([config.deploymentName, 'ECSPolicy']),
             statements,
         });
@@ -115,6 +116,13 @@ export class LisaServeIAMStack extends Stack {
                 type: ECSTaskType.API,
             },
         ];
+
+        new StringParameter(this, createCdkId(['ECSPolicy', 'SP']), {
+            parameterName: `${config.deploymentPrefix}/policies/${taskPolicyId}`,
+            stringValue: taskPolicy.managedPolicyArn,
+            description: `Managed Policy ARN for LISA ${taskPolicyId}`,
+        });
+
         ecsRoles.forEach((role) => {
             const roleName = createCdkId([config.deploymentName, role.id, 'Role']);
             const taskRole = new Role(this, createCdkId([role.id, 'Role']), {


### PR DESCRIPTION
This change fixes an issue with deploying models after the initial deployment when using the permissions boundary aspect. The new version adds the disambiguation string regardless of whether or not the policy already has a defined name, so we can't just "know" what the policy will be anymore. This change puts the policy ARN into a String Parameter so that we can refer to it in later stacks. We can "know" the string param name, which lets us get the ARN from its value for use in the model stacks.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
