### PR TITLE
Properly set certificates for lambdas and ECS containers. 

### DIFF
--- a/lambda/repository/lambda_functions.py
+++ b/lambda/repository/lambda_functions.py
@@ -505,7 +505,8 @@ def ingest_documents(event: dict, context: dict) -> dict:
         doc_repo.save(doc_entity)
         doc_entities.append(doc_entity)
 
-    doc_ids = (doc.document_id for doc in doc_entities)
+    doc_ids = [doc.document_id for doc in doc_entities]
+
     subdoc_ids = [sub_id for doc in doc_entities for sub_id in doc.subdocs]
     return {
         "documentIds": doc_ids,

--- a/lib/api-base/ecsCluster.ts
+++ b/lib/api-base/ecsCluster.ts
@@ -179,6 +179,9 @@ export class ECSCluster extends Construct {
             // Requires mount point /etc/pki from host
             environment.SSL_CERT_DIR = '/etc/pki/tls/certs';
             environment.SSL_CERT_FILE = config.certificateAuthorityBundle;
+            environment.REQUESTS_CA_BUNDLE = config.certificateAuthorityBundle;
+            environment.AWS_CA_BUNDLE = config.certificateAuthorityBundle;
+            environment.CURL_CA_BUNDLE = config.certificateAuthorityBundle;
         }
 
         // Retrieve execution role if it has been overridden

--- a/lib/core/layers/common/create_env_variables.py
+++ b/lib/core/layers/common/create_env_variables.py
@@ -19,7 +19,11 @@ region_name = os.environ["AWS_REGION"]
 if "iso" in region_name:
     cacerts_directory = "/etc/pki/ca-trust/extracted/pem"
     merged_cert_filename = os.path.join(cacerts_directory, "tls-ca-bundle.pem")
-    os.environ["AWS_CA_BUNDLE"] = merged_cert_filename
-    os.environ["REQUESTS_CA_BUNDLE"] = merged_cert_filename
-    os.environ["SSL_CERT_FILE"] = merged_cert_filename
-    os.environ["SSL_CERT_DIR"] = cacerts_directory
+    if not os.environ.get("AWS_CA_BUNDLE"):
+        os.environ["AWS_CA_BUNDLE"] = merged_cert_filename
+    if not os.environ.get("REQUESTS_CA_BUNDLE"):
+        os.environ["REQUESTS_CA_BUNDLE"] = merged_cert_filename
+    if not os.environ.get("SSL_CERT_DIR"):
+        os.environ["SSL_CERT_DIR"] = cacerts_directory
+    if not os.environ.get("SSL_CERT_FILE"):
+        os.environ["SSL_CERT_FILE"] = merged_cert_filename

--- a/lib/serve/rest-api/src/auth.py
+++ b/lib/serve/rest-api/src/auth.py
@@ -71,11 +71,11 @@ def get_oidc_metadata(cert_path: Optional[str] = None) -> Dict[str, Any]:
 
 def get_jwks_client() -> jwt.PyJWKClient:
     """Get JWK Client for JWT signing operations."""
-    if ("SSL_CERT_DIR" not in os.environ) or ("SSL_CERT_FILE" not in os.environ):
+    if "SSL_CERT_FILE" not in os.environ:
         cert_path = None
         logger.info("Using default certificate for SSL verification.")
     else:
-        cert_path = str(Path(os.environ["SSL_CERT_DIR"], os.environ["SSL_CERT_FILE"]).absolute())
+        cert_path = str(Path(os.environ["SSL_CERT_FILE"]).absolute())
         logger.info("Using self-signed certificate for SSL verification.")
     ssl_context = ssl.create_default_context()
     if cert_path:

--- a/lib/serve/rest-api/src/main.py
+++ b/lib/serve/rest-api/src/main.py
@@ -72,11 +72,7 @@ async def lifespan(app: FastAPI):  # type: ignore
         "endpointUrls": {},
     }
     try:
-        verify_path = (
-            None
-            if ("SSL_CERT_DIR" not in os.environ) or ("SSL_CERT_FILE" not in os.environ)
-            else f"{os.getenv('SSL_CERT_DIR')}/{os.getenv('SSL_CERT_FILE')}"
-        )
+        verify_path = os.getenv("SSL_CERT_FILE") or None
         session = get_session()
         async with session.create_client("ssm", region_name=os.environ["AWS_REGION"], verify=verify_path) as client:
             response = await client.get_parameter(Name=os.environ["REGISTERED_MODELS_PS_NAME"])


### PR DESCRIPTION
To better support customers deploying into isolated regions, this PR will address a number of issues found while testing isolated deployments.

Properly set certificates for lambdas and ECS containers. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.