### PR TITLE
Allow pipeline with 0 chunk size

### DIFF
--- a/lambda/utilities/common_functions.py
+++ b/lambda/utilities/common_functions.py
@@ -357,10 +357,8 @@ def get_rest_api_container_endpoint() -> str:
 
 def get_username(event: dict) -> str:
     """Get the username from the event."""
-    try:
-        return str(event["requestContext"]["authorizer"]["username"])
-    except (KeyError, TypeError):
-        raise ValueError("Missing username in request context")
+    username: str = event.get("requestContext", {}).get("authorizer", {}).get("username", "system")
+    return username
 
 
 def is_admin(event: dict) -> bool:

--- a/lambda/utilities/file_processing.py
+++ b/lambda/utilities/file_processing.py
@@ -154,7 +154,11 @@ def process_record(
         s3_uri = _get_s3_uri(bucket=bucket, key=key)
         extracted_text = _extract_text_by_content_type(content_type=content_type, s3_object=s3_object)
         docs = [Document(page_content=extracted_text, metadata=_get_metadata(s3_uri=s3_uri, name=key))]
-        doc_chunks = _generate_chunks(docs, chunk_size=chunk_size, chunk_overlap=chunk_overlap) if chunk_size > 0 else docs
+        doc_chunks = (
+            _generate_chunks(docs, chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+            if chunk_size and chunk_size > 0
+            else docs
+        )
         # Update part number of doc metadata
         for i, doc in enumerate(doc_chunks):
             doc.metadata["part"] = i + 1

--- a/lambda/utilities/file_processing.py
+++ b/lambda/utilities/file_processing.py
@@ -154,7 +154,7 @@ def process_record(
         s3_uri = _get_s3_uri(bucket=bucket, key=key)
         extracted_text = _extract_text_by_content_type(content_type=content_type, s3_object=s3_object)
         docs = [Document(page_content=extracted_text, metadata=_get_metadata(s3_uri=s3_uri, name=key))]
-        doc_chunks = _generate_chunks(docs, chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+        doc_chunks = _generate_chunks(docs, chunk_size=chunk_size, chunk_overlap=chunk_overlap) if chunk_size > 0 else docs
         # Update part number of doc metadata
         for i, doc in enumerate(doc_chunks):
             doc.metadata["part"] = i + 1

--- a/lambda/utilities/validation.py
+++ b/lambda/utilities/validation.py
@@ -123,7 +123,7 @@ def validate_chunk_params(chunk_size: Optional[int], chunk_overlap: Optional[int
         if not isinstance(chunk_size, int):
             raise ValidationError("Chunk size must be an integer")
 
-        if chunk_size < 100 or chunk_size > 10000:
+        if 100 > chunk_size > 0 or chunk_size > 10000:
             raise ValidationError("Chunk size must be between 100 and 10000")
 
     if chunk_overlap is not None:

--- a/lib/rag/index.ts
+++ b/lib/rag/index.ts
@@ -266,6 +266,7 @@ export class LisaRagStack extends Stack {
         baseEnvironment['LISA_RAG_VECTOR_STORE_TABLE'] = ragRepositoryConfigTable.tableName;
         baseEnvironment['LISA_RAG_CREATE_STATE_MACHINE_ARN_PARAMETER'] = `${config.deploymentPrefix}/vectorstorecreator/statemachine/create`;
         baseEnvironment['LISA_RAG_DELETE_STATE_MACHINE_ARN_PARAMETER'] = `${config.deploymentPrefix}/vectorstorecreator/statemachine/delete`;
+        baseEnvironment['MANAGEMENT_KEY_SECRET_NAME_PS'] = `${config.deploymentPrefix}/managementKeySecretName`;
 
         new IngestPipelineStateMachine(this, 'IngestPipelineStateMachine', {
             config,


### PR DESCRIPTION
Allow users to setup pipeline with 0 chunk size allowing ingestion of entire documents as a single chunk


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
