### PR TITLE
fix chat stack dependencies

### DIFF
--- a/lib/stages.ts
+++ b/lib/stages.ts
@@ -247,8 +247,10 @@ export class LisaServeApplicationStage extends Stage {
             apiDeploymentStack.addDependency(ragStack);
         }
 
+        // Declare metricsStack here so that we can reference it in chatStack
+        let metricsStack: LisaMetricsStack | undefined;
         if (config.deployMetrics) {
-            const metricsStack = new LisaMetricsStack(this, 'LisaMetrics', {
+            metricsStack = new LisaMetricsStack(this, 'LisaMetrics', {
                 ...baseStackProps,
                 authorizer: apiBaseStack.authorizer!,
                 stackName: createCdkId([config.deploymentName, config.appName, 'metrics', config.deploymentStage]),
@@ -277,6 +279,9 @@ export class LisaServeApplicationStage extends Stage {
             });
             chatStack.addDependency(apiBaseStack);
             chatStack.addDependency(coreStack);
+            if (metricsStack) {
+                chatStack.addDependency(metricsStack);
+            }
             apiDeploymentStack.addDependency(chatStack);
             this.stacks.push(chatStack);
 


### PR DESCRIPTION
*Description of changes:*

This change fixes the chatStack dependencies. If the `deployMetrics` config option is set to true it is necessary to have the chatStack declare a dependency on the Metrics stack so that the session lambdas deployed by the chatStack are configured correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
