### PR TITLE
Fix: Add synchronous model validation to CreateModel API

### DIFF
--- a/lambda/models/domain_objects.py
+++ b/lambda/models/domain_objects.py
@@ -14,7 +14,6 @@
 
 """Domain objects for interacting with the model endpoints."""
 
-from decimal import Decimal
 from enum import Enum
 from typing import Annotated, Dict, List, Optional, Union
 
@@ -68,7 +67,7 @@ class MetricConfig(BaseModel):
     """Metric configuration for autoscaling."""
 
     albMetricName: str = Field(min_length=1)
-    targetValue: Decimal
+    targetValue: NonNegativeInt
     duration: PositiveInt
     estimatedInstanceWarmup: PositiveInt
 

--- a/lambda/models/domain_objects.py
+++ b/lambda/models/domain_objects.py
@@ -131,7 +131,7 @@ class ContainerHealthCheckConfig(BaseModel):
     """Health check configuration for a container."""
 
     command: Union[str, List[str]]
-    interval: NonNegativeInt
+    interval: PositiveInt
     startPeriod: PositiveInt
     timeout: PositiveInt
     retries: PositiveInt

--- a/lambda/models/state_machine/create_model.py
+++ b/lambda/models/state_machine/create_model.py
@@ -53,7 +53,7 @@ litellm_client = LiteLLMClient(
 )
 
 
-def get_container_path(inference_container_type: InferenceContainer):
+def get_container_path(inference_container_type: InferenceContainer) -> str:
     """
     Get the LISA repository path for referencing container build scripts.
 

--- a/lambda/utilities/validators.py
+++ b/lambda/utilities/validators.py
@@ -14,6 +14,8 @@
 
 """Functional validators for use with Pydantic."""
 
+from typing import Any, List
+
 import botocore.session
 
 sess = botocore.session.Session()
@@ -25,3 +27,13 @@ def validate_instance_type(type: str) -> str:
         return type
 
     raise ValueError("Invalid EC2 instance type.")
+
+
+def validate_all_fields_defined(fields: List[Any]) -> bool:
+    """Validate that all fields are non-null in the field list."""
+    return all((field is not None for field in fields))
+
+
+def validate_any_fields_defined(fields: List[Any]) -> bool:
+    """Validate that at least one field is non-null in the field list."""
+    return any((field is not None for field in fields))


### PR DESCRIPTION
Refactors the API model file to add validation on requests, that way we fail much earlier and give users the ability to do client-side troubleshooting before the state machine fails for the same reasons in the backend.

Main validations added:
* Int values specified as positive (>0) or non-negative (>=0)
* strings must have a minimum length of at least 1 to avoid the empty string issues we were seeing
* Removed some of the custom logic for checking against 0 since we have the pydantic types to use instead
* moved autoScalingInstanceConfig validation logic to its corresponding object because the field validation made more sense to happen there.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
