### PR TITLE
Properly display error messages from proxied calls

### DIFF
--- a/lib/serve/rest-api/src/api/endpoints/v2/litellm_passthrough.py
+++ b/lib/serve/rest-api/src/api/endpoints/v2/litellm_passthrough.py
@@ -130,14 +130,16 @@ async def litellm_passthrough(request: Request, api_path: str) -> Response:
 
     http_method = request.method
     if http_method == "GET":
-        return JSONResponse(requests.request(method=http_method, url=litellm_path, headers=headers).json())
+        response = requests.request(method=http_method, url=litellm_path, headers=headers)
+        return JSONResponse(response.json(), status_code=response.status_code)
     # not a GET request, so expect a JSON payload as part of the request
     params = await request.json()
     if params.get("stream", False):  # if a streaming request
         response = requests.request(method=http_method, url=litellm_path, json=params, headers=headers, stream=True)
-        return StreamingResponse(generate_response(response.iter_lines()))
+        return StreamingResponse(generate_response(response.iter_lines()), status_code=response.status_code)
     else:  # not a streaming request
-        return JSONResponse(requests.request(method=http_method, url=litellm_path, json=params, headers=headers).json())
+        response = requests.request(method=http_method, url=litellm_path, json=params, headers=headers)
+        return JSONResponse(response.json(), status_code=response.status_code)
 
 
 def refresh_management_tokens() -> list[str]:

--- a/lib/user-interface/react/src/components/chatbot/Chat.tsx
+++ b/lib/user-interface/react/src/components/chatbot/Chat.tsx
@@ -271,7 +271,11 @@ export default function Chat ({ sessionId }) {
                 await memory.saveContext({input: params.inputs.input}, {output: resp.join('')});
                 setIsStreaming(false);
             } catch (exception) {
-                notificationService.generateNotification('An error occurred while processing your request.', 'error');
+                setSession((prev) => ({
+                    ...prev,
+                    history: prev.history.slice(0, -1),
+                }));
+                notificationService.generateNotification('An error occurred while processing your request.', 'error', undefined, exception.error?.message ? <p>{JSON.stringify(exception.error.message)}</p> : undefined);
             }
         };
 
@@ -290,7 +294,7 @@ export default function Chat ({ sessionId }) {
                     ),
                 }));
             } catch (exception) {
-                notificationService.generateNotification('An error occurred while processing your request.', 'error');
+                notificationService.generateNotification('An error occurred while processing your request.', 'error', undefined, exception.error?.message ? <p>{JSON.stringify(exception.error.message)}</p> : undefined);
             }
         };
 


### PR DESCRIPTION
LISA has not properly displayed error messages for quite some time, this is because all responses were returning http_status 200. Updated BE to pass back the status code from the proxied call.


![Screenshot 2025-03-03 at 2 28 17 PM](https://github.com/user-attachments/assets/f1a75622-d743-4156-8170-9b9abd272e6e)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
