### PR TITLE
Add vite base property

### DIFF
--- a/ecs_model_deployer/package.json
+++ b/ecs_model_deployer/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "node esbuild.js && npm run copy-assets && npm run pack:prod && npm run copy-dist",
+    "build": "node esbuild.js && npm run copy-assets && npm run pack:prod",
     "copy-assets": "cp package.json ./src/cdk*json ../VERSION ./dist",
     "pack:prod": "cd ./dist && npm i --omit dev",
     "copy-dist": "mkdir -p ../dist/ecs_model_deployer && cp -r ./dist/* ../dist/ecs_model_deployer/",

--- a/lib/docs/package.json
+++ b/lib/docs/package.json
@@ -5,7 +5,7 @@
   "description": "Documentation of LISA",
   "scripts": {
     "prebuild": "(cd ../../ && npm run generateSchemaDocs)",
-    "build": "npm run docs:build && npm run copy-dist",
+    "build": "npm run docs:build",
     "copy-dist": "mkdir -p ../../dist/docs && cp -r ./dist/* ../../dist/docs/",
     "docs:dev": "vitepress dev .",
     "docs:build": "vitepress build .",

--- a/lib/serve/rest-api/Dockerfile
+++ b/lib/serve/rest-api/Dockerfile
@@ -26,6 +26,9 @@ RUN echo "$LITELLM_CONFIG" > litellm_config.yaml
 # Copy the source code into the container
 COPY src/ ./src
 
+# Generate the prisma binary
+RUN prisma generate
+
 # Make entrypoint.sh executable
 RUN chmod +x src/entrypoint.sh
 

--- a/lib/user-interface/react/package.json
+++ b/lib/user-interface/react/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node ./scripts/set-revision-info.mjs && tsc && vite build && npm run copy-dist",
+    "build": "node ./scripts/set-revision-info.mjs && tsc && vite build",
     "copy-dist": "mkdir -p ../../../dist/lisa-web && cp -r ./dist/* ../../../dist/lisa-web/",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",

--- a/lib/user-interface/react/vite.config.ts
+++ b/lib/user-interface/react/vite.config.ts
@@ -21,7 +21,6 @@ import { resolve } from 'node:path';
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [react(), splitVendorChunkPlugin()],
-    base: '/prod/',
     server: {
         port: 3000,
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "jest",
     "cdk": "cdk",
     "prepare": "husky",
-    "prepublishOnly": "npm run build && npm run copy-dist",
+    "prepublishOnly": "npm run build && npm run copy-dist -ws",
     "migrate-properties": "node ./scripts/migrate-properties.mjs",
     "generateSchemaDocs": "npx zod2md -c ./lib/zod2md.config.ts && npx zod2md -c ./lib/zod2md.rag.ts"
   },

--- a/vector_store_deployer/package.json
+++ b/vector_store_deployer/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "node esbuild.js && npm run copy-assets && npm run pack:prod && npm run copy-dist",
+    "build": "node esbuild.js && npm run copy-assets && npm run pack:prod",
     "copy-assets": "cp package.json ./src/cdk*json ../VERSION ./dist",
     "pack:prod": "cd ./dist && npm i --omit dev",
     "copy-dist": "mkdir -p ../dist/vector_store_deployer && cp -r ./dist/* ../dist/vector_store_deployer/",


### PR DESCRIPTION
With the last package updates, the vite base parameter wasn't being passed in correctly to build the web application. This updates the package.json build to allow the vite base parameter to be passed into the correct build command. Also, removing the default 'prod' base from vite. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
