### PR TITLE
Remove "path" from API model

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ curl -s -H "Authorization: Bearer <admin_token>" -X GET https://<apigw_endpoint>
         }
       },
       "containerConfig": {
-        "baseImage": {
+        "image": {
           "baseImage": "vllm/vllm-openai:v0.5.0",
           "path": "vllm",
           "type": "asset"
@@ -660,9 +660,8 @@ curl -s -H "Authorization: Bearer <admin_token>" -X GET https://<apigw_endpoint>
 
 LISA provides the `/models` endpoint for creating both ECS and LiteLLM-hosted models. Depending on the request payload, infrastructure will be created or bypassed (e.g., for LiteLLM-only models).
 
-This API accepts the same model definition parameters that were accepted in the V2 model definitions within the config.yaml file with one notable difference: the `containerConfig.baseImage.path` field is
-now a path relative to the `lib/serve/ecs-model` directory, instead of from its original path relative to the repository root. This means that if the path used to be `lib/serve/ecs-model/textgen/tgi`, then
-it will now be `textgen/tgi` for the CreateModel API. For vLLM models, the `path` will be `vllm`, and for TEI, it will be `embedding/tei`.
+This API accepts the same model definition parameters that were accepted in the V2 model definitions within the config.yaml file with one notable difference: the `containerConfig.image.path` field is
+now omitted because it corresponded with the `inferenceContainer` selection. As a convenience, this path s no longer required.
 
 #### Request Example:
 
@@ -681,7 +680,7 @@ POST https://<apigw_endpoint>/models
   "instanceType": "g5.xlarge",
   "streaming": true,
   "containerConfig": {
-    "baseImage": {
+    "image": {
       "baseImage": "vllm/vllm-openai:v0.5.0",
       "path": "vllm",
       "type": "asset"

--- a/lambda/models/domain_objects.py
+++ b/lambda/models/domain_objects.py
@@ -120,14 +120,13 @@ class ContainerConfigImage(BaseModel):
     """Image image configuration for a container."""
 
     baseImage: str
-    path: str
     type: str
 
 
 class ContainerConfig(BaseModel):
     """Container configuration."""
 
-    baseImage: ContainerConfigImage
+    image: ContainerConfigImage
     sharedMemorySize: int
     healthCheckConfig: ContainerHealthCheckConfig
     environment: dict[str, str]

--- a/lib/user-interface/react/src/components/model-management/create-model/ContainerConfig.tsx
+++ b/lib/user-interface/react/src/components/model-management/create-model/ContainerConfig.tsx
@@ -28,7 +28,7 @@ export function ContainerConfig (props: FormProps<IContainerConfig>) : ReactElem
         <SpaceBetween size={'s'}>
             <Container
                 header={
-                    <Header variant='h2'>Memory Size & Base Image Config</Header>
+                    <Header variant='h2'>Memory Size & Image Config</Header>
                 }
             >
                 <SpaceBetween size={'s'}>
@@ -40,14 +40,14 @@ export function ContainerConfig (props: FormProps<IContainerConfig>) : ReactElem
                             <span style={{lineHeight: '2.5em', paddingLeft: '0.5em'}}>MiB</span>
                         </Grid>
                     </FormField>
-                    <FormField label='Base Image' errorText={props.formErrors?.containerConfig?.baseImage?.baseImage}>
-                        <Input value={props.item.baseImage.baseImage} inputMode='text' onBlur={() => props.touchFields(['containerConfig.baseImage.baseImage'])} onChange={({ detail }) => {
-                            props.setFields({ 'containerConfig.baseImage.baseImage': detail.value });
+                    <FormField label='Base Image' errorText={props.formErrors?.containerConfig?.image?.baseImage}>
+                        <Input value={props.item.image.baseImage} inputMode='text' onBlur={() => props.touchFields(['containerConfig.image.baseImage'])} onChange={({ detail }) => {
+                            props.setFields({ 'containerConfig.image.baseImage': detail.value });
                         }}/>
                     </FormField>
-                    <FormField label='Type' errorText={props.formErrors?.containerConfig?.baseImage?.type}>
-                        <Input value={props.item.baseImage.type} inputMode='text' onBlur={() => props.touchFields(['containerConfig.baseImage.type'])} onChange={({ detail }) => {
-                            props.setFields({ 'containerConfig.baseImage.type': detail.value });
+                    <FormField label='Type' errorText={props.formErrors?.containerConfig?.image?.type}>
+                        <Input value={props.item.image.type} inputMode='text' onBlur={() => props.touchFields(['containerConfig.image.type'])} onChange={({ detail }) => {
+                            props.setFields({ 'containerConfig.image.type': detail.value });
                         }}/>
                     </FormField>
                 </SpaceBetween>

--- a/lib/user-interface/react/src/components/model-management/create-model/ContainerConfig.tsx
+++ b/lib/user-interface/react/src/components/model-management/create-model/ContainerConfig.tsx
@@ -45,11 +45,6 @@ export function ContainerConfig (props: FormProps<IContainerConfig>) : ReactElem
                             props.setFields({ 'containerConfig.baseImage.baseImage': detail.value });
                         }}/>
                     </FormField>
-                    <FormField label='Path' errorText={props.formErrors?.containerConfig?.baseImage?.path}>
-                        <Input value={props.item.baseImage.path} inputMode='text' onBlur={() => props.touchFields(['containerConfig.baseImage.path'])} onChange={({ detail }) => {
-                            props.setFields({ 'containerConfig.baseImage.path': detail.value });
-                        }}/>
-                    </FormField>
                     <FormField label='Type' errorText={props.formErrors?.containerConfig?.baseImage?.type}>
                         <Input value={props.item.baseImage.type} inputMode='text' onBlur={() => props.touchFields(['containerConfig.baseImage.type'])} onChange={({ detail }) => {
                             props.setFields({ 'containerConfig.baseImage.type': detail.value });

--- a/lib/user-interface/react/src/shared/model/model-management.model.ts
+++ b/lib/user-interface/react/src/shared/model/model-management.model.ts
@@ -81,7 +81,7 @@ export type IAutoScalingConfig = {
 };
 
 export type IContainerConfig = {
-    baseImage: IContainerConfigImage;
+    image: IContainerConfigImage;
     sharedMemorySize: number;
     healthCheckConfig: IContainerHealthCheckConfig;
     environment?: Record<string, string>[];
@@ -184,7 +184,7 @@ export const autoScalingConfigSchema = z.object({
 });
 
 export const containerConfigSchema = z.object({
-    baseImage: containerConfigImageSchema.default(containerConfigImageSchema.parse({})),
+    image: containerConfigImageSchema.default(containerConfigImageSchema.parse({})),
     sharedMemorySize: z.number().min(0).default(2048),
     healthCheckConfig: containerHealthCheckConfigSchema.default(containerHealthCheckConfigSchema.parse({})),
     environment: AttributeEditorSchema,

--- a/lib/user-interface/react/src/shared/model/model-management.model.ts
+++ b/lib/user-interface/react/src/shared/model/model-management.model.ts
@@ -49,7 +49,6 @@ export type IContainerHealthCheckConfig = {
 
 export type IContainerConfigImage = {
     baseImage: string;
-    path: string;
     type: string;
 };
 
@@ -139,7 +138,6 @@ const containerHealthCheckConfigSchema = z.object({
 
 const containerConfigImageSchema = z.object({
     baseImage: z.string().default(''),
-    path: z.string().default(''),
     type: z.string().default('asset'),
 });
 


### PR DESCRIPTION
The "path" component of the ContainerConfig object was redundant and unnecessarily complicated for customers to use. Historically, it referred to the path location of Dockerfiles from the root of the repo to where the model definitions were, but since we add customization on top of containers, we end up requiring that the paths are used. We specify in another option whether the model is using TGI/TEI/vLLM, and for all of these, there's a 1:1 match for it and its corresponding "path" option. The container spinup will fail if these don't match.

As part of the 3.0 release, the path changed even further to be relative to a folder inside of the root, which made it difficult to document and describe how to use it. This change removes it altogether and instead requires the backend to know where the files are, simplifying the request for customers, and preventing them from making more mistakes when creating a new LISA-hosted model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
