### PR TITLE
Fix Incorrect BASE_URL Assignment in Vite Templates

### DIFF
--- a/lib/user-interface/react/vite.config.ts
+++ b/lib/user-interface/react/vite.config.ts
@@ -29,5 +29,6 @@ export default defineConfig({
             '@': resolve(__dirname, 'src'),
             '#root': resolve(__dirname, '..', '..', '..'),
         },
-    }
+    },
+    base: process.env.BASE_URL || '/',
 });

--- a/lib/user-interface/userInterfaceConstruct.ts
+++ b/lib/user-interface/userInterfaceConstruct.ts
@@ -185,8 +185,11 @@ export class UserInterfaceConstruct extends Construct {
 
         const appEnvSource = Source.data('env.js', `window.env = ${JSON.stringify(appEnvConfig)}`);
         const uriPrefix = config.apiGatewayConfig?.domainName ? '' : `${config.deploymentStage}/`;
+        console.log(`assets: deploymentStage=${config.deploymentStage}`);
+        console.log(`uriSuffix=${uriPrefix}`);
         let webappAssets;
         if (!config.webAppAssetsPath) {
+            console.log('generating web assets...');
             webappAssets = Source.asset(ROOT_PATH, {
                 bundling: {
                     image: Runtime.NODEJS_18_X.bundlingImage,
@@ -197,7 +200,7 @@ export class UserInterfaceConstruct extends Construct {
                         [
                             'set -x',
                             'npm --cache /tmp/.npm install',
-                            `npm --cache /tmp/.npm run build -w lisa-web`,
+                            'npm --cache /tmp/.npm run build -w lisa-web',
                             'cp -aur /asset-input/lib/user-interface/react/dist/* /asset-output/',
                         ].join(' && '),
                     ],
@@ -226,6 +229,7 @@ export class UserInterfaceConstruct extends Construct {
                 },
             });
         } else {
+            console.log(`Using existing web assets from ${config.webAppAssetsPath}`);
             webappAssets = Source.asset(config.webAppAssetsPath);
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
n certain environments, the BASE_URL was not being correctly set during the rendering of Vite templates. This fix ensures that BASE_URL is now properly assigned, restoring the expected behavior across all environments.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
