### PR TITLE
Decouple RAG and UI

### DIFF
--- a/lambda/authorizer/lambda_functions.py
+++ b/lambda/authorizer/lambda_functions.py
@@ -68,7 +68,7 @@ def lambda_handler(event: Dict[str, Any], context) -> Dict[str, Any]:  # type: i
         logger.debug(f"Generated policy: {allow_policy}")
         return allow_policy
 
-    if is_valid_api_token(id_token):
+    if os.environ.get("TOKEN_TABLE_NAME", None) and is_valid_api_token(id_token):
         username = "api-token"
         groups = json.dumps([])
         allow_policy = generate_policy(effect="Allow", resource=event["methodArn"], username=username)

--- a/lambda/authorizer/lambda_functions.py
+++ b/lambda/authorizer/lambda_functions.py
@@ -32,8 +32,8 @@ logger = logging.getLogger(__name__)
 
 secrets_manager = boto3.client("secretsmanager", region_name=os.environ["AWS_REGION"], config=retry_config)
 ddb_resource = boto3.resource("dynamodb", region_name=os.environ["AWS_REGION"])
-token_table = ddb_resource.Table(os.environ.get("TOKEN_TABLE_NAME", ""))
-TOKEN_EXPIRATION_NAME = "tokenExpiration"
+token_table = ddb_resource.Table(os.environ.get("TOKEN_TABLE_NAME", ""))  # nosec B105
+TOKEN_EXPIRATION_NAME = "tokenExpiration"  # nosec B105
 
 
 @authorization_wrapper
@@ -117,9 +117,7 @@ def _get_token_info(token: str) -> Any:
     return ddb_response.get("Item", None)
 
 
-def is_valid_api_token(value: str) -> bool:
-    """Return if API Token from request headers is valid if found."""
-    token = value.removeprefix("Bearer").strip()
+def is_valid_api_token(token: str) -> bool:
     if token:
         token_info = _get_token_info(token)
         if token_info:

--- a/lambda/authorizer/lambda_functions.py
+++ b/lambda/authorizer/lambda_functions.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import ssl
+from datetime import datetime
 from functools import cache
 from typing import Any, Dict, Optional
 
@@ -30,6 +31,9 @@ from utilities.common_functions import authorization_wrapper, get_id_token, retr
 logger = logging.getLogger(__name__)
 
 secrets_manager = boto3.client("secretsmanager", region_name=os.environ["AWS_REGION"], config=retry_config)
+ddb_resource = boto3.resource("dynamodb", region_name=os.environ["AWS_REGION"])
+token_table = ddb_resource.Table(os.environ.get("TOKEN_TABLE_NAME", ""))
+TOKEN_EXPIRATION_NAME = "tokenExpiration"
 
 
 @authorization_wrapper
@@ -59,6 +63,14 @@ def lambda_handler(event: Dict[str, Any], context) -> Dict[str, Any]:  # type: i
         username = "lisa-management-token"
         # Add management token to Admin groups
         groups = json.dumps([admin_group])
+        allow_policy = generate_policy(effect="Allow", resource=event["methodArn"], username=username)
+        allow_policy["context"] = {"username": username, "groups": groups}
+        logger.debug(f"Generated policy: {allow_policy}")
+        return allow_policy
+
+    if is_valid_api_token(id_token):
+        username = "api-token"
+        groups = json.dumps([])
         allow_policy = generate_policy(effect="Allow", resource=event["methodArn"], username=username)
         allow_policy["context"] = {"username": username, "groups": groups}
         logger.debug(f"Generated policy: {allow_policy}")
@@ -97,6 +109,25 @@ def generate_policy(*, effect: str, resource: str, username: str = "username") -
         },
     }
     return policy
+
+
+def _get_token_info(token: str) -> Any:
+    """Return DDB entry for token if it exists."""
+    ddb_response = token_table.get_item(Key={"token": token}, ReturnConsumedCapacity="NONE")
+    return ddb_response.get("Item", None)
+
+
+def is_valid_api_token(value: str) -> bool:
+    """Return if API Token from request headers is valid if found."""
+    token = value.removeprefix("Bearer").strip()
+    if token:
+        token_info = _get_token_info(token)
+        if token_info:
+            token_expiration = int(token_info.get(TOKEN_EXPIRATION_NAME, datetime.max.timestamp()))
+            current_time = int(datetime.now().timestamp())
+            if current_time < token_expiration:  # token has not expired yet
+                return True
+    return False
 
 
 def id_token_is_valid(*, id_token: str, client_id: str, authority: str) -> Dict[str, Any] | None:

--- a/lambda/utilities/common_functions.py
+++ b/lambda/utilities/common_functions.py
@@ -350,7 +350,7 @@ def get_rest_api_container_endpoint() -> str:
 def get_username(event: dict) -> str:
     """Get the username from the event."""
     try:
-        return str(event["requestContext"]["authorizer"]["claims"]["username"])
+        return str(event["requestContext"]["authorizer"]["username"])
     except (KeyError, TypeError):
         raise ValueError("Missing username in request context")
 

--- a/lib/api-base/authorizer.ts
+++ b/lib/api-base/authorizer.ts
@@ -98,7 +98,7 @@ export class CustomAuthorizer extends Construct {
                 ADMIN_GROUP: config.authConfig!.adminGroup,
                 JWT_GROUPS_PROP: config.authConfig!.jwtGroupsProperty,
                 MANAGEMENT_KEY_NAME: managementKeySecretNameStringParameter.stringValue,
-                TOKEN_TABLE_NAME: tokenTable?.tableName ?? 'undefined',
+                ...(tokenTable ? { TOKEN_TABLE_NAME: tokenTable?.tableName } : {})
             },
             role: role,
             vpc: vpc.vpc,

