### PR TITLE
Feature/partition make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,11 +56,20 @@ ifeq (${REGION},)
 $(error region must be set in command line using REGION variable or config files)
 endif
 
-# URL_SUFFIX - used for the docker login
+ifeq (${PARTITION},)
+PARTITION := $(shell cat $(PROJECT_DIR)/config-custom.yaml | yq .partition )
+endif
+ifeq (${PARTITION}, null)
+PARTITION := aws
+endif
+
+# DOMAIN - used for the docker login
+ifeq (${DOMAIN},)
 ifeq ($(findstring iso,${REGION}),)
-URL_SUFFIX := amazonaws.com
+DOMAIN := amazonaws.com
 else
-URL_SUFFIX := c2s.ic.gov
+DOMAIN := c2s.ic.gov
+endif
 endif
 
 # Arguments defined through config files
@@ -117,16 +126,18 @@ MODEL_BUCKET := $(shell cat $(PROJECT_DIR)/config-custom.yaml | yq '.s3BucketMod
 
 ## Bootstrap AWS Account with CDK bootstrap
 bootstrap:
-	@printf "Bootstrapping: $(ACCOUNT_NUMBER) | $(REGION)\n"
+	@printf "Bootstrapping: $(ACCOUNT_NUMBER) | $(REGION) | $(PARTITION)\n"
 
 ifdef PROFILE
 	@cdk bootstrap \
 		--profile $(PROFILE) \
 		aws://$(ACCOUNT_NUMBER)/$(REGION) \
+		--partition $(PARTITION) \
 		--cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess
 else
 	@cdk bootstrap \
 		aws://$(ACCOUNT_NUMBER)/$(REGION) \
+		--partition $(PARTITION) \
 		--cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess
 endif
 
@@ -234,11 +245,11 @@ cleanMisc:
 dockerLogin: dockerCheck
 ifdef PROFILE
 	@$(foreach ACCOUNT,$(ACCOUNT_NUMBERS_ECR), \
-		aws ecr get-login-password --region ${REGION} --profile ${PROFILE} | $(DOCKER_CMD) login --username AWS --password-stdin ${ACCOUNT}.dkr.ecr.${REGION}.${URL_SUFFIX} >/dev/null 2>&1; \
+		aws ecr get-login-password --region ${REGION} --profile ${PROFILE} | $(DOCKER_CMD) login --username AWS --password-stdin ${ACCOUNT}.dkr.ecr.${REGION}.${DOMAIN} >/dev/null 2>&1; \
 	)
 else
 	@$(foreach ACCOUNT,$(ACCOUNT_NUMBERS_ECR), \
-		aws ecr get-login-password --region ${REGION} | $(DOCKER_CMD) login --username AWS --password-stdin ${ACCOUNT}.dkr.ecr.${REGION}.${URL_SUFFIX} >/dev/null 2>&1; \
+		aws ecr get-login-password --region ${REGION} | $(DOCKER_CMD) login --username AWS --password-stdin ${ACCOUNT}.dkr.ecr.${REGION}.${DOMAIN} >/dev/null 2>&1; \
 	)
 endif
 
@@ -255,6 +266,8 @@ define print_config
     -----------------------------------\n \
     Account Number         $(ACCOUNT_NUMBER)\n \
     Region                 $(REGION)\n \
+    Partition              $(PARTITION)\n \
+    Domain                 $(DOMAIN)\n \
     App Name               $(APP_NAME)\n \
     Deployment Stage       $(DEPLOYMENT_STAGE)\n \
     Deployment Name        $(DEPLOYMENT_NAME)"

--- a/bin/lisa.ts
+++ b/bin/lisa.ts
@@ -40,6 +40,8 @@ const mappings: EnvMapping[] = [
     ['PROFILE', 'profile'],
     ['DEPLOYMENT_NAME', 'deploymentName'],
     ['ACCOUNT_NUMBER', 'accountNumber'],
+    ['PARTITION', 'partition'],
+    ['DOMAIN', 'domain'],
     ['REGION', 'region'],
 ];
 mappings.forEach(([envVar, configVar]) => {

--- a/lib/docs/admin/getting-started.md
+++ b/lib/docs/admin/getting-started.md
@@ -164,6 +164,7 @@ When deploying for dev and testing you can use a self-signed certificate for the
 
 ```bash
 export REGION=<your-region>
+export DOMAIN=<your-domain> #Optional if not running in 'aws' partition
 ./scripts/gen-certs.sh
 aws iam upload-server-certificate --server-certificate-name <cert-name> --certificate-body file://scripts/server.pem --private-key file://scripts/server.key
 ```
@@ -172,7 +173,7 @@ Update your `config-custom.yaml` with the certificate ARN:
 
 ```yaml
 restApiConfig:
-  sslCertIamArn: arn:aws:iam::<account-number>:server-certificate/<certificate-name>
+  sslCertIamArn: arn:<aws-partition>:iam::<account-number>:server-certificate/<certificate-name>
 ```
 
 ## Step 9: Customize Model Deployment

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -584,6 +584,8 @@ const RawConfigSchema = z
             })
             .describe('AWS account number for deployment. Must be 12 digits.'),
         region: z.string().describe('AWS region for deployment.'),
+        partition: z.string().default('aws').describe('AWS partition for deployment.'),
+        domain: z.string().default('amazonaws.com').describe('AWS domain for deployment'),
         restApiConfig: FastApiContainerConfigSchema,
         vpcId: z.string().optional().describe('VPC ID for the application. (e.g. vpc-0123456789abcdef)'),
         subnets: z.array(z.object({

--- a/scripts/gen-certs.sh
+++ b/scripts/gen-certs.sh
@@ -12,7 +12,11 @@ if [[ -z $REGION ]]; then
     exit 1
 fi
 
-domain="*.$REGION.elb.amazonaws.com"
+if [[ -z $DOMAIN ]]; then
+    DOMAIN="amazonaws.com"
+fi
+
+domain="*.$REGION.elb.$DOMAIN"
 
 # Check if the certificate and key files already exist
 if [ ! -f "$outPathCert" ] || [ ! -f "$outPathKey" ]; then
@@ -21,7 +25,7 @@ if [ ! -f "$outPathCert" ] || [ ! -f "$outPathKey" ]; then
   maj=$(echo "$openssl_version" | cut -d. -f1)
   min=$(echo "$openssl_version" | cut -d. -f2)
   if [ $maj -eq 1 ] && [ $min -lt 10 ] || [ $maj -lt 1 ]; then
-    echo "Warning: Your version of OpenSSL ${openssl_version} is not supported. Please upgrade to version 1.10+")
+    echo "Warning: Your version of OpenSSL ${openssl_version} is not supported. Please upgrade to version 1.10+"
     exit 1
   fi
 


### PR DESCRIPTION
Add partition and domain overrides when deploying LISA. With these additions, we can now run `make bootstrap` and `make deploy` in regions not in commercial AWS with the overrides `PARTITION` and `DOMAIN`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
