### PR TITLE
Updates to address some cdk-nag warnings

### DIFF
--- a/lib/api-base/utils.ts
+++ b/lib/api-base/utils.ts
@@ -39,6 +39,7 @@ import { IRole } from 'aws-cdk-lib/aws-iam';
 import { Code, Function, Runtime, ILayerVersion, IFunction, CfnPermission } from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
 import { Vpc } from '../networking/vpc';
+import { Queue } from 'aws-cdk-lib/aws-sqs';
 
 /**
  * Type representing python lambda function
@@ -105,6 +106,11 @@ export function registerAPIEndpoint (
         });
     } else {
         handler = new Function(scope, functionId, {
+            deadLetterQueueEnabled: true,
+            deadLetterQueue: new Queue(scope, `${functionId}DLQ`, {
+                queueName: `${functionId}DLQ`,
+                enforceSSL: true,
+            }),
             functionName: functionId,
             runtime: pythonRuntime,
             handler: `${funcDef.resource}.lambda_functions.${funcDef.name}`,
@@ -116,6 +122,7 @@ export function registerAPIEndpoint (
             timeout: funcDef.timeout || Duration.seconds(180),
             memorySize: 512,
             layers,
+            reservedConcurrentExecutions: 1000,
             role,
             vpc: vpc?.vpc,
             securityGroups,

--- a/lib/models/state-machine/create-model.ts
+++ b/lib/models/state-machine/create-model.ts
@@ -35,6 +35,7 @@ import { LambdaInvoke } from 'aws-cdk-lib/aws-stepfunctions-tasks';
 import { Repository } from 'aws-cdk-lib/aws-ecr';
 import { IStringParameter } from 'aws-cdk-lib/aws-ssm';
 import { Vpc } from '../../networking/vpc';
+import { Queue } from 'aws-cdk-lib/aws-sqs';
 
 type CreateModelStateMachineProps = BaseProps & {
     modelTable: ITable,
@@ -74,11 +75,17 @@ export class CreateModelStateMachine extends Construct {
 
         const setModelToCreating = new LambdaInvoke(this, 'SetModelToCreating', {
             lambdaFunction: new Function(this, 'SetModelToCreatingFunc', {
+                deadLetterQueueEnabled: true,
+                deadLetterQueue: new Queue(this, 'SetModelToCreatingDLQ', {
+                    queueName: 'SetModelToCreatingDLQ',
+                    enforceSSL: true,
+                }),
                 runtime: config.lambdaConfig.pythonRuntime,
                 handler: 'models.state_machine.create_model.handle_set_model_to_creating',
                 code: Code.fromAsset(config.lambdaSourcePath),
                 timeout: LAMBDA_TIMEOUT,
                 memorySize: LAMBDA_MEMORY,
+                reservedConcurrentExecutions: 1000,
                 role: role,
                 vpc: vpc?.vpc,
                 vpcSubnets: vpc?.subnetSelection,
@@ -93,11 +100,17 @@ export class CreateModelStateMachine extends Construct {
 
         const startCopyDockerImage = new LambdaInvoke(this, 'StartCopyDockerImage', {
             lambdaFunction: new Function(this, 'StartCopyDockerImageFunc', {
+                deadLetterQueueEnabled: true,
+                deadLetterQueue: new Queue(this, 'StartCopyDockerImageDLQ', {
+                    queueName: 'StartCopyDockerImageDLQ',
+                    enforceSSL: true,
+                }),
                 runtime: config.lambdaConfig.pythonRuntime,
                 handler: 'models.state_machine.create_model.handle_start_copy_docker_image',
                 code: Code.fromAsset(config.lambdaSourcePath),
                 timeout: LAMBDA_TIMEOUT,
                 memorySize: LAMBDA_MEMORY,
+                reservedConcurrentExecutions: 1000,
                 role: role,
                 vpc: vpc?.vpc,
                 vpcSubnets: vpc?.subnetSelection,
@@ -110,11 +123,17 @@ export class CreateModelStateMachine extends Construct {
 
         const pollDockerImageAvailable = new LambdaInvoke(this, 'PollDockerImageAvailable', {
             lambdaFunction: new Function(this, 'PollDockerImageAvailableFunc', {
+                deadLetterQueueEnabled: true,
+                deadLetterQueue: new Queue(this, 'PollDockerImageAvailableDLQ', {
+                    queueName: 'PollDockerImageAvailableDLQ',
+                    enforceSSL: true,
+                }),
                 runtime: config.lambdaConfig.pythonRuntime,
                 handler: 'models.state_machine.create_model.handle_poll_docker_image_available',
                 code: Code.fromAsset(config.lambdaSourcePath),
                 timeout: LAMBDA_TIMEOUT,
                 memorySize: LAMBDA_MEMORY,
+                reservedConcurrentExecutions: 1000,
                 role: role,
                 vpc: vpc?.vpc,
                 vpcSubnets: vpc?.subnetSelection,
@@ -127,11 +146,17 @@ export class CreateModelStateMachine extends Construct {
 
         const handleFailureState = new LambdaInvoke(this, 'HandleFailure', {
             lambdaFunction: new Function(this, 'HandleFailureFunc', {
+                deadLetterQueueEnabled: true,
+                deadLetterQueue: new Queue(this, 'HandleFailureDLQ', {
+                    queueName: 'HandleFailureDLQ',
+                    enforceSSL: true,
+                }),
                 runtime: config.lambdaConfig.pythonRuntime,
                 handler: 'models.state_machine.create_model.handle_failure',
                 code: Code.fromAsset(config.lambdaSourcePath),
                 timeout: LAMBDA_TIMEOUT,
                 memorySize: LAMBDA_MEMORY,
+                reservedConcurrentExecutions: 1000,
                 role: role,
                 vpc: vpc?.vpc,
                 vpcSubnets: vpc?.subnetSelection,
@@ -150,11 +175,17 @@ export class CreateModelStateMachine extends Construct {
 
         const startCreateStack = new LambdaInvoke(this, 'StartCreateStack', {
             lambdaFunction: new Function(this, 'StartCreateStackFunc', {
+                deadLetterQueueEnabled: true,
+                deadLetterQueue: new Queue(this, 'StartCreateStackDLQ', {
+                    queueName: 'StartCreateStackDLQ',
+                    enforceSSL: true,
+                }),
                 runtime: config.lambdaConfig.pythonRuntime,
                 handler: 'models.state_machine.create_model.handle_start_create_stack',
                 code: Code.fromAsset(config.lambdaSourcePath),
                 timeout: Duration.minutes(8),
                 memorySize: LAMBDA_MEMORY,
+                reservedConcurrentExecutions: 1000,
                 role: role,
                 vpc: vpc?.vpc,
                 vpcSubnets: vpc?.subnetSelection,
@@ -167,11 +198,17 @@ export class CreateModelStateMachine extends Construct {
 
         const pollCreateStack = new LambdaInvoke(this, 'PollCreateStack', {
             lambdaFunction: new Function(this, 'PollCreateStackFunc', {
+                deadLetterQueueEnabled: true,
+                deadLetterQueue: new Queue(this, 'PollCreateStackDLQ', {
+                    queueName: 'PollCreateStackDLQ',
+                    enforceSSL: true,
+                }),
                 runtime: config.lambdaConfig.pythonRuntime,
                 handler: 'models.state_machine.create_model.handle_poll_create_stack',
                 code: Code.fromAsset(config.lambdaSourcePath),
                 timeout: LAMBDA_TIMEOUT,
                 memorySize: LAMBDA_MEMORY,
+                reservedConcurrentExecutions: 1000,
                 role: role,
                 vpc: vpc?.vpc,
                 vpcSubnets: vpc?.subnetSelection,
@@ -190,11 +227,17 @@ export class CreateModelStateMachine extends Construct {
 
         const addModelToLitellm = new LambdaInvoke(this, 'AddModelToLitellm', {
             lambdaFunction: new Function(this, 'AddModelToLitellmFunc', {
+                deadLetterQueueEnabled: true,
+                deadLetterQueue: new Queue(this, 'AddModelToLitellmDLQ', {
+                    queueName: 'AddModelToLitellmDLQ',
+                    enforceSSL: true,
+                }),
                 runtime: config.lambdaConfig.pythonRuntime,
                 handler: 'models.state_machine.create_model.handle_add_model_to_litellm',
                 code: Code.fromAsset(config.lambdaSourcePath),
                 timeout: LAMBDA_TIMEOUT,
                 memorySize: LAMBDA_MEMORY,
+                reservedConcurrentExecutions: 1000,
                 role: role,
                 vpc: vpc?.vpc,
                 vpcSubnets: vpc?.subnetSelection,

--- a/lib/models/state-machine/delete-model.ts
+++ b/lib/models/state-machine/delete-model.ts
@@ -33,6 +33,7 @@ import { ITable } from 'aws-cdk-lib/aws-dynamodb';
 import { LAMBDA_MEMORY, LAMBDA_TIMEOUT, OUTPUT_PATH, POLLING_TIMEOUT } from './constants';
 import { IStringParameter } from 'aws-cdk-lib/aws-ssm';
 import { Vpc } from '../../networking/vpc';
+import { Queue } from 'aws-cdk-lib/aws-sqs';
 
 type DeleteModelStateMachineProps = BaseProps & {
     modelTable: ITable,
@@ -68,11 +69,17 @@ export class DeleteModelStateMachine extends Construct {
         // Input payload to state machine contains the model name that we want to delete.
         const setModelToDeleting = new LambdaInvoke(this, 'SetModelToDeleting', {
             lambdaFunction: new Function(this, 'SetModelToDeletingFunc', {
+                deadLetterQueueEnabled: true,
+                deadLetterQueue: new Queue(this, 'SetModelToDeletingDLQ', {
+                    queueName: 'SetModelToDeletingDLQ',
+                    enforceSSL: true,
+                }),
                 runtime: config.lambdaConfig.pythonRuntime,
                 handler: 'models.state_machine.delete_model.handle_set_model_to_deleting',
                 code: Code.fromAsset(config.lambdaSourcePath),
                 timeout: LAMBDA_TIMEOUT,
                 memorySize: LAMBDA_MEMORY,
+                reservedConcurrentExecutions: 1000,
                 role: role,
                 vpc: vpc?.vpc,
                 vpcSubnets: vpc?.subnetSelection,
@@ -85,11 +92,17 @@ export class DeleteModelStateMachine extends Construct {
 
         const deleteFromLitellm = new LambdaInvoke(this, 'DeleteFromLitellm', {
             lambdaFunction: new Function(this, 'DeleteFromLitellmFunc', {
+                deadLetterQueueEnabled: true,
+                deadLetterQueue: new Queue(this, 'DeleteFromLitellmDLQ', {
+                    queueName: 'DeleteFromLitellmDLQ',
+                    enforceSSL: true,
+                }),
                 runtime: config.lambdaConfig.pythonRuntime,
                 handler: 'models.state_machine.delete_model.handle_delete_from_litellm',
                 code: Code.fromAsset(config.lambdaSourcePath),
                 timeout: LAMBDA_TIMEOUT,
                 memorySize: LAMBDA_MEMORY,
+                reservedConcurrentExecutions: 1000,
                 role: role,
                 vpc: vpc?.vpc,
                 vpcSubnets: vpc?.subnetSelection,
@@ -102,11 +115,17 @@ export class DeleteModelStateMachine extends Construct {
 
         const deleteStack = new LambdaInvoke(this, 'DeleteStack', {
             lambdaFunction: new Function(this, 'DeleteStackFunc', {
+                deadLetterQueueEnabled: true,
+                deadLetterQueue: new Queue(this, 'DeleteStackDLQ', {
+                    queueName: 'DeleteStackDLQ',
+                    enforceSSL: true,
+                }),
                 runtime: config.lambdaConfig.pythonRuntime,
                 handler: 'models.state_machine.delete_model.handle_delete_stack',
                 code: Code.fromAsset(config.lambdaSourcePath),
                 timeout: LAMBDA_TIMEOUT,
                 memorySize: LAMBDA_MEMORY,
+                reservedConcurrentExecutions: 1000,
                 role: role,
                 vpc: vpc?.vpc,
                 vpcSubnets: vpc?.subnetSelection,
@@ -119,11 +138,17 @@ export class DeleteModelStateMachine extends Construct {
 
         const monitorDeleteStack = new LambdaInvoke(this, 'MonitorDeleteStack', {
             lambdaFunction: new Function(this, 'MonitorDeleteStackFunc', {
+                deadLetterQueueEnabled: true,
+                deadLetterQueue: new Queue(this, 'MonitorDeleteStackDLQ', {
+                    queueName: 'MonitorDeleteStackDLQ',
+                    enforceSSL: true,
+                }),
                 runtime: config.lambdaConfig.pythonRuntime,
                 handler: 'models.state_machine.delete_model.handle_monitor_delete_stack',
                 code: Code.fromAsset(config.lambdaSourcePath),
                 timeout: LAMBDA_TIMEOUT,
                 memorySize: LAMBDA_MEMORY,
+                reservedConcurrentExecutions: 1000,
                 role: role,
                 vpc: vpc?.vpc,
                 vpcSubnets: vpc?.subnetSelection,
@@ -136,11 +161,17 @@ export class DeleteModelStateMachine extends Construct {
 
         const deleteFromDdb = new LambdaInvoke(this, 'DeleteFromDdb', {
             lambdaFunction: new Function(this, 'DeleteFromDdbFunc', {
+                deadLetterQueueEnabled: true,
+                deadLetterQueue: new Queue(this, 'DeleteFromDdbDLQ', {
+                    queueName: 'DeleteFromDdbDLQ',
+                    enforceSSL: true,
+                }),
                 runtime: config.lambdaConfig.pythonRuntime,
                 handler: 'models.state_machine.delete_model.handle_delete_from_ddb',
                 code: Code.fromAsset(config.lambdaSourcePath),
                 timeout: LAMBDA_TIMEOUT,
                 memorySize: LAMBDA_MEMORY,
+                reservedConcurrentExecutions: 1000,
                 role: role,
                 vpc: vpc?.vpc,
                 vpcSubnets: vpc?.subnetSelection,

--- a/lib/models/state-machine/update-model.ts
+++ b/lib/models/state-machine/update-model.ts
@@ -26,6 +26,7 @@ import { LambdaInvoke } from 'aws-cdk-lib/aws-stepfunctions-tasks';
 import { LAMBDA_MEMORY, LAMBDA_TIMEOUT, OUTPUT_PATH, POLLING_TIMEOUT } from './constants';
 import { Choice, Condition, DefinitionBody, StateMachine, Succeed, Wait, WaitTime } from 'aws-cdk-lib/aws-stepfunctions';
 import { Vpc } from '../../networking/vpc';
+import { Queue } from 'aws-cdk-lib/aws-sqs';
 
 
 type UpdateModelStateMachineProps = BaseProps & {
@@ -69,11 +70,17 @@ export class UpdateModelStateMachine extends Construct {
 
         const handleJobIntake = new LambdaInvoke(this, 'HandleJobIntake', {
             lambdaFunction: new Function(this, 'HandleJobIntakeFunc', {
+                deadLetterQueueEnabled: true,
+                deadLetterQueue: new Queue(this, 'HandleJobIntakeDLQ', {
+                    queueName: 'HandleJobIntakeDLQ',
+                    enforceSSL: true,
+                }),
                 runtime: config.lambdaConfig.pythonRuntime,
                 handler: 'models.state_machine.update_model.handle_job_intake',
                 code: Code.fromAsset(config.lambdaSourcePath),
                 timeout: LAMBDA_TIMEOUT,
                 memorySize: LAMBDA_MEMORY,
+                reservedConcurrentExecutions: 1000,
                 role: role,
                 vpc: vpc?.vpc,
                 vpcSubnets: vpc?.subnetSelection,
@@ -86,11 +93,17 @@ export class UpdateModelStateMachine extends Construct {
 
         const handlePollCapacity = new LambdaInvoke(this, 'HandlePollCapacity', {
             lambdaFunction: new Function(this, 'HandlePollCapacityFunc', {
+                deadLetterQueueEnabled: true,
+                deadLetterQueue: new Queue(this, 'HandlePollCapacityDLQ', {
+                    queueName: 'HandlePollCapacityDLQ',
+                    enforceSSL: true,
+                }),
                 runtime: config.lambdaConfig.pythonRuntime,
                 handler: 'models.state_machine.update_model.handle_poll_capacity',
                 code: Code.fromAsset(config.lambdaSourcePath),
                 timeout: LAMBDA_TIMEOUT,
                 memorySize: LAMBDA_MEMORY,
+                reservedConcurrentExecutions: 1000,
                 role: role,
                 vpc: vpc?.vpc,
                 vpcSubnets: vpc?.subnetSelection,
@@ -103,11 +116,17 @@ export class UpdateModelStateMachine extends Construct {
 
         const handleFinishUpdate = new LambdaInvoke(this, 'HandleFinishUpdate', {
             lambdaFunction: new Function(this, 'HandleFinishUpdateFunc', {
+                deadLetterQueueEnabled: true,
+                deadLetterQueue: new Queue(this, 'HandleFinishUpdateDLQ', {
+                    queueName: 'HandleFinishUpdateDLQ',
+                    enforceSSL: true,
+                }),
                 runtime: config.lambdaConfig.pythonRuntime,
                 handler: 'models.state_machine.update_model.handle_finish_update',
                 code: Code.fromAsset(config.lambdaSourcePath),
                 timeout: LAMBDA_TIMEOUT,
                 memorySize: LAMBDA_MEMORY,
+                reservedConcurrentExecutions: 1000,
                 role: role,
                 vpc: vpc?.vpc,
                 vpcSubnets: vpc?.subnetSelection,

--- a/lib/serve/index.ts
+++ b/lib/serve/index.ts
@@ -101,6 +101,11 @@ export class LisaServeApplicationStack extends Stack {
 
         // const rotateManagementKeyLambdaId = createCdkId([id, 'RotateManagementKeyLambda'])
         // const rotateManagementKeyLambda = new Function(this, rotateManagementKeyLambdaId, {
+        //     deadLetterQueueEnabled: true,
+        //     deadLetterQueue: new Queue(this, 'RotateManagementKeyLambdaDLQ', {
+        //         queueName: 'RotateManagementKeyLambdaDLQ',
+        //         enforceSSL: true,
+        //     }),
         //     functionName: rotateManagementKeyLambdaId,
         //     runtime: config.lambdaConfig.pythonRuntime,
         //     handler: 'management_key.rotate_management_key',
@@ -112,6 +117,7 @@ export class LisaServeApplicationStack extends Stack {
         //     },
         //     layers: [commonLambdaLayer],
         //     vpc: props.vpc.vpc,
+        //     reservedConcurrentExecutions: 1000,
         // });
 
         // managementKeySecret.grantRead(rotateManagementKeyLambda);

--- a/test/cdk/stacks/chat.test.ts
+++ b/test/cdk/stacks/chat.test.ts
@@ -120,6 +120,6 @@ describe.each(regions)('Chat Nag Pack Tests | Region Test: %s', (awsRegion) => {
 
     test('NIST800.53r5 CDK NAG Errors', () => {
         const errors = Annotations.fromStack(stack).findError('*', Match.stringLikeRegexp('NIST.*'));
-        expect(errors.length).toBe(14);
+        expect(errors.length).toBe(4);
     });
 });

--- a/test/cdk/stacks/core-api-base.test.ts
+++ b/test/cdk/stacks/core-api-base.test.ts
@@ -112,6 +112,6 @@ describe.each(regions)('API Core Nag Pack Tests | Region Test: %s', (awsRegion) 
 
     test('NIST800.53r5 CDK NAG Errors', () => {
         const errors = Annotations.fromStack(stack).findError('*', Match.stringLikeRegexp('NIST.*'));
-        expect(errors.length).toBe(7);
+        expect(errors.length).toBe(5);
     });
 });


### PR DESCRIPTION
Addresses lowest hanging fruit for CDK nag warnings. Reduces nags to 299 from 355.

- added DQL for lambdas w/enforced SSL
- added limits for lambda concurrency


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
