### PR TITLE
Add ability to delete legacy vector stores through UI

### DIFF
--- a/lambda/repository/lambda_functions.py
+++ b/lambda/repository/lambda_functions.py
@@ -247,9 +247,7 @@ def list_all(event: dict, context: dict) -> List[Dict[str, Any]]:
     registered_repositories = vs_repo.get_registered_repositories()
     admin_override = is_admin(event)
     return [
-        repo
-        for repo in registered_repositories
-        if admin_override or user_has_group(user_groups, repo["allowedGroups"])
+        repo for repo in registered_repositories if admin_override or user_has_group(user_groups, repo["allowedGroups"])
     ]
 
 

--- a/lambda/repository/lambda_functions.py
+++ b/lambda/repository/lambda_functions.py
@@ -706,7 +706,7 @@ def delete(event: dict, context: dict) -> Any:
         return {"status": "success", "executionArn": response["executionArn"]}
 
 
-def _remove_legacy(repository_id: str):
+def _remove_legacy(repository_id: str) -> None:
     registered_repositories = ssm_client.get_parameter(Name=os.environ["REGISTERED_REPOSITORIES_PS"])
     registered_repositories = json.loads(registered_repositories["Parameter"]["Value"])
     updated_repositories = [repo for repo in registered_repositories if repo.get("repositoryId") != repository_id]

--- a/lambda/repository/lambda_functions.py
+++ b/lambda/repository/lambda_functions.py
@@ -245,7 +245,11 @@ def list_all(event: dict, context: dict) -> List[Dict[str, Any]]:
     """
     user_groups = get_groups(event)
     registered_repositories = vs_repo.get_registered_repositories()
-    return [repo for repo in registered_repositories if is_admin(event) or user_has_group(user_groups, repo["allowedGroups"])]
+    return [
+        repo
+        for repo in registered_repositories
+        if is_admin(event) or user_has_group(user_groups, repo["allowedGroups"])
+    ]
 
 
 @api_wrapper
@@ -701,6 +705,7 @@ def delete(event: dict, context: dict) -> Any:
         # Return success status and execution ARN
         return {"status": "success", "executionArn": response["executionArn"]}
 
+
 def _remove_legacy(repository_id: str):
     registered_repositories = ssm_client.get_parameter(Name=os.environ["REGISTERED_REPOSITORIES_PS"])
     registered_repositories = json.loads(registered_repositories["Parameter"]["Value"])
@@ -712,5 +717,5 @@ def _remove_legacy(repository_id: str):
             Name=os.environ["REGISTERED_REPOSITORIES_PS"],
             Value=json.dumps(updated_repositories),
             Type="String",
-            Overwrite=True
+            Overwrite=True,
         )

--- a/lambda/repository/lambda_functions.py
+++ b/lambda/repository/lambda_functions.py
@@ -245,10 +245,11 @@ def list_all(event: dict, context: dict) -> List[Dict[str, Any]]:
     """
     user_groups = get_groups(event)
     registered_repositories = vs_repo.get_registered_repositories()
+    admin_override = is_admin(event)
     return [
         repo
         for repo in registered_repositories
-        if is_admin(event) or user_has_group(user_groups, repo["allowedGroups"])
+        if admin_override or user_has_group(user_groups, repo["allowedGroups"])
     ]
 
 
@@ -687,7 +688,7 @@ def delete(event: dict, context: dict) -> Any:
         raise ValidationError("repositoryId is required")
 
     repository = vs_repo.find_repository_by_id(repository_id=repository_id, raw_config=True)
-    if repository.get("editable", False) is False:
+    if repository.get("legacy", False) is True:
         _remove_legacy(repository_id)
         vs_repo.delete(repository_id=repository_id)
         return {"status": "success", "executionArn": "legacy"}

--- a/lambda/repository/vector_store_repo.py
+++ b/lambda/repository/vector_store_repo.py
@@ -43,7 +43,7 @@ class VectorStoreRepository:
         for item in items:
             item["config"]["editable"] = item.get("editable", True)
             registered_repositories.append(item["config"])
-            
+
         return registered_repositories
 
     def get_repository_status(self) -> dict[str, str]:
@@ -94,20 +94,18 @@ class VectorStoreRepository:
     def delete(self, repository_id: str) -> bool:
         """
         Delete a repository by its ID.
-        
+
         Args:
             repository_id: The ID of the repository to delete.
-            
+
         Returns:
             True if deletion was successful.
-            
+
         Raises:
             ValueError: If the deletion fails.
         """
         try:
-            self.table.delete_item(
-                Key={"repositoryId": repository_id}
-            )
+            self.table.delete_item(Key={"repositoryId": repository_id})
             return True
         except Exception as e:
-            raise ValueError(f"Failed to delete repository: {repository_id}", e)        
+            raise ValueError(f"Failed to delete repository: {repository_id}", e)

--- a/lambda/repository/vector_store_repo.py
+++ b/lambda/repository/vector_store_repo.py
@@ -41,7 +41,7 @@ class VectorStoreRepository:
 
         registered_repositories = []
         for item in items:
-            item["config"]["editable"] = item.get("editable", True)
+            item["config"]["legacy"] = item.get("legacy", False)
             registered_repositories.append(item["config"])
 
         return registered_repositories

--- a/lambda/repository/vector_store_repo.py
+++ b/lambda/repository/vector_store_repo.py
@@ -38,7 +38,13 @@ class VectorStoreRepository:
             items.extend(response["Items"])
         # Convert all ddb Numbers to floats to correctly serialize to json
         items = convert_decimal(items)
-        return [item["config"] for item in items if "config" in item]
+
+        registered_repositories = []
+        for item in items:
+            item["config"]["editable"] = item.get("editable", True)
+            registered_repositories.append(item["config"])
+            
+        return registered_repositories
 
     def get_repository_status(self) -> dict[str, str]:
         """Get a list the status of all repositories"""
@@ -84,3 +90,24 @@ class VectorStoreRepository:
 
         repository: dict[str, Any] = convert_decimal(response.get("Item"))
         return repository if raw_config else cast(dict[str, Any], repository.get("config", {}))
