### PR TITLE
Fix cdk bootstrap in make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ PROJECT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 HEADLESS = false
 DOCKER_CMD ?= $(or $(CDK_DOCKER),docker)
 
-# Arguments defined through command line or config.yaml
 
 # PROFILE (optional argument)
 ifeq (${PROFILE},)
@@ -131,13 +130,13 @@ bootstrap:
 	@printf "Bootstrapping: $(ACCOUNT_NUMBER) | $(REGION) | $(PARTITION)\n"
 
 ifdef PROFILE
-	@cdk bootstrap \
+	@npx cdk bootstrap \
 		--profile $(PROFILE) \
 		aws://$(ACCOUNT_NUMBER)/$(REGION) \
 		--partition $(PARTITION) \
 		--cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess
 else
-	@cdk bootstrap \
+	@npx cdk bootstrap \
 		aws://$(ACCOUNT_NUMBER)/$(REGION) \
 		--partition $(PARTITION) \
 		--cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess


### PR DESCRIPTION
Use npx with cdk bootstrap in make file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
