### PR TITLE
Added availabilityZone to Subnet config schema

### DIFF
--- a/lib/schema/configSchema.ts
+++ b/lib/schema/configSchema.ts
@@ -760,6 +760,7 @@ export const RawConfigObject = z.object({
     subnets: z.array(z.object({
         subnetId: z.string().startsWith('subnet-'),
         ipv4CidrBlock: z.string(),
+        availabilityZone: z.string().describe('Specify the availability zone for the subnet in the format <region><letter> (e.g., us-east-1a).'),
     })).optional().describe('Array of subnet objects for the application. These contain a subnetId(e.g. [subnet-fedcba9876543210] and ipv4CidrBlock'),
     securityGroupConfig: SecurityGroupConfigSchema.optional(),
     deploymentStage: z.string().default('prod').describe('Deployment stage for the application.'),

--- a/vector_store_deployer/src/lib/opensearch.ts
+++ b/vector_store_deployer/src/lib/opensearch.ts
@@ -58,7 +58,8 @@ export class OpenSearchVectorStoreStack extends PipelineStack {
             subnetSelection = {
                 subnets: props.config.subnets?.map((subnet, index) => Subnet.fromSubnetAttributes(this, index.toString(), {
                     subnetId: subnet.subnetId,
-                    ipv4CidrBlock: subnet.ipv4CidrBlock
+                    ipv4CidrBlock: subnet.ipv4CidrBlock,
+                    availabilityZone: subnet.availabilityZone
                 }))
             };
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When deploying OpenSearch clusters, an issue was encountered where the OpenSearch Domain attempts to access the availabilityZone property on a subnet. However, since the subnets are imported using Subnet.fromSubnetAttributes, the availabilityZone property is not populated, resulting in a runtime exception.

This PR updates the configuration schema to require the availabilityZone property when using private VPCs/subnets, ensuring it is explicitly defined to avoid this issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