--- a/lib/core/api_base.ts
+++ b/lib/core/api_base.ts
@@ -22,9 +22,11 @@ import { CustomAuthorizer } from '../api-base/authorizer';
 import { BaseProps } from '../schema';
 import { Vpc } from '../networking/vpc';
 import { Role } from 'aws-cdk-lib/aws-iam';
+import { ITable } from 'aws-cdk-lib/aws-dynamodb';
 
 type LisaApiBaseStackProps = {
     vpc: Vpc;
+    tokenTable: ITable | undefined;
 } & BaseProps &
     StackProps;
 
@@ -38,7 +40,7 @@ export class LisaApiBaseStack extends Stack {
     constructor (scope: Construct, id: string, props: LisaApiBaseStackProps) {
         super(scope, id, props);
 
-        const { config, vpc } = props;
+        const { config, vpc, tokenTable } = props;
 
         const deployOptions: StageOptions = {
             stageName: config.deploymentStage,
@@ -63,6 +65,7 @@ export class LisaApiBaseStack extends Stack {
         const authorizer = new CustomAuthorizer(this, 'LisaApiAuthorizer', {
             config: config,
             securityGroups: [vpc.securityGroups.lambdaSg],
+            tokenTable,
             vpc,
             ...(config.roles &&
             {

--- a/lib/schema/configSchema.ts
+++ b/lib/schema/configSchema.ts
@@ -783,14 +783,6 @@ export const RawConfigSchema = RawConfigObject
     )
     .refine(
         (config) => {
-            return !(config.deployRag && !config.deployUi);
-        },
-        {
-            message: 'UI Stack is needed for Rag stack. You must set deployUI to true if deployRag is true.',
-        },
-    )
-    .refine(
-        (config) => {
             return (
                 !(config.deployChat || config.deployRag || config.deployUi) ||
                 config.authConfig

--- a/lib/serve/index.ts
+++ b/lib/serve/index.ts
@@ -72,9 +72,9 @@ export class LisaServeApplicationStack extends Stack {
                 encryption: TableEncryption.AWS_MANAGED,
                 removalPolicy: config.removalPolicy,
             });
-
-            this.tokenTable = tokenTable;
         }
+
+        this.tokenTable = tokenTable;
 
         // Create REST API
         const restApi = new FastApiContainer(this, 'RestApi', {

--- a/lib/serve/index.ts
+++ b/lib/serve/index.ts
@@ -18,7 +18,7 @@
 import path from 'node:path';
 
 import { Stack, StackProps } from 'aws-cdk-lib';
-import { AttributeType, BillingMode, Table, TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { AttributeType, BillingMode, ITable, Table, TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
 import { Credentials, DatabaseInstance, DatabaseInstanceEngine } from 'aws-cdk-lib/aws-rds';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
@@ -47,6 +47,7 @@ export class LisaServeApplicationStack extends Stack {
     public readonly restApi: FastApiContainer;
     public readonly modelsPs: StringParameter;
     public readonly endpointUrl: StringParameter;
+    public readonly tokenTable: ITable | undefined;
 
     /**
    * @param {Construct} scope - The parent or owner of the construct.
@@ -71,6 +72,8 @@ export class LisaServeApplicationStack extends Stack {
                 encryption: TableEncryption.AWS_MANAGED,
                 removalPolicy: config.removalPolicy,
             });
+
+            this.tokenTable = tokenTable;
         }
 
         // Create REST API

--- a/lib/stages.ts
+++ b/lib/stages.ts
@@ -192,6 +192,7 @@ export class LisaServeApplicationStage extends Stage {
 
         const apiBaseStack = new LisaApiBaseStack(this, 'LisaApiBase', {
             ...baseStackProps,
+            tokenTable: serveStack.tokenTable,
             stackName: createCdkId([config.deploymentName, config.appName, 'API']),
             description: `LISA-API: ${config.deploymentName}-${config.deploymentStage}`,
             vpc: networkingStack.vpc

--- a/test/cdk/mocks/MockApp.ts
+++ b/test/cdk/mocks/MockApp.ts
@@ -71,8 +71,14 @@ export default class MockApp {
             ...baseStackProps,
             stackName: 'LisaNetworking'
         });
+        const serveStack = new LisaServeApplicationStack(app, 'LisaServe', {
+            ...baseStackProps,
+            stackName: 'LisaServe',
+            vpc: networkingStack.vpc,
+        });
         const apiBaseStack = new LisaApiBaseStack(app, 'LisaApiBase', {
             ...baseStackProps,
+            tokenTable: serveStack.tokenTable,
             stackName: 'LisaApiBase',
             vpc: networkingStack.vpc,
         });
@@ -94,11 +100,6 @@ export default class MockApp {
             ...baseStackProps,
             stackName: 'LisaIAM',
             config: config,
-        });
-        const serveStack = new LisaServeApplicationStack(app, 'LisaServe', {
-            ...baseStackProps,
-            stackName: 'LisaServe',
-            vpc: networkingStack.vpc,
         });
 
         const uiStack = new UserInterfaceStack(app, 'LisaUI', {


### PR DESCRIPTION
*Description of changes:*
- Removed hard dependency in schema for RAG and UI to both be deployed
- Added ability for users to be able to auth with LISA APIs with tokens
- Tested this:
  - Deployed LISA without UI
  - Made API call to create embedding model - with admin secret
  - Made API call to create RAG Repo - with admin secret
  - Made API call  to ingest document - with token from token table
  - Made API call to do similarity search - with token from token table


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
