### PR TITLE
Update Docs gateway stage url to match github

### DIFF
--- a/lib/docs/index.ts
+++ b/lib/docs/index.ts
@@ -78,7 +78,7 @@ export class LisaDocsStack extends Stack {
             description: 'API Gateway for S3 hosted website',
             endpointConfiguration: { types: [EndpointType.REGIONAL] },
             deployOptions: {
-                stageName: 'lisa',
+                stageName: 'LISA',
             },
             binaryMediaTypes: ['*/*'],
         });


### PR DESCRIPTION
When deploying LISA docs to an account, the stage must match the base url. This changes the url to match the deployed base url in Github. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
