### PR TITLE
Enabling headless deployment in make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ define print_config
 endef
 
 ## Deploy all infrastructure
-deploy:
+deploy: dockerCheck dockerLogin cleanMisc modelCheck buildEcsDeployer
 	$(call print_config)
 ifneq (,$(findstring true, $(HEADLESS)))
 	npx cdk deploy ${STACK} $(if $(PROFILE),--profile ${PROFILE}) --require-approval never -c ${ENV}='$(shell echo '${${ENV}}')';

--- a/Makefile
+++ b/Makefile
@@ -240,96 +240,43 @@ listStacks:
 buildEcsDeployer:
 	@cd ./ecs_model_deployer && npm install && npm run build
 
+define print_config
+    @printf "\n \
+    DEPLOYING $(STACK) STACK APP INFRASTRUCTURE \n \
+    -----------------------------------\n \
+    Account Number         $(ACCOUNT_NUMBER)\n \
+    Region                 $(REGION)\n \
+    App Name               $(APP_NAME)\n \
+    Deployment Stage       $(DEPLOYMENT_STAGE)\n \
+    Deployment Name        $(DEPLOYMENT_NAME)"
+    @if [ -n "$(PROFILE)" ]; then \
+        printf "\n Deployment Profile     $(PROFILE)"; \
+    fi
+    @printf "\n-----------------------------------\n"
+endef
+
 ## Deploy all infrastructure
-deploy: dockerCheck dockerLogin cleanMisc modelCheck buildEcsDeployer
+deploy:
+	$(call print_config)
 ifneq (,$(findstring true, $(HEADLESS)))
-	if [ -z ${PROFILE} ]; then \
-        npx cdk deploy ${STACK} -c ${ENV}='$(shell echo '${${ENV}}')'; \
-    else \
-        npx cdk deploy ${STACK} --profile ${PROFILE} -c ${ENV}='$(shell echo '${${ENV}}')'; \
-    fi;
-else ifdef PROFILE
-	@printf "\n \
-	DEPLOYING $(STACK) STACK APP INFRASTRUCTURE \n \
-	-----------------------------------\n \
-	Deployment Profile     ${PROFILE}\n \
-	Account Number         ${ACCOUNT_NUMBER}\n \
-	Region                 ${REGION}\n \
-	App Name               ${APP_NAME}\n \
-	Deployment Stage       ${DEPLOYMENT_STAGE}\n \
-	Deployment Name        ${DEPLOYMENT_NAME}\n \
-	-----------------------------------\n \
-	Is the configuration correct? [y/N]  "\
-	&& read confirm_config &&\
-	if \
-		[ $${confirm_config:-'N'} = 'y' ]; \
-		then \
-			npx cdk deploy ${STACK} \
-				--profile ${PROFILE} \
-				-c ${ENV}='$(shell echo '${${ENV}}')'; \
-	fi;
+	npx cdk deploy ${STACK} $(if $(PROFILE),--profile ${PROFILE}) --require-approval never -c ${ENV}='$(shell echo '${${ENV}}')'; \
 else
-	@printf "\n \
-	DEPLOYING $(STACK) STACK APP INFRASTRUCTURE \n \
-	-----------------------------------\n \
-	Account Number         ${ACCOUNT_NUMBER}\n \
-	Region                 ${REGION}\n \
-	App Name               ${APP_NAME}\n \
-	Deployment Stage       ${DEPLOYMENT_STAGE}\n \
-	Deployment Name        ${DEPLOYMENT_NAME}\n \
-	-----------------------------------\n \
-	Is the configuration correct? [y/N]  "\
+	@printf "Is the configuration correct? [y/N]  "\
 	&& read confirm_config &&\
