### PR TITLE
Unified error handling for Model Create/Update form

### DIFF
--- a/lib/user-interface/react/src/shared/reducers/model-management.reducer.ts
+++ b/lib/user-interface/react/src/shared/reducers/model-management.reducer.ts
@@ -46,7 +46,7 @@ export const modelManagementApi = createApi({
                 // transform into SerializedError
                 return {
                     name: 'Create Model Error',
-                    message: baseQueryReturnValue.data.detail.map((error) => error.msg).join(', ')
+                    message: baseQueryReturnValue.data?.type === 'RequestValidationError' ? baseQueryReturnValue.data.detail.map((error) => error.msg).join(', ') : baseQueryReturnValue.data.message
                 };
             },
             invalidatesTags: ['models'],
@@ -61,7 +61,7 @@ export const modelManagementApi = createApi({
                 // transform into SerializedError
                 return {
                     name: 'Update Model Error',
-                    message: baseQueryReturnValue.data.detail.map((error) => error.msg).join(', ')
+                    message: baseQueryReturnValue.data?.type === 'RequestValidationError' ? baseQueryReturnValue.data.detail.map((error) => error.msg).join(', ') : baseQueryReturnValue.data.message
                 };
             },
             invalidatesTags: ['models'],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The backend returns with different error responses depending on the type of error. Most errors are JSON responses (`{"message": string}`) but validation errors are slightly more complicated so multiple validation errors can be represented...

```json
{
  "detail": [
    {
      "loc": [
        "body",
        "size"
      ],
      "msg": "value is not a valid integer",
      "type": "type_error.integer"
    }
  ],
  "type": "RequestValidationError"
}
```

This PR updates the Model Create/Update form to handle the two types of responses possible.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