+
+    def delete(self, repository_id: str) -> bool:
+        """
+        Delete a repository by its ID.
+        
+        Args:
+            repository_id: The ID of the repository to delete.
+            
+        Returns:
+            True if deletion was successful.
+            
+        Raises:
+            ValueError: If the deletion fails.
+        """
+        try:
+            self.table.delete_item(
+                Key={"repositoryId": repository_id}
+            )
+            return True
+        except Exception as e:
+            raise ValueError(f"Failed to delete repository: {repository_id}", e)        

--- a/lambda/repository/vector_store_repo.py
+++ b/lambda/repository/vector_store_repo.py
@@ -41,7 +41,8 @@ class VectorStoreRepository:
 
         registered_repositories = []
         for item in items:
-            item["config"]["legacy"] = item.get("legacy", False)
+            if item.get("legacy", False):
+                item["config"]["legacy"] = True
             registered_repositories.append(item["config"])
 
         return registered_repositories

--- a/lib/configSchema.ts
+++ b/lib/configSchema.ts
@@ -460,11 +460,11 @@ const AuthConfigSchema = z.object({
 }).describe('Configuration schema for authorization.');
 
 export const RdsInstanceConfig = z.object({
-    username: z.string().default('postgres').describe('Database username.'),
-    passwordSecretId: z.string().optional().describe('SecretsManager Secret ID that stores an existing database password.'),
-    dbHost: z.string().optional().describe('Database hostname for existing database instance.'),
-    dbName: z.string().default('postgres').describe('Database name for existing database instance.'),
-    dbPort: z.number().default(5432).describe('Port to open on the database instance.'),
+    username: z.string().default('postgres').describe('The username used for database connection.'),
+    passwordSecretId: z.string().optional().describe('The SecretsManager Secret ID that stores the existing database password.'),
+    dbHost: z.string().optional().describe('The database hostname for the existing database instance.'),
+    dbName: z.string().default('postgres').describe('The name of the database for the database instance.'),
+    dbPort: z.number().default(5432).describe('The port of the existing database instance or the port to be opened on the database instance.'),
 }).describe('Configuration schema for RDS Instances needed for LiteLLM scaling or PGVector RAG operations.\n \n ' +
     'The optional fields can be omitted to create a new database instance, otherwise fill in all fields to use an existing database instance.');
 