-	if \
-		[ $${confirm_config:-'N'} = 'y' ]; \
-		then \
-			npx cdk deploy ${STACK} \
-				-c ${ENV}='$(shell echo '${${ENV}}')'; \
+	if [ $${confirm_config:-'N'} = 'y' ]; then \
+		npx cdk deploy ${STACK} $(if $(PROFILE),--profile ${PROFILE})  -c ${ENV}='$(shell echo '${${ENV}}')'; \
 	fi;
 endif
 
 
 ## Tear down all infrastructure
 destroy: cleanMisc
-ifdef PROFILE
-	@printf "\n \
-	DESTROYING $(STACK) STACK APP INFRASTRUCTURE \n \
-	-----------------------------------\n \
-	Deployment Profile     ${PROFILE}\n \
-	Account Number         ${ACCOUNT_NUMBER}\n \
-	Region                 ${REGION}\n \
-	App Name               ${APP_NAME}\n \
-	Deployment Stage       ${DEPLOYMENT_STAGE}\n \
-	Deployment Name        ${DEPLOYMENT_NAME}\n \
-	-----------------------------------\n \
-	Is the configuration correct? [y/N]  "\
+	$(call print_config)
+	@printf "Is the configuration correct? [y/N]  "\
 	&& read confirm_config &&\
-	if \
-		[ $${confirm_config:-'N'} = 'y' ]; \
-		then \
-			npx cdk destroy ${STACK} \
-				--force \
-				--profile ${PROFILE}; \
+	if [ $${confirm_config:-'N'} = 'y' ]; then \
+		npx cdk destroy ${STACK} --force $(if $(PROFILE),--profile ${PROFILE}); \
 	fi;
-else
-	@printf "\n \
-	DESTROYING $(STACK) STACK APP INFRASTRUCTURE \n \
-	-----------------------------------\n \
-	Account Number         ${ACCOUNT_NUMBER}\n \
-	Region                 ${REGION}\n \
-	App Name               ${APP_NAME}\n \
-	Deployment Stage       ${DEPLOYMENT_STAGE}\n \
-	Deployment Name        ${DEPLOYMENT_NAME}\n \
-	-----------------------------------\n \
-	Is the configuration correct? [y/N]  "\
-	&& read confirm_config &&\
-	if \
-		[ $${confirm_config:-'N'} = 'y' ]; \
-		then \
-			npx cdk destroy ${STACK} \
-				--force; \
-	fi;
-endif
 
 
 #################################################################################

--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ endef
 deploy:
 	$(call print_config)
 ifneq (,$(findstring true, $(HEADLESS)))
-	npx cdk deploy ${STACK} $(if $(PROFILE),--profile ${PROFILE}) --require-approval never -c ${ENV}='$(shell echo '${${ENV}}')'; \
+	npx cdk deploy ${STACK} $(if $(PROFILE),--profile ${PROFILE}) --require-approval never -c ${ENV}='$(shell echo '${${ENV}}')';
 else
 	@printf "Is the configuration correct? [y/N]  "\
 	&& read confirm_config &&\

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@
 #################################################################################
 
 PROJECT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+HEADLESS = false
 
 # Arguments defined through command line or config.yaml
 
@@ -241,7 +242,13 @@ buildEcsDeployer:
 
 ## Deploy all infrastructure
 deploy: dockerCheck dockerLogin cleanMisc modelCheck buildEcsDeployer
-ifdef PROFILE
+ifneq (,$(findstring true, $(HEADLESS)))
+	if [ -z ${PROFILE} ]; then \
+        npx cdk deploy ${STACK} -c ${ENV}='$(shell echo '${${ENV}}')'; \
+    else \
+        npx cdk deploy ${STACK} --profile ${PROFILE} -c ${ENV}='$(shell echo '${${ENV}}')'; \
+    fi;
+else ifdef PROFILE
 	@printf "\n \
 	DEPLOYING $(STACK) STACK APP INFRASTRUCTURE \n \
 	-----------------------------------\n \


### PR DESCRIPTION
Enabling headless deployment in makefile. You can do this by running `make deploy HEADLESS=true`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
