### PR TITLE
Fix: Generate tiktoken cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__/
 .pytest_cache/
 *.key
 *.pem
+TIKTOKEN_CACHE
 
 # CDK asset staging directory
 .cdk.staging

--- a/lib/api-base/fastApiContainer.ts
+++ b/lib/api-base/fastApiContainer.ts
@@ -26,6 +26,8 @@ import { ECSCluster } from './ecsCluster';
 import { BaseProps, Ec2Metadata, EcsSourceType } from '../schema';
 import { Vpc } from '../networking/vpc';
 import { REST_API_PATH } from '../util';
+import * as child_process from 'child_process';
+import * as path from 'path';
 
 // This is the amount of memory to buffer (or subtract off) from the total instance memory, if we don't include this,
 // the container can have a hard time finding available RAM resources to start and the tasks will fail deployment
@@ -79,6 +81,7 @@ export class FastApiContainer extends Construct {
             AWS_REGION_NAME: config.region, // for supporting SageMaker endpoints in LiteLLM
             THREADS: Ec2Metadata.get('m5.large').vCpus.toString(),
             LITELLM_KEY: config.litellmConfig.db_key,
+            TIKTOKEN_CACHE_DIR: '/app/TIKTOKEN_CACHE'
         };
 
         if (config.restApiConfig.internetFacing) {
@@ -94,6 +97,13 @@ export class FastApiContainer extends Construct {
         if (tokenTable) {
             environment.TOKEN_TABLE_NAME = tokenTable.tableName;
         }
+
+        // Pre-generate the tiktoken cache to ensure it does not attempt to fetch data from the internet at runtime.
+        if (config.restApiConfig.imageConfig === undefined) {
+            const cache_dir = path.join(REST_API_PATH, 'TIKTOKEN_CACHE');
+            child_process.execSync(`python3 scripts/cache-tiktoken-for-offline.py ${cache_dir}`, { stdio: 'inherit' });
+        }
+        
         const image = config.restApiConfig.imageConfig || {
             baseImage: config.baseImage,
             path: REST_API_PATH,

--- a/lib/serve/rest-api/Dockerfile
+++ b/lib/serve/rest-api/Dockerfile
@@ -26,6 +26,8 @@ RUN echo "$LITELLM_CONFIG" > litellm_config.yaml
 # Copy the source code into the container
 COPY src/ ./src
 
+COPY TIKTOKEN_CACHE ./TIKTOKEN_CACHE
+
 # Generate the prisma binary
 RUN prisma generate
 

--- a/scripts/cache-tiktoken-for-offline.py
+++ b/scripts/cache-tiktoken-for-offline.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import tiktoken_ext.openai_public  # Assuming this is the correct import
+
+def main():
+    # Ensure the script gets a valid argument for 'TIKTOKEN_CACHE_DIR'
+    if len(sys.argv) < 2:
+        print("Error: You must provide the 'TIKTOKEN_CACHE_DIR' as the first argument.")
+        sys.exit(1)
+    
+    # Set the environment variable 'TIKTOKEN_CACHE_DIR' to the first argument
+    os.environ['TIKTOKEN_CACHE_DIR'] = sys.argv[1]
+    print(f"Environment variable 'TIKTOKEN_CACHE_DIR' set to: {os.environ['TIKTOKEN_CACHE_DIR']}")
+
+    # Iterate over the encoding constructors in 'tiktoken_ext.openai_public.ENCODING_CONSTRUCTORS'
+    for name, func in tiktoken_ext.openai_public.ENCODING_CONSTRUCTORS.items():
+        print(f"Calling function '{name}':")
+        func()  # Call the function
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR addresses issues caused by transient dependencies on tiktoken, which attempts to download files from the internet at runtime. In environments where our Lambda functions or containers do not have internet access, this behavior causes failures.

To resolve this, the required cache files are now pre-generated and bundled into both the REST API container and the RAG Lambda layer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
