### PR TITLE
Subnet import fix

### DIFF
--- a/lib/networking/vpc/index.ts
+++ b/lib/networking/vpc/index.ts
@@ -73,7 +73,10 @@ export class Vpc extends Construct {
             // A VPC must be supplied if Subnets are being used.
             if (config.subnets && config.subnets.length > 0) {
                 this.subnetSelection = {
-                    subnets: props.config.subnets?.map((subnet, index) => Subnet.fromSubnetId(this, index.toString(), subnet.subnetId))
+                    subnets: props.config.subnets?.map((subnet, index) => Subnet.fromSubnetAttributes(this, index.toString(), {
+                        subnetId: subnet.subnetId,
+                        ipv4CidrBlock: subnet.ipv4CidrBlock
+                    }))
                 };
 
                 this.subnetGroup = new SubnetGroup(this, createCdkId([config.deploymentName, 'Imported-Subnets']), {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When using an existing VPC and subnets, the subnets were being imported incorrectly, causing an exception during CDK synthesis. This fix addresses the issue by ensuring that subnets are imported with the `ipv4CidrBlock` property defined, as it is required for our configuration.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