@@ -531,13 +531,13 @@ export type OpenSearchConfig =
 
 export const RagRepositoryConfigSchema = z
     .object({
-        repositoryId: z.string().nonempty().describe('Unique identifier for repository. Used in API calls and UI. Must be unique across all repositories.'),
-        repositoryName: z.string().optional().describe('Name to display in the UI'),
-        type: z.nativeEnum(RagRepositoryType),
+        repositoryId: z.string().nonempty().describe('A unique identifier for the repository, used in API calls and the UI. It must be distinct across all repositories.'),
+        repositoryName: z.string().optional().describe('The user-friendly name displayed in the UI.'),
+        type: z.nativeEnum(RagRepositoryType).describe('The vector store designated for this repository.'),
         opensearchConfig: z.union([OpenSearchExistingClusterConfig, OpenSearchNewClusterConfig]).optional(),
         rdsConfig: RdsInstanceConfig.optional(),
         pipelines: z.array(RagRepositoryPipeline).optional().default([]).describe('Rag ingestion pipeline for automated inclusion into a vector store from S3'),
-        allowedGroups: z.array(z.string().nonempty()).optional().default([]),
+        allowedGroups: z.array(z.string().nonempty()).optional().default([]).describe('The groups provided by the Identity Provider that have access to this repository. If no groups are specified, access is granted to everyone.'),
     })
     .refine((input) => {
         return !((input.type === RagRepositoryType.OPENSEARCH && input.opensearchConfig === undefined) ||

--- a/lib/rag/index.ts
+++ b/lib/rag/index.ts
@@ -485,7 +485,7 @@ export class LisaRagStack extends Stack {
                     repositoryId: ragConfig.repositoryId, // Partition key value
                     status: 'CREATE_COMPLETE',
                     config: ragConfig,
-                    editable: false
+                    legacy: true
                 }),
             };
 

--- a/lib/user-interface/react/src/components/configuration/RepositoryActions.tsx
+++ b/lib/user-interface/react/src/components/configuration/RepositoryActions.tsx
@@ -35,7 +35,7 @@ export type RepositoryActionProps = {
     setEdit: (state: boolean) => void;
 };
 
-function RepositoryActions(props: RepositoryActionProps): ReactElement {
+function RepositoryActions (props: RepositoryActionProps): ReactElement {
     const dispatch = useAppDispatch();
     const notificationService = useNotificationService(dispatch);
     const { setEdit, setNewRepositoryModalVisible, setSelectedItems } = props;

--- a/lib/user-interface/react/src/components/configuration/RepositoryActions.tsx
+++ b/lib/user-interface/react/src/components/configuration/RepositoryActions.tsx
@@ -14,12 +14,11 @@
  limitations under the License.
  */
 
-import React, { ReactElement, useEffect } from 'react';
-import { Button, ButtonDropdown, ButtonDropdownProps, Icon, SpaceBetween } from '@cloudscape-design/components';
+import React, { ReactElement, useEffect, useState } from 'react';
+import { Alert, Button, ButtonDropdown, ButtonDropdownProps, Checkbox, Icon, SpaceBetween } from '@cloudscape-design/components';
 import { useAppDispatch } from '../../config/store';
 import { useNotificationService } from '../../shared/util/hooks';
 import { INotificationService } from '../../shared/notification/notification.service';
-import { MutationTrigger } from '@reduxjs/toolkit/dist/query/react/buildHooks';
 import { Action, ThunkDispatch } from '@reduxjs/toolkit';
 import { setConfirmationModal } from '../../shared/reducers/modal.reducer';
 import {
@@ -36,7 +35,7 @@ export type RepositoryActionProps = {
     setEdit: (state: boolean) => void;
 };
 
-function RepositoryActions (props: RepositoryActionProps): ReactElement {
+function RepositoryActions(props: RepositoryActionProps): ReactElement {
     const dispatch = useAppDispatch();
     const notificationService = useNotificationService(dispatch);
     const { setEdit, setNewRepositoryModalVisible, setSelectedItems } = props;
@@ -68,7 +67,8 @@ type RagRepository = RagRepositoryConfig & {
 
 function RepositoryActionButton (dispatch: ThunkDispatch<any, any, Action>, notificationService: INotificationService, props: RepositoryActionProps): ReactElement {
     const { setEdit, selectedItems, setSelectedItems, setNewRepositoryModalVisible } = props;
-
+    const [disabledModal, setDisabledModel] = useState(false);
+    const [showModal, setShowModal] = useState(false);
     const selectedRepo: RagRepository = selectedItems[0];
     const [
         deleteMutation,
@@ -100,6 +100,37 @@ function RepositoryActionButton (dispatch: ThunkDispatch<any, any, Action>, noti
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isUpdateSuccess, isUpdateError, updateError, isUpdating]);
 
+    useEffect(() => {
+        if (showModal) {
+            dispatch(setConfirmationModal({
+                action: 'Delete',
+                resourceName: 'Repository',
+                onConfirm: () => deleteMutation(selectedRepo.repositoryId),
+                onDismiss: () => {
+                    setDisabledModel(false);
+                    setShowModal(false);
+                },
+                description: (
+                    <SpaceBetween direction='vertical' size='s'>
+                        <p key={'message'}>This will delete the following repository: {selectedRepo.repositoryId}.</p>
+                        {selectedRepo.editable === false &&
+                            <Alert key={'alert'} type='warning'>
+                                <Checkbox
+                                    checked={disabledModal}
+                                    onChange={({ detail }) => {
+                                        setDisabledModel(detail.checked);
+                                    }}>
+                                    This is a legacy repository configured through YAML. Deleting it will only remove it from the UI, and you will need to redeploy the CDK to remove the associated AWS resources.
+                                </Checkbox>
+                            </Alert>
+                        }
+                    </SpaceBetween>
+                ),
+                disabled: selectedRepo.editable === false && !disabledModal
+            }));
+        }
+    }, [showModal, selectedRepo, disabledModal, deleteMutation, dispatch]);
+
     const items: ButtonDropdownProps.Item[] = [
         {
             id: 'edit',
@@ -120,7 +151,7 @@ function RepositoryActionButton (dispatch: ThunkDispatch<any, any, Action>, noti
             disabled={!selectedRepo}
             loading={isDeleteLoading || isUpdating}
             onItemClick={(e) =>
-                RepositoryActionHandler(e, selectedRepo, dispatch, deleteMutation, setNewRepositoryModalVisible, setEdit)
+                RepositoryActionHandler(e, setNewRepositoryModalVisible, setEdit, setShowModal)
             }
         >
             Actions
@@ -128,13 +159,11 @@ function RepositoryActionButton (dispatch: ThunkDispatch<any, any, Action>, noti
     );
 }
 
-const RepositoryActionHandler = async (
+const RepositoryActionHandler = (
     e: any,
-    selectedRepo: RagRepositoryConfig,
-    dispatch: ThunkDispatch<any, any, Action>,
-    deleteMutation: MutationTrigger<any>,
     setNewRepositoryModalVisible: (boolean) => void,
     setEdit: (boolean) => void,
+    setShowModal: (boolean) => void
 ) => {
     switch (e.detail.id) {
         case 'edit':
@@ -142,14 +171,7 @@ const RepositoryActionHandler = async (
             setNewRepositoryModalVisible(true);
             break;
         case 'rm':
-            dispatch(
-                setConfirmationModal({
-                    action: 'Delete',
-                    resourceName: 'Repository',
-                    onConfirm: () => deleteMutation(selectedRepo.repositoryId),
-                    description: `This will delete the following repository: ${selectedRepo.repositoryId}.`,
-                }),
-            );
+            setShowModal(true);
             break;
         default:
             return;

--- a/lib/user-interface/react/src/components/configuration/RepositoryActions.tsx
+++ b/lib/user-interface/react/src/components/configuration/RepositoryActions.tsx
@@ -62,7 +62,7 @@ function RepositoryActions (props: RepositoryActionProps): ReactElement {
 }
 
 type RagRepository = RagRepositoryConfig & {
-    editable?: boolean
+    legacy?: boolean
 };
 
 function RepositoryActionButton (dispatch: ThunkDispatch<any, any, Action>, notificationService: INotificationService, props: RepositoryActionProps): ReactElement {
@@ -113,7 +113,7 @@ function RepositoryActionButton (dispatch: ThunkDispatch<any, any, Action>, noti
                 description: (
                     <SpaceBetween direction='vertical' size='s'>
                         <p key={'message'}>This will delete the following repository: {selectedRepo.repositoryId}.</p>
-                        {selectedRepo.editable === false &&
+                        {selectedRepo?.legacy &&
                             <Alert key={'alert'} type='warning'>
                                 <Checkbox
                                     checked={disabledModal}
@@ -126,7 +126,7 @@ function RepositoryActionButton (dispatch: ThunkDispatch<any, any, Action>, noti
                         }
                     </SpaceBetween>
                 ),
-                disabled: selectedRepo.editable === false && !disabledModal
+                disabled: selectedRepo?.legacy && !disabledModal
             }));
         }
     }, [showModal, selectedRepo, disabledModal, deleteMutation, dispatch]);
@@ -135,8 +135,8 @@ function RepositoryActionButton (dispatch: ThunkDispatch<any, any, Action>, noti
         {
             id: 'edit',
             text: 'Edit',
-            disabled: selectedItems.length !== 1 || !selectedRepo?.editable,
-            disabledReason: selectedItems.length !== 1 ? '' : !selectedRepo?.editable ? 'Legacy repositories created through YAML cannot be edited.' : undefined
+            disabled: selectedItems.length !== 1 || selectedRepo?.legacy,
+            disabledReason: selectedItems.length !== 1 ? '' : selectedRepo?.legacy ? 'Legacy repositories created through YAML cannot be edited.' : undefined
         },
         {
             id: 'rm',

--- a/lib/user-interface/react/src/components/configuration/RepositoryActions.tsx
+++ b/lib/user-interface/react/src/components/configuration/RepositoryActions.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { ReactElement, useEffect } from 'react';
-import { Button, ButtonDropdown, Icon, SpaceBetween } from '@cloudscape-design/components';
+import { Button, ButtonDropdown, ButtonDropdownProps, Icon, SpaceBetween } from '@cloudscape-design/components';
 import { useAppDispatch } from '../../config/store';
 import { useNotificationService } from '../../shared/util/hooks';
 import { INotificationService } from '../../shared/notification/notification.service';
@@ -62,10 +62,14 @@ function RepositoryActions (props: RepositoryActionProps): ReactElement {
     );
 }
 
+type RagRepository = RagRepositoryConfig & {
+    editable?: boolean
+};
+
 function RepositoryActionButton (dispatch: ThunkDispatch<any, any, Action>, notificationService: INotificationService, props: RepositoryActionProps): ReactElement {
     const { setEdit, selectedItems, setSelectedItems, setNewRepositoryModalVisible } = props;
 
-    const selectedRepo: RagRepositoryConfig = selectedItems[0];
+    const selectedRepo: RagRepository = selectedItems[0];
     const [
         deleteMutation,
         { isSuccess: isDeleteSuccess, isError: isDeleteError, error: deleteError, isLoading: isDeleteLoading },
@@ -96,11 +100,12 @@ function RepositoryActionButton (dispatch: ThunkDispatch<any, any, Action>, noti
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isUpdateSuccess, isUpdateError, updateError, isUpdating]);
 
-    const items = [
+    const items: ButtonDropdownProps.Item[] = [
         {
             id: 'edit',
             text: 'Edit',
-            disabled: selectedItems.length !== 1,
+            disabled: selectedItems.length !== 1 || !selectedRepo?.editable,
+            disabledReason: selectedItems.length !== 1 ? '' : !selectedRepo?.editable ? 'Legacy repositories created through YAML cannot be edited.' : undefined
         },
         {
             id: 'rm',

--- a/lib/user-interface/react/src/components/configuration/createRepository/OpenSearchConfigForm.tsx
+++ b/lib/user-interface/react/src/components/configuration/createRepository/OpenSearchConfigForm.tsx
@@ -30,7 +30,7 @@ type OpenSearchConfigProps = {
     isEdit: boolean
 };
 
-export function OpenSearchConfigForm(props: FormProps<OpenSearchConfig> & OpenSearchConfigProps): ReactElement {
+export function OpenSearchConfigForm (props: FormProps<OpenSearchConfig> & OpenSearchConfigProps): ReactElement {
     const { data: instances, isLoading: isLoadingInstances } = useGetInstancesQuery();
     const { item, touchFields, setFields, formErrors, isEdit } = props;
 

--- a/lib/user-interface/react/src/components/configuration/createRepository/OpenSearchConfigForm.tsx
+++ b/lib/user-interface/react/src/components/configuration/createRepository/OpenSearchConfigForm.tsx
@@ -15,12 +15,11 @@
  */
 
 import Container from '@cloudscape-design/components/container';
-import { Checkbox, Header } from '@cloudscape-design/components';
+import { Checkbox, Header, Tabs } from '@cloudscape-design/components';
 import FormField from '@cloudscape-design/components/form-field';
-import Tiles from '@cloudscape-design/components/tiles';
 import Input from '@cloudscape-design/components/input';
 import Select from '@cloudscape-design/components/select';
-import React, { ReactElement, useMemo, useState } from 'react';
+import React, { ReactElement, useMemo } from 'react';
 import { FormProps } from '../../../shared/form/form-props';
 import { OpenSearchConfig } from '../../../../../../configSchema';
 import { EbsDeviceVolumeType } from '../../../../../../cdk';
@@ -31,8 +30,7 @@ type OpenSearchConfigProps = {
     isEdit: boolean
 };
 
-export function OpenSearchConfigForm (props: FormProps<OpenSearchConfig> & OpenSearchConfigProps): ReactElement {
-    const [useExistingConfig, setUseExistingConfig] = useState('');
+export function OpenSearchConfigForm(props: FormProps<OpenSearchConfig> & OpenSearchConfigProps): ReactElement {
     const { data: instances, isLoading: isLoadingInstances } = useGetInstancesQuery();
     const { item, touchFields, setFields, formErrors, isEdit } = props;
 
@@ -43,109 +41,121 @@ export function OpenSearchConfigForm (props: FormProps<OpenSearchConfig> & OpenS
     return (
         <Container header={<Header variant='h2'>OpenSearch Config</Header>}>
             <SpaceBetween size={'s'}>
-                <FormField>
-                    <Tiles
-                        onChange={({ detail }) => setUseExistingConfig(detail.value)}
-                        columns={-1}
-                        value={useExistingConfig}
-                        items={[
-                            { label: 'Create new', value: '' },
-                            { label: 'Use existing', value: 'true' },
-                        ]}
-                        readOnly={isEdit}
-                    />
-                </FormField>
+                <Tabs
+                    tabs={[
+                        {
+                            label: 'Create new',
+                            id: 'new',
+                            content: (
+                                <SpaceBetween direction='vertical' size='s'>
+                                    <FormField label='Data Nodes'
+                                        errorText={formErrors?.opensearchConfig?.dataNodes}
+                                        description={'The number of data nodes (instances) to use in the Amazon OpenSearch Service domain.'}>
+                                        <Input value={item.dataNodes?.toString()}
+                                            type='number' inputMode='numeric'
+                                            onBlur={() => touchFields(['opensearchConfig.dataNodes'])}
+                                            onChange={({ detail }) => setFields({ 'opensearchConfig.dataNodes': Number(detail.value) })}
+                                            disabled={isEdit} />
+                                    </FormField>
+                                    <FormField label='Data Node Instance Type'
+                                        errorText={formErrors?.opensearchConfig?.dataNodeInstanceType}
+                                        description={'The instance type for your data nodes.'}>
+                                        <Select
+                                            options={instanceOptions}
+                                            selectedOption={{ value: item.dataNodeInstanceType }}
+                                            loadingText='Loading instances'
+                                            disabled={isEdit}
+                                            onBlur={() => touchFields(['opensearchConfig.dataNodeInstanceType'])}
+                                            onChange={({ detail }) => setFields({ 'opensearchConfig.dataNodeInstanceType': detail.selectedOption.value })}
+                                            filteringType='auto'
+                                            statusType={isLoadingInstances ? 'loading' : 'finished'}
+                                            virtualScroll
+                                        />
+                                    </FormField>
+                                    <FormField label='Master Nodes'
+                                        errorText={formErrors?.opensearchConfig?.masterNodes}
+                                        description={'The number of instances to use for the master node.'}>
+                                        <Input value={item.masterNodes?.toString()}
+                                            type='number' inputMode='numeric'
+                                            onBlur={() => touchFields(['opensearchConfig.masterNodes'])}
+                                            onChange={({ detail }) => setFields({ 'opensearchConfig.masterNodes': Number(detail.value) })}
+                                            disabled={isEdit} />
+                                    </FormField>
+                                    <FormField label='Master Node Instance Type'
+                                        errorText={formErrors?.opensearchConfig?.masterNodeInstanceType}
+                                        description={'The hardware configuration of the computer that hosts the dedicated master node'}>
+                                        <Select
+                                            options={instanceOptions}
+                                            selectedOption={{ value: item.masterNodeInstanceType }}
+                                            loadingText='Loading instances'
+                                            disabled={isEdit}
+                                            onBlur={() => touchFields(['opensearchConfig.masterNodeInstanceType'])}
+                                            onChange={({ detail }) => setFields({ 'opensearchConfig.masterNodeInstanceType': detail.selectedOption.value })}
+                                            filteringType='auto'
+                                            statusType={isLoadingInstances ? 'loading' : 'finished'}
+                                            virtualScroll
+                                        />
+                                    </FormField>
+                                    <FormField label='Volume Size'
+                                        errorText={formErrors?.opensearchConfig?.volumeSize}
+                                        description={'The size (in GiB) of the EBS volume for each data node. The minimum and maximum size of an EBS volume depends on the EBS volume type and the instance type to which it is attached.'}>
+                                        <Input value={item.volumeSize?.toString()}
+                                            type='number' inputMode='numeric'
+                                            onBlur={() => touchFields(['opensearchConfig.volumeSize'])}
+                                            onChange={({ detail }) => setFields({ 'opensearchConfig.volumeSize': Number(detail.value) })}
+                                            disabled={isEdit} />
+                                    </FormField>
+                                    <FormField label='Volume Type'
+                                        errorText={formErrors?.opensearchConfig?.volumeType}
+                                        description={'The EBS volume type to use with the Amazon OpenSearch Service domain'}>
+                                        <Select
+                                            selectedOption={{
+                                                label: item.volumeType,
+                                                value: item.volumeType,
+                                            }}
+                                            onChange={({ detail }) => setFields({ 'opensearchConfig.volumeType': detail.selectedOption.value })}
+                                            onBlur={() => touchFields(['opensearchConfig.volumeType'])}
+                                            options={Object.keys(EbsDeviceVolumeType).map((key) => ({
+                                                label: key,
+                                                value: EbsDeviceVolumeType[key],
+                                            }),
+                                            )}
+                                            disabled={isEdit}
+                                        />
+                                    </FormField>
+                                    <FormField>
+                                        <Checkbox
+                                            onChange={({ detail }) => setFields({ 'opensearchConfig.multiAzWithStandby': detail.checked })}
+                                            checked={item.multiAzWithStandby}
+                                            disabled={isEdit}
+                                            description='Indicates whether Multi-AZ with Standby deployment option is enabled.'>
+                                            Multiple AZ With Standby
+                                        </Checkbox>
+                                    </FormField>
+                                </SpaceBetween>
+                            )
+                        },
+                        {
+                            label: 'Use existing',
+                            id: 'second',
+                            content: (
+                                <FormField label='Endpoint'
+                                    errorText={formErrors?.opensearchConfig?.endpoint}
+                                    description={'Existing OpenSearch endoint'}>
+                                    <Input
+                                        value={item.endpoint}
+                                        inputMode='text'
+                                        onBlur={() => touchFields(['opensearchConfig.endpoint'])}
+                                        onChange={({ detail }) => setFields({ 'opensearchConfig.endpoint': detail.value })}
+                                        disabled={isEdit}
+                                        placeholder={'es.region.amazonaws.com '}
+                                    />
+                                </FormField>
+                            )
+                        },
+                    ]}
+                />
             </SpaceBetween>
-            {useExistingConfig ?
-                <FormField label='Endpoint' errorText={formErrors?.opensearchConfig?.endpoint}>
-                    <Input
-                        value={item.endpoint}
-                        inputMode='text'
-                        onBlur={() => touchFields(['opensearchConfig.endpoint'])}
-                        onChange={({ detail }) => setFields({ 'opensearchConfig.endpoint': detail.value })}
-                        disabled={isEdit}
-                    />
-                </FormField>
-                :
-                <>
-                    <FormField label='Data Nodes' errorText={formErrors?.opensearchConfig?.dataNodes}>
-                        <Input value={item.dataNodes?.toString()}
-                            type='number' inputMode='numeric'
-                            onBlur={() => touchFields(['opensearchConfig.dataNodes'])}
-                            onChange={({ detail }) => setFields({ 'opensearchConfig.dataNodes': Number(detail.value) })}
-                            disabled={isEdit} />
-                    </FormField>
-                    <FormField label='Data Node Instance Type'
-                        errorText={formErrors?.opensearchConfig?.dataNodeInstanceType}>
-                        <Select
-                            options={instanceOptions}
-                            selectedOption={{ value: item.dataNodeInstanceType }}
-                            loadingText='Loading instances'
-                            disabled={isEdit}
-                            onBlur={() => touchFields(['opensearchConfig.dataNodeInstanceType'])}
-                            onChange={({ detail }) => setFields({ 'opensearchConfig.dataNodeInstanceType': detail.selectedOption.value })}
-                            filteringType='auto'
-                            statusType={isLoadingInstances ? 'loading' : 'finished'}
-                            virtualScroll
-                        />
-                    </FormField>
-                    <FormField label='Master Nodes'
-                        errorText={formErrors?.opensearchConfig?.masterNodes}>
-                        <Input value={item.masterNodes?.toString()}
-                            type='number' inputMode='numeric'
-                            onBlur={() => touchFields(['opensearchConfig.masterNodes'])}
-                            onChange={({ detail }) => setFields({ 'opensearchConfig.masterNodes': Number(detail.value) })}
-                            disabled={isEdit} />
-                    </FormField>
-                    <FormField label='Master Node Instance Type'
-                        errorText={formErrors?.opensearchConfig?.masterNodeInstanceType}>
-                        <Select
-                            options={instanceOptions}
-                            selectedOption={{ value: item.masterNodeInstanceType }}
-                            loadingText='Loading instances'
-                            disabled={isEdit}
-                            onBlur={() => touchFields(['opensearchConfig.masterNodeInstanceType'])}
-                            onChange={({ detail }) => setFields({ 'opensearchConfig.masterNodeInstanceType': detail.selectedOption.value })}
-                            filteringType='auto'
-                            statusType={isLoadingInstances ? 'loading' : 'finished'}
-                            virtualScroll
-                        />
-                    </FormField>
-                    <FormField label='Volume Size'
-                        errorText={formErrors?.opensearchConfig?.volumeSize}>
-                        <Input value={item.volumeSize?.toString()}
-                            type='number' inputMode='numeric'
-                            onBlur={() => touchFields(['opensearchConfig.volumeSize'])}
-                            onChange={({ detail }) => setFields({ 'opensearchConfig.volumeSize': Number(detail.value) })}
-                            disabled={isEdit} />
-                    </FormField>
-                    <FormField label='Volume Type'
-                        errorText={formErrors?.opensearchConfig?.volumeType}>
-                        <Select
-                            selectedOption={{
-                                label: item.volumeType,
-                                value: item.volumeType,
-                            }}
-                            onChange={({ detail }) => setFields({ 'opensearchConfig.volumeType': detail.selectedOption.value })}
-                            onBlur={() => touchFields(['opensearchConfig.volumeType'])}
-                            options={Object.keys(EbsDeviceVolumeType).map((key) => ({
-                                label: key,
-                                value: EbsDeviceVolumeType[key],
-                            }),
-                            )}
-                            disabled={isEdit}
-                        />
-                    </FormField>
-                    <FormField>
-                        <Checkbox
-                            onChange={({ detail }) => setFields({ 'opensearchConfig.multiAzWithStandby': detail.checked })}
-                            checked={item.multiAzWithStandby}
-                            disabled={isEdit}>
-                            Multiple AZ With Standby
-                        </Checkbox>
-                    </FormField>
-                </>
-            }
         </Container>
     );
 }

--- a/lib/user-interface/react/src/components/configuration/createRepository/PipelineConfigForm.tsx
+++ b/lib/user-interface/react/src/components/configuration/createRepository/PipelineConfigForm.tsx
@@ -85,6 +85,7 @@ export function PipelineConfigForm (props: FormProps<PipelineConfig[]> & Pipelin
                         <FormField
                             label='Chunk Size'
                             errorText={formErrors.pipelines?.[index]?.chunkSize}
+                            description={'The size of the chunks used for document segmentation.'}
                         >
                             <Input
                                 type='number' inputMode='numeric'
@@ -99,6 +100,7 @@ export function PipelineConfigForm (props: FormProps<PipelineConfig[]> & Pipelin
                         <FormField
                             label='Chunk Overlap'
                             errorText={formErrors.pipelines?.[index]?.chunkOverlap}
+                            description={'The size of the overlap between chunks.'}
                         >
                             <Input
                                 type='number' inputMode='numeric'
@@ -113,6 +115,7 @@ export function PipelineConfigForm (props: FormProps<PipelineConfig[]> & Pipelin
                         <FormField
                             label='Embedding Model'
                             errorText={formErrors.pipelines?.[index]?.embeddingModel}
+                            description={'The embedding model used for document ingestion in this pipeline.'}
                         >
                             <Select
                                 options={embeddingOptions}
@@ -130,6 +133,7 @@ export function PipelineConfigForm (props: FormProps<PipelineConfig[]> & Pipelin
                         <FormField
                             label='S3 Bucket'
                             errorText={formErrors.pipelines?.[index]?.s3Bucket}
+                            description={'The S3 bucket monitored by this pipeline for document processing.'}
                         >
                             <Input
                                 value={pipeline.s3Bucket}
@@ -142,7 +146,8 @@ export function PipelineConfigForm (props: FormProps<PipelineConfig[]> & Pipelin
 
                         <FormField
                             label='S3 Prefix'
-                            errorText={formErrors.pipelines?.[index]?.s3Prefix}>
+                            errorText={formErrors.pipelines?.[index]?.s3Prefix}
+                            description={'The prefix within the S3 bucket monitored for document processing.'}>
                             <Input
                                 value={pipeline.s3Prefix}
                                 onChange={({ detail }) =>
@@ -154,15 +159,16 @@ export function PipelineConfigForm (props: FormProps<PipelineConfig[]> & Pipelin
 
                         <FormField
                             label='Trigger'
-                            errorText={formErrors.pipelines?.[index]?.trigger}>
+                            errorText={formErrors.pipelines?.[index]?.trigger}
+                            description={'The event type that triggers document ingestion.'}>
                             <Select
                                 selectedOption={{ label: pipeline.trigger, value: pipeline.trigger }}
                                 onChange={({ detail }) =>
                                     onChange(index, 'trigger', detail.selectedOption.value as 'daily' | 'event')
                                 }
                                 options={[
-                                    { label: 'Daily', value: 'daily' },
-                                    { label: 'Event', value: 'event' },
+                                    { label: 'Daily', value: 'daily', description: 'This ingestion pipeline is scheduled to run once per day.' },
+                                    { label: 'Event', value: 'event', description: 'This ingestion pipeline runs whenever changes are detected.' },
                                 ]}
                                 onBlur={() => touchFields([`pipelines[${index}].trigger`])}
                             />

--- a/lib/user-interface/react/src/components/configuration/createRepository/RdsConfigForm.tsx
+++ b/lib/user-interface/react/src/components/configuration/createRepository/RdsConfigForm.tsx
@@ -26,7 +26,7 @@ type RdsConfigProps = {
     isEdit: boolean
 };
 
-export function RdsConfigForm(props: FormProps<RdsConfigSchema> & RdsConfigProps): ReactElement {
+export function RdsConfigForm (props: FormProps<RdsConfigSchema> & RdsConfigProps): ReactElement {
     const { item, touchFields, setFields, formErrors, isEdit } = props;
 
     return (

--- a/lib/user-interface/react/src/components/configuration/createRepository/RdsConfigForm.tsx
+++ b/lib/user-interface/react/src/components/configuration/createRepository/RdsConfigForm.tsx
@@ -15,7 +15,7 @@
  */
 
 import Container from '@cloudscape-design/components/container';
-import { Header } from '@cloudscape-design/components';
+import { Header, SpaceBetween } from '@cloudscape-design/components';
 import FormField from '@cloudscape-design/components/form-field';
 import Input from '@cloudscape-design/components/input';
 import React, { ReactElement } from 'react';
@@ -26,46 +26,54 @@ type RdsConfigProps = {
     isEdit: boolean
 };
 
-export function RdsConfigForm (props: FormProps<RdsConfigSchema> & RdsConfigProps): ReactElement {
+export function RdsConfigForm(props: FormProps<RdsConfigSchema> & RdsConfigProps): ReactElement {
     const { item, touchFields, setFields, formErrors, isEdit } = props;
 
     return (
-        <Container header={<Header variant='h2'>RDS Config</Header>}>
-            <FormField label='Username' errorText={formErrors?.rdsConfig?.username}>
-                <Input value={item.username} inputMode='text'
-                    onBlur={() => touchFields(['rdsConfig.username'])}
-                    onChange={({ detail }) => setFields({ 'rdsConfig.username': detail.value })}
-                    placeholder='RDS Username' disabled={isEdit} />
-            </FormField>
-            <FormField label='Password Secret Id (optional)'
-                errorText={formErrors?.rdsConfig?.passwordSecretId}>
-                <Input value={item.passwordSecretId} inputMode='text'
-                    onBlur={() => touchFields(['rdsConfig.passwordSecretId'])}
-                    onChange={({ detail }) => setFields({ 'rdsConfig.passwordSecretId': detail.value })}
-                    placeholder='RDS Password Secret Id' disabled={isEdit} />
-            </FormField>
-            <FormField label='DB Host (optional)'
-                errorText={formErrors?.rdsConfig?.dbHost}>
-                <Input value={item.dbHost} inputMode='text'
-                    onBlur={() => touchFields(['rdsConfig.dbHost'])}
-                    onChange={({ detail }) => setFields({ 'rdsConfig.dbHost': detail.value })}
-                    placeholder='DB Host' disabled={isEdit} />
-            </FormField>
-            <FormField label='DB Name'
-                errorText={formErrors?.rdsConfig?.dbName}>
-                <Input value={item.dbName} inputMode='text'
-                    onBlur={() => touchFields(['rdsConfig.dbName'])}
-                    onChange={({ detail }) => setFields({ 'rdsConfig.dbName': detail.value })}
-                    placeholder='DB Name' disabled={isEdit} />
-            </FormField>
-            <FormField label='DB Port'
-                errorText={formErrors?.rdsConfig?.dbPort}>
-                <Input value={item.dbPort?.toString()}
-                    type='number' inputMode='numeric'
-                    onBlur={() => touchFields(['rdsConfig.dbPort'])}
-                    onChange={({ detail }) => setFields({ 'rdsConfig.dbPort': Number(detail.value) })}
-                    disabled={isEdit} />
-            </FormField>
+        <Container header={<Header variant='h2'>PostgreSQL Config</Header>}>
+            <SpaceBetween direction='vertical' size='s'>
+                <FormField label='Username' key={'username'}
+                    errorText={formErrors?.rdsConfig?.username}
+                    description={'The username used for database connection.'}>
+                    <Input value={item.username} inputMode='text'
+                        onBlur={() => touchFields(['rdsConfig.username'])}
+                        onChange={({ detail }) => setFields({ 'rdsConfig.username': detail.value })}
+                        placeholder='Username' disabled={isEdit} />
+                </FormField>
+                <FormField label='Password Secret Id - optional' key={'password'}
+                    errorText={formErrors?.rdsConfig?.passwordSecretId}
+                    description={'The SecretsManager Secret ID that stores the existing database password.'}>
+                    <Input value={item.passwordSecretId} inputMode='text'
+                        onBlur={() => touchFields(['rdsConfig.passwordSecretId'])}
+                        onChange={({ detail }) => setFields({ 'rdsConfig.passwordSecretId': detail.value })}
+                        placeholder='Password Secret Id' disabled={isEdit} />
+                </FormField>
+                <FormField label='Host - optional' key={'host'}
+                    errorText={formErrors?.rdsConfig?.dbHost}
+                    description={'Database hostname for existing database instance.'}>
+                    <Input value={item.dbHost} inputMode='text'
+                        onBlur={() => touchFields(['rdsConfig.dbHost'])}
+                        onChange={({ detail }) => setFields({ 'rdsConfig.dbHost': detail.value })}
+                        placeholder='rds.region.amazonaws.com ' disabled={isEdit} />
+                </FormField>
+                <FormField label='Name' key={'name'}
+                    errorText={formErrors?.rdsConfig?.dbName}
+                    description={'The name of the database for the database instance.'}>
+                    <Input value={item.dbName} inputMode='text'
+                        onBlur={() => touchFields(['rdsConfig.dbName'])}
+                        onChange={({ detail }) => setFields({ 'rdsConfig.dbName': detail.value })}
+                        placeholder='postgres' disabled={isEdit} />
+                </FormField>
+                <FormField label='Port' key={'port'}
+                    errorText={formErrors?.rdsConfig?.dbPort}
+                    description={'The port of the existing database instance or the port to be opened on the database instance.'}>
+                    <Input value={item.dbPort?.toString()}
+                        type='number' inputMode='numeric'
+                        onBlur={() => touchFields(['rdsConfig.dbPort'])}
+                        onChange={({ detail }) => setFields({ 'rdsConfig.dbPort': Number(detail.value) })}
+                        disabled={isEdit} />
+                </FormField>
+            </SpaceBetween>
         </Container>
     );
 }

--- a/lib/user-interface/react/src/components/configuration/createRepository/RepositoryConfigForm.tsx
+++ b/lib/user-interface/react/src/components/configuration/createRepository/RepositoryConfigForm.tsx
@@ -39,21 +39,27 @@ export function RepositoryConfigForm (props: FormProps<RagRepositoryConfig> & Re
     const { item, touchFields, setFields, formErrors, isEdit } = props;
     return (
         <SpaceBetween size={'s'}>
-            <FormField label='Repository ID' errorText={formErrors?.repositoryId}>
+            <FormField label='Repository ID'
+                errorText={formErrors?.repositoryId}
+                description={'A unique identifier for the repository, used in API calls and the UI. It must be distinct across all repositories.'}>
                 <Input value={item.repositoryId} inputMode='text'
                     onBlur={() => touchFields(['repositoryId'])}
                     onChange={({ detail }) => {
                         setFields({ 'repositoryId': detail.value });
                     }} disabled={isEdit} placeholder='postgres-rag' />
             </FormField>
-            <FormField label='Repository Name (optional)' errorText={formErrors?.repositoryName}>
+            <FormField label='Repository Name - optional'
+                errorText={formErrors?.repositoryName}
+                description={'The user-friendly name displayed in the UI.'}>
                 <Input value={item.repositoryName} inputMode='text'
                     onBlur={() => touchFields(['repositoryName'])}
                     onChange={({ detail }) => {
                         setFields({ 'repositoryName': detail.value });
                     }} placeholder='Postgres RAG' />
             </FormField>
-            <FormField label='Repository Type' errorText={formErrors?.type}>
+            <FormField label='Repository Type'
+                errorText={formErrors?.type}
+                description={'The vector store designated for this repository.'}>
                 <Select
                     selectedOption={{ label: item.type, value: item.type }}
                     onChange={({ detail }) => {
@@ -95,6 +101,7 @@ export function RepositoryConfigForm (props: FormProps<RagRepositoryConfig> & Re
                 errorText={formErrors?.allowedGroups}
                 values={item.allowedGroups ?? []}
                 onChange={(detail) => setFields({ 'allowedGroups': detail })}
+                description={'The groups provided by the Identity Provider that have access to this repository. If no groups are specified, access is granted to everyone.'}
             ></ArrayInputField>
 
         </SpaceBetween>

--- a/lib/user-interface/react/src/shared/form/array-input.tsx
+++ b/lib/user-interface/react/src/shared/form/array-input.tsx
@@ -20,7 +20,6 @@ import Input from '@cloudscape-design/components/input';
 import { Button, SpaceBetween } from '@cloudscape-design/components';
 
 type ArrayInputProps = FormFieldProps & {
-    // label: string;
     values: string[];
     onChange: (newValues: string[]) => void;
 };

--- a/lib/user-interface/react/src/shared/form/array-input.tsx
+++ b/lib/user-interface/react/src/shared/form/array-input.tsx
@@ -15,18 +15,19 @@
 */
 
 import React, { ReactElement } from 'react';
-import FormField from '@cloudscape-design/components/form-field';
+import FormField, { FormFieldProps } from '@cloudscape-design/components/form-field';
 import Input from '@cloudscape-design/components/input';
 import { Button, SpaceBetween } from '@cloudscape-design/components';
 
-type ArrayInputProps = {
-    label: string;
+type ArrayInputProps = FormFieldProps & {
+    // label: string;
     values: string[];
     onChange: (newValues: string[]) => void;
-    errorText?: string;
 };
 
-export function ArrayInputField ({ label, values, onChange, errorText }: ArrayInputProps): ReactElement {
+export function ArrayInputField (props: ArrayInputProps): ReactElement {
+    const { onChange, values } = props;
+
     const handleInputChange = (index: number, value: string) => {
         const newValues = [...values];
         newValues[index] = value;
@@ -44,8 +45,7 @@ export function ArrayInputField ({ label, values, onChange, errorText }: ArrayIn
 
     return (
         <FormField
-            label={label}
-            errorText={errorText}
+            {...props}
         >
             <SpaceBetween size='xs'>
                 {values.map((value, index) => (

--- a/lib/user-interface/react/src/shared/modal/confirmation-modal.tsx
+++ b/lib/user-interface/react/src/shared/modal/confirmation-modal.tsx
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-import { Modal as CloudscapeModal, Box, SpaceBetween, Button } from '@cloudscape-design/components';
+import { Modal as CloudscapeModal, Box, SpaceBetween, Button, ModalProps, NonCancelableCustomEvent } from '@cloudscape-design/components';
 import React, { ReactElement, useState } from 'react';
 import { useAppDispatch } from '../../config/store';
 import { dismissModal } from '../reducers/modal.reducer';
@@ -28,6 +28,7 @@ export type ConfirmationModalProps = {
     postConfirm?: CallbackFunction;
     description?: string | ReactElement;
     disabled?: boolean;
+    onDismiss?: (event?: NonCancelableCustomEvent<ModalProps.DismissDetail>) => void;
 };
 
 function ConfirmationModal ({
@@ -37,19 +38,20 @@ function ConfirmationModal ({
     postConfirm,
     description,
     disabled,
+    onDismiss
 }: ConfirmationModalProps) : ReactElement{
     const [processing, setProcessing] = useState(false);
     const dispatch = useAppDispatch();
 
     return (
         <CloudscapeModal
-            onDismiss={() => [dispatch(dismissModal())]}
+            onDismiss={(event) => [dispatch(dismissModal()), onDismiss?.(event)]}
             visible={true}
             closeAriaLabel='Close modal'
             footer={
                 <Box float='right'>
                     <SpaceBetween direction='horizontal' size='xs'>
-                        <Button onClick={() => [dispatch(dismissModal())]}>
+                        <Button onClick={() => [dispatch(dismissModal()), onDismiss?.()]}>
                             Cancel
                         </Button>
                         <Button
@@ -59,6 +61,7 @@ function ConfirmationModal ({
                                 setProcessing(true);
                                 await onConfirm();
                                 dispatch(dismissModal());
+                                onDismiss?.();
                                 if (postConfirm) {
                                     postConfirm();
                                 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Although legacy vector stores cannot be edited through the UI, we aim to enable their deletion. While this will not remove the resources, it will render them inactive and allow for their destruction during the next deployment. This PR also includes the following UI improvements:

- Disabled the edit option for legacy repositories.
- Updated the create repository form to include descriptions.
- Added a mandatory acknowledgment when deleting legacy repositories, informing users that a deployment is required to actually remove AWS resources.

<img width="853" alt="Screenshot 2025-02-16 at 21 43 00" src="https://github.com/user-attachments/assets/a99fc889-ed7e-489b-aa74-7fa1d6aaf9a8" />

<img width="625" alt="Screenshot 2025-02-16 at 21 11 54" src="https://github.com/user-attachments/assets/ea02f5ad-a7ab-4555-a757-e18a9d27392b" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
