### PR TITLE
Feature/mcp cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,4 +378,4 @@ test-coverage:
           --cov-report term-missing \
           --cov-report html:build/coverage \
           --cov-report xml:build/coverage/coverage.xml \
-          --cov-fail-under 50
+          --cov-fail-under 65

--- a/lambda/mcp_server/models.py
+++ b/lambda/mcp_server/models.py
@@ -14,9 +14,21 @@
 
 import uuid
 from datetime import datetime
+from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel, Field
+
+
+class McpServerStatus(str, Enum):
+    """Enum representing the prompt template type."""
+
+    def __str__(self) -> str:
+        """Represent the enum as a string."""
+        return str(self.value)
+
+    ACTIVE = "active"
+    INACTIVE = "inactive"
 
 
 class McpServerModel(BaseModel):
@@ -45,3 +57,6 @@ class McpServerModel(BaseModel):
 
     # Custom client properties for the MCP client
     clientConfig: Optional[dict] = Field(default_factory=lambda: None)
+
+    # Status of the server set by admins
+    status: Optional[McpServerStatus] = Field(default=McpServerStatus.INACTIVE)

--- a/lambda/mcp_server/models.py
+++ b/lambda/mcp_server/models.py
@@ -52,6 +52,9 @@ class McpServerModel(BaseModel):
     # Name of the MCP server
     name: str
 
+    # Description of the MCP server
+    description: Optional[str] = Field(default_factory=lambda: None)
+
     # Custom headers for the MCP client
     customHeaders: Optional[dict] = Field(default_factory=lambda: None)
 

--- a/lambda/user_preferences/__init__.py
+++ b/lambda/user_preferences/__init__.py
@@ -1,0 +1,13 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.

--- a/lambda/user_preferences/lambda_functions.py
+++ b/lambda/user_preferences/lambda_functions.py
@@ -1,0 +1,78 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Lambda functions for managing User Preferences in AWS DynamoDB."""
+import json
+import logging
+import os
+from decimal import Decimal
+from typing import Any
+
+import boto3
+from boto3.dynamodb.conditions import Key
+from utilities.common_functions import api_wrapper, get_item, get_username, retry_config
+
+from .models import UserPreferencesModel
+
+logger = logging.getLogger(__name__)
+
+# Initialize the DynamoDB resource and the table using environment variables
+dynamodb = boto3.resource("dynamodb", region_name=os.environ["AWS_REGION"], config=retry_config)
+table = dynamodb.Table(os.environ["USER_PREFERENCES_TABLE_NAME"])
+
+
+@api_wrapper
+def get(event: dict, context: dict) -> Any:
+    """Retrieve a user's user preferences from DynamoDB."""
+    user_id = get_username(event)
+
+    # Query for the user preferences
+    response = table.query(KeyConditionExpression=Key("user").eq(user_id), Limit=1, ScanIndexForward=False)
+    item = get_item(response)
+
+    if item is None:
+        return None
+
+    if item["user"] == user_id:
+        return item
+
+    raise ValueError(f"Not authorized to get {user_id}'s preferences.")
+
+
+@api_wrapper
+def update(event: dict, context: dict) -> Any:
+    """Update an existing user preferences in DynamoDB."""
+    user_id = get_username(event)
+    body = json.loads(event["body"], parse_float=Decimal)
+    user_preferences_model = UserPreferencesModel(**body)
+
+    # Query for the latest user preferences revision
+    response = table.query(KeyConditionExpression=Key("user").eq(user_id), Limit=1, ScanIndexForward=False)
+    item = get_item(response)
+
+    if item is None:
+        user_preferences_model = UserPreferencesModel(**body)
+        # Insert the new user preferences item into the DynamoDB table
+        logger.info(f"Creating User Preferences: {user_preferences_model.model_dump(exclude_none=True)}")
+        table.put_item(Item=user_preferences_model.model_dump(exclude_none=True))
+        return user_preferences_model.model_dump()
+
+    # Check if the user is authorized to update the user preferences
+    if item["user"] == user_id:
+        # Update the user preferences
+        logger.info(f"Updating User Preferences: {user_preferences_model.model_dump(exclude_none=True)}")
+        table.put_item(Item=user_preferences_model.model_dump(exclude_none=True))
+        return user_preferences_model.model_dump()
+
+    raise ValueError(f"Not authorized to update {user_id}'s preferences.")

--- a/lambda/user_preferences/models.py
+++ b/lambda/user_preferences/models.py
@@ -1,0 +1,28 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from pydantic import BaseModel
+
+
+class UserPreferencesModel(BaseModel):
+    """
+    A Pydantic model representing a template for prompts.
+    Contains metadata and functionality to create new revisions.
+    """
+
+    # User whose preferences this is
+    user: str
+
+    # User's preferences
+    preferences: dict

--- a/lib/chat/api/user-preferences.ts
+++ b/lib/chat/api/user-preferences.ts
@@ -93,7 +93,7 @@ export class UserPreferencesApi extends Construct {
         const apis: PythonLambdaFunction[] = [
             {
                 name: 'get',
-                resource: 'user_preferences',
+                resource: 'user-preferences',
                 description: 'Returns the preferences for the calling user',
                 path: 'user_preferences',
                 method: 'GET',
@@ -101,7 +101,7 @@ export class UserPreferencesApi extends Construct {
             },
             {
                 name: 'update',
-                resource: 'user_preferences',
+                resource: 'user-preferences',
                 description: 'Creates or updates user preferences for user',
                 path: 'user_preferences',
                 method: 'PUT',

--- a/lib/chat/api/user-preferences.ts
+++ b/lib/chat/api/user-preferences.ts
@@ -1,0 +1,134 @@
+/**
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { IAuthorizer, RestApi } from 'aws-cdk-lib/aws-apigateway';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { IRole } from 'aws-cdk-lib/aws-iam';
+import { ISecurityGroup } from 'aws-cdk-lib/aws-ec2';
+import { LayerVersion } from 'aws-cdk-lib/aws-lambda';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import { Construct } from 'constructs';
+
+import { getDefaultRuntime, PythonLambdaFunction, registerAPIEndpoint } from '../../api-base/utils';
+import { BaseProps } from '../../schema';
+import { createLambdaRole } from '../../core/utils';
+import { Vpc } from '../../networking/vpc';
+import { LAMBDA_PATH } from '../../util';
+
+/**
+ * Properties for UserPreferencesApi Construct.
+ *
+ * @property {IVpc} vpc - Stack VPC
+ * @property {Layer} commonLayer - Lambda layer for all Lambdas.
+ * @property {IRestApi} restAPI - REST APIGW for UI and Lambdas
+ * @property {IRole} lambdaExecutionRole - Execution role for lambdas
+ * @property {IAuthorizer} authorizer - APIGW authorizer
+ * @property {ISecurityGroup[]} securityGroups - Security groups for Lambdas
+ * @property {Map<number, ISubnet> }importedSubnets for application.
+ */
+type UserPreferencesProps = {
+    authorizer: IAuthorizer;
+    restApiId: string;
+    rootResourceId: string;
+    securityGroups: ISecurityGroup[];
+    vpc: Vpc;
+} & BaseProps;
+
+/**
+ * API which Maintains user preferences state in DynamoDB
+ */
+export class UserPreferencesApi extends Construct {
+    constructor (scope: Construct, id: string, props: UserPreferencesProps) {
+        super(scope, id);
+
+        const { authorizer, config, restApiId, rootResourceId, securityGroups, vpc } = props;
+
+        // Get common layer based on arn from SSM due to issues with cross stack references
+        const commonLambdaLayer = LayerVersion.fromLayerVersionArn(
+            this,
+            'user-preferences-common-lambda-layer',
+            StringParameter.valueForStringParameter(this, `${config.deploymentPrefix}/layerVersion/common`),
+        );
+
+        const fastapiLambdaLayer = LayerVersion.fromLayerVersionArn(
+            this,
+            'user-preferences-fastapi-lambda-layer',
+            StringParameter.valueForStringParameter(this, `${config.deploymentPrefix}/layerVersion/fastapi`),
+        );
+
+        // Create DynamoDB table to handle user preferences
+        const userPreferencesTable = new dynamodb.Table(this, 'UserPreferencesTable', {
+            partitionKey: {
+                name: 'user',
+                type: dynamodb.AttributeType.STRING,
+            },
+            billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+            encryption: dynamodb.TableEncryption.AWS_MANAGED,
+            removalPolicy: config.removalPolicy,
+        });
+
+        const restApi = RestApi.fromRestApiAttributes(this, 'RestApi', {
+            restApiId: restApiId,
+            rootResourceId: rootResourceId,
+        });
+
+        const env = {
+            USER_PREFERENCES_TABLE_NAME: userPreferencesTable.tableName
+        };
+
+        // Create API Lambda functions
+        const apis: PythonLambdaFunction[] = [
+            {
+                name: 'get',
+                resource: 'user_preferences',
+                description: 'Returns the preferences for the calling user',
+                path: 'user_preferences',
+                method: 'GET',
+                environment: env,
+            },
+            {
+                name: 'update',
+                resource: 'user_preferences',
+                description: 'Creates or updates user preferences for user',
+                path: 'user_preferences',
+                method: 'PUT',
+                environment: env,
+            },
+        ];
+
+        const lambdaRole: IRole = createLambdaRole(this, config.deploymentName, 'UserPreferencesApi', userPreferencesTable.tableArn, config.roles?.LambdaExecutionRole);
+        const lambdaPath = config.lambdaPath || LAMBDA_PATH;
+        apis.forEach((f) => {
+            const lambdaFunction = registerAPIEndpoint(
+                this,
+                restApi,
+                lambdaPath,
+                [commonLambdaLayer, fastapiLambdaLayer],
+                f,
+                getDefaultRuntime(),
+                vpc,
+                securityGroups,
+                authorizer,
+                lambdaRole,
+            );
+            if (f.method === 'POST' || f.method === 'PUT') {
+                userPreferencesTable.grantWriteData(lambdaFunction);
+            } else if (f.method === 'GET') {
+                userPreferencesTable.grantReadData(lambdaFunction);
+            }
+        });
+    }
+}

--- a/lib/chat/api/user-preferences.ts
+++ b/lib/chat/api/user-preferences.ts
@@ -93,17 +93,17 @@ export class UserPreferencesApi extends Construct {
         const apis: PythonLambdaFunction[] = [
             {
                 name: 'get',
-                resource: 'user-preferences',
+                resource: 'user_preferences',
                 description: 'Returns the preferences for the calling user',
-                path: 'user_preferences',
+                path: 'user-preferences',
                 method: 'GET',
                 environment: env,
             },
             {
                 name: 'update',
-                resource: 'user-preferences',
+                resource: 'user_preferences',
                 description: 'Creates or updates user preferences for user',
-                path: 'user_preferences',
+                path: 'user-preferences',
                 method: 'PUT',
                 environment: env,
             },

--- a/lib/chat/chatConstruct.ts
+++ b/lib/chat/chatConstruct.ts
@@ -26,6 +26,7 @@ import { Vpc } from '../networking/vpc';
 import { ConfigurationApi } from './api/configuration';
 import { PromptTemplateApi } from './api/prompt-template-api';
 import { McpApi } from './api/mcp';
+import { UserPreferencesApi } from './api/user-preferences';
 
 export type LisaChatProps = {
     authorizer: IAuthorizer;
@@ -78,6 +79,15 @@ export class LisaChatApplicationConstruct extends Construct {
         });
 
         new McpApi(scope, 'McpApi', {
+            authorizer,
+            config,
+            restApiId,
+            rootResourceId,
+            securityGroups,
+            vpc,
+        });
+
+        new UserPreferencesApi(scope, 'UserPreferencesApi', {
             authorizer,
             config,
             restApiId,

--- a/lib/user-interface/react/package.json
+++ b/lib/user-interface/react/package.json
@@ -48,7 +48,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "~5.1.6",
     "unraw": "^3.0.0",
-    "use-mcp": "^0.0.14",
+    "use-mcp": "^0.0.18",
     "vitepress": "^1.6.3"
   },
   "devDependencies": {

--- a/lib/user-interface/react/package.json
+++ b/lib/user-interface/react/package.json
@@ -48,7 +48,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "~5.1.6",
     "unraw": "^3.0.0",
-    "use-mcp": "^0.0.9",
+    "use-mcp": "^0.0.14",
     "vitepress": "^1.6.3"
   },
   "devDependencies": {

--- a/lib/user-interface/react/src/components/chatbot/Chat.tsx
+++ b/lib/user-interface/react/src/components/chatbot/Chat.tsx
@@ -66,7 +66,7 @@ import { useToolChain } from './hooks/useToolChain.hooks';
 import { WelcomeScreen } from './components/WelcomeScreen';
 import { buildMessageContent, buildMessageMetadata } from './utils/messageBuilder.utils';
 import { getButtonItems, useButtonActions } from './config/buttonConfig';
-import { useListMcpServersQuery } from '@/shared/reducers/mcp-server.reducer';
+import { McpServerStatus, useListMcpServersQuery } from '@/shared/reducers/mcp-server.reducer';
 
 export default function Chat ({ sessionId }) {
     const dispatch = useAppDispatch();
@@ -104,7 +104,11 @@ export default function Chat ({ sessionId }) {
     const lastProcessedMessageIndex = useRef(-1);
     const startToolChainRef = useRef<(session: LisaChatSession) => Promise<void>>();
 
-    const { data: {Items: mcpServers} = {Items: []} } = useListMcpServersQuery(undefined, { refetchOnMountOrArgChange: true });
+    const { data: mcpServers } = useListMcpServersQuery(undefined, { refetchOnMountOrArgChange: true,
+        selectFromResult: (state) => ({
+            isFetching: state.isFetching,
+            data: (state.data?.Items || []).filter((server) => (server.status === McpServerStatus.Active)),
+        }) },);
     // Use the custom hook to manage multiple MCP connections
     const { tools: mcpTools, callTool, McpConnections } = useMultipleMcp(config?.configuration?.enabledComponents?.mcpConnections ? mcpServers : undefined);
 

--- a/lib/user-interface/react/src/components/chatbot/Chat.tsx
+++ b/lib/user-interface/react/src/components/chatbot/Chat.tsx
@@ -708,11 +708,11 @@ export default function Chat ({ sessionId }) {
                                             </div>
                                         </TextContent>
                                     </Box>
-                                    {enabledServers && enabledServers.length > 0 && (
+                                    {enabledServers && enabledServers.length > 0 ? (
                                         <Box>
                                             <Icon name='gen-ai' variant='success' /> {enabledServers.length} MCP Servers - {openAiTools?.length || 0} tools
                                         </Box>
-                                    )}
+                                    ) : (<div></div>)}
                                     <Box float='right' variant='div'>
                                         <StatusIndicator type={isConnected ? 'success' : 'error'}>
                                             {isConnected ? 'Connected' : 'Disconnected'}

--- a/lib/user-interface/react/src/components/chatbot/Chat.tsx
+++ b/lib/user-interface/react/src/components/chatbot/Chat.tsx
@@ -75,7 +75,6 @@ import {
 } from '@/shared/reducers/user-preferences.reducer';
 import { setConfirmationModal } from '@/shared/reducers/modal.reducer';
 import ConfirmationModal from '@/shared/modal/confirmation-modal';
-import { darkStyles, JsonView } from 'react-json-view-lite';
 import { selectCurrentUsername } from '@/shared/reducers/user.reducer';
 
 export default function Chat ({ sessionId }) {
@@ -578,12 +577,14 @@ export default function Chat ({ sessionId }) {
                     onConfirm={handleToolApproval}
                     onDismiss={handleToolRejection}
                     description={
-                        <div>
-                            <p>The AI is about to execute the following tool:</p>
-                            <p><strong>Tool Name:</strong> {toolApprovalModal.tool.name}</p>
-                            <p><strong>Arguments:</strong></p>
-                            <JsonView data={toolApprovalModal.tool.args} style={darkStyles} />
-                            <p>Do you want to allow this tool execution?</p>
+                        <SpaceBetween size='m' direction='vertical'>
+                            <SpaceBetween size='s' direction='vertical'>
+                                <p>The AI is about to execute the following tool:</p>
+                                <p><strong>Tool Name:</strong> {toolApprovalModal.tool.name}</p>
+                                <p><strong>Arguments:</strong></p>
+                                {JSON.stringify(toolApprovalModal.tool.args).replace('{', '').replace('}', '')}
+                                <p><strong>Do you want to allow this tool execution?</strong></p>
+                            </SpaceBetween>
                             <hr/>
                             <Checkbox
                                 onChange={({ detail }) =>
@@ -593,7 +594,7 @@ export default function Chat ({ sessionId }) {
                             >
                                 Auto-approve this tool in the future
                             </Checkbox>
-                        </div>
+                        </SpaceBetween>
                     }
                 />
             )}

--- a/lib/user-interface/react/src/components/chatbot/hooks/mcp.hooks.tsx
+++ b/lib/user-interface/react/src/components/chatbot/hooks/mcp.hooks.tsx
@@ -17,6 +17,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMcp } from 'use-mcp/react';
 import { McpServer } from '@/shared/reducers/mcp-server.reducer';
+import { McpPreferences } from '@/shared/reducers/user-preferences.reducer';
 
 // Individual MCP Connection Component
 export const McpConnection = ({ server, onToolsChange, onConnectionChange }: {
@@ -59,7 +60,7 @@ export const McpConnection = ({ server, onToolsChange, onConnectionChange }: {
 };
 
 // Custom hook to manage multiple MCP connections dynamically
-export const useMultipleMcp = (servers: McpServer[]) => {
+export const useMultipleMcp = (servers: McpServer[], mcpPreferences: McpPreferences) => {
     const [allTools, setAllTools] = useState([]);
     const [serverToolsMap, setServerToolsMap] = useState<Map<string, any[]>>(new Map());
     const [connectionsMap, setConnectionsMap] = useState<Map<string, any>>(new Map());
@@ -68,7 +69,7 @@ export const useMultipleMcp = (servers: McpServer[]) => {
     const handleToolsChange = useCallback((tools: any[], clientName: string) => {
         setServerToolsMap((prev) => {
             const newMap = new Map(prev);
-            newMap.set(clientName, tools);
+            newMap.set(clientName, tools.filter((tool) => !mcpPreferences?.enabledServers?.find((server) => server.name === clientName)?.disabledTools.includes(tool.name)));
             return newMap;
         });
 
@@ -89,7 +90,7 @@ export const useMultipleMcp = (servers: McpServer[]) => {
             });
             return newMap;
         });
-    }, []);
+    }, [mcpPreferences?.enabledServers]);
 
     const handleConnectionChange = useCallback((connection: any, clientName: string) => {
         setConnectionsMap((prev) => {
@@ -134,6 +135,7 @@ export const useMultipleMcp = (servers: McpServer[]) => {
                 onToolsChange={handleToolsChange}
                 onConnectionChange={handleConnectionChange}
             />
-        ))
+        )),
+        toolToServerMap
     };
 };

--- a/lib/user-interface/react/src/components/chatbot/hooks/useMemory.hooks.tsx
+++ b/lib/user-interface/react/src/components/chatbot/hooks/useMemory.hooks.tsx
@@ -41,7 +41,7 @@ export const useMemory = (
         }),
     );
 
-    // Update memory when userPrompt changes
+    // Update memory when session history or buffer size changes
     useEffect(() => {
         setMemory(
             new ChatMemory({
@@ -51,7 +51,7 @@ export const useMemory = (
                 k: chatConfiguration.sessionConfiguration.chatHistoryBufferSize,
             }),
         );
-    }, [userPrompt, session, chatConfiguration.sessionConfiguration.chatHistoryBufferSize]);
+    }, [session, chatConfiguration.sessionConfiguration.chatHistoryBufferSize]);
 
     // Update metadata when model or configuration changes
     useEffect(() => {

--- a/lib/user-interface/react/src/components/chatbot/hooks/useToolChain.hooks.tsx
+++ b/lib/user-interface/react/src/components/chatbot/hooks/useToolChain.hooks.tsx
@@ -17,18 +17,23 @@
 import React, { useCallback, useRef, useState } from 'react';
 import { LisaChatMessage, LisaChatSession, MessageTypes } from '@/components/types';
 import { GenerateLLMRequestParams } from '@/shared/model/chat.configurations.model';
+import { McpPreferences } from '@/shared/reducers/user-preferences.reducer';
 
 export const useToolChain = ({
     callTool,
     generateResponse,
     setSession,
     notificationService,
+    toolToServerMap,
+    mcpPreferences,
 }: {
     callTool: (toolName: string, args: any) => Promise<any>;
     generateResponse: (params: GenerateLLMRequestParams) => Promise<void>;
     session: LisaChatSession;
     setSession: (updater: (prev: LisaChatSession) => LisaChatSession) => void;
     notificationService: any;
+    toolToServerMap: Map<string, string>,
+    mcpPreferences: McpPreferences,
 }) => {
     const isProcessingChain = useRef(false);
     const stopRequested = useRef(false);
@@ -63,21 +68,29 @@ export const useToolChain = ({
         return toolResultContent;
     }, []);
 
+    const checkOverriddenApproval = (toolName: string): boolean => {
+        if (mcpPreferences?.overrideAllApprovals) {
+            return true;
+        } else {
+            const serverName = toolToServerMap.get(toolName);
+            return mcpPreferences?.enabledServers.find((server: any) => server.name === serverName)?.autoApprovedTools?.includes(toolName) ?? false;
+        }
+    };
+
     const executeToolWithApproval = useCallback(async (tool: any): Promise<any> => {
-        // if (true) {
-        return new Promise((resolve, reject) => {
-            setToolApprovalModal({
-                visible: true,
-                tool,
-                resolve,
-                reject
+        if (checkOverriddenApproval(tool.name)) {
+            return await callTool(tool.name, tool.args);
+        } else {
+            return new Promise((resolve, reject) => {
+                setToolApprovalModal({
+                    visible: true,
+                    tool,
+                    resolve,
+                    reject
+                });
             });
-        });
-        // } else {
-        //     // If approval is not enabled, execute directly
-        //     return await callMcpTool(tool);
-        // }
-    }, []);
+        }
+    }, [callTool, checkOverriddenApproval]);
 
     const handleToolApproval = useCallback(async () => {
         if (!toolApprovalModal) return;

--- a/lib/user-interface/react/src/components/chatbot/hooks/useToolChain.hooks.tsx
+++ b/lib/user-interface/react/src/components/chatbot/hooks/useToolChain.hooks.tsx
@@ -68,16 +68,16 @@ export const useToolChain = ({
         return toolResultContent;
     }, []);
 
-    const checkOverriddenApproval = (toolName: string): boolean => {
-        if (mcpPreferences?.overrideAllApprovals) {
-            return true;
-        } else {
-            const serverName = toolToServerMap.get(toolName);
-            return mcpPreferences?.enabledServers.find((server: any) => server.name === serverName)?.autoApprovedTools?.includes(toolName) ?? false;
-        }
-    };
-
     const executeToolWithApproval = useCallback(async (tool: any): Promise<any> => {
+        const checkOverriddenApproval = (toolName: string): boolean => {
+            if (mcpPreferences?.overrideAllApprovals) {
+                return true;
+            } else {
+                const serverName = toolToServerMap.get(toolName);
+                return mcpPreferences?.enabledServers.find((server: any) => server.name === serverName)?.autoApprovedTools?.includes(toolName) ?? false;
+            }
+        };
+
         if (checkOverriddenApproval(tool.name)) {
             return await callTool(tool.name, tool.args);
         } else {
@@ -90,7 +90,7 @@ export const useToolChain = ({
                 });
             });
         }
-    }, [callTool, checkOverriddenApproval]);
+    }, [callTool, mcpPreferences, toolToServerMap]);
 
     const handleToolApproval = useCallback(async () => {
         if (!toolApprovalModal) return;

--- a/lib/user-interface/react/src/components/mcp/McpServerActions.tsx
+++ b/lib/user-interface/react/src/components/mcp/McpServerActions.tsx
@@ -31,7 +31,7 @@ export type McpServerActionsProps = {
     selectedItems: readonly McpServer[];
     setSelectedItems: (items: McpServer[]) => void;
     preferences: McpPreferences;
-    toggleYoloMode: () => void;
+    toggleAutopilotMode: () => void;
 };
 
 export function McpServerActions (props: McpServerActionsProps): ReactElement {
@@ -100,8 +100,8 @@ function McpServerActionButton (dispatch: ThunkDispatch<any, any, Action>, notif
     }
 
     items.push({
-        text: `${user.preferences?.overrideAllApprovals === true ? 'Disable' : 'Enable'} YOLO Mode`,
-        id: 'toggleYoloMode',
+        text: `${user.preferences?.overrideAllApprovals === true ? 'Disable' : 'Enable'} Autopilot Mode`,
+        id: 'toggleAutopilotMode',
     });
 
     return (
@@ -111,7 +111,7 @@ function McpServerActionButton (dispatch: ThunkDispatch<any, any, Action>, notif
             disabled={!items}
             loading={isDeleteLoading}
             onItemClick={(e) =>
-                ModelActionHandler(e, selectedMcpServer, dispatch, deleteMutation, navigate, props.toggleYoloMode)
+                ModelActionHandler(e, selectedMcpServer, dispatch, deleteMutation, navigate, props.toggleAutopilotMode)
             }
         >
             Actions
@@ -125,7 +125,7 @@ const ModelActionHandler = (
     dispatch: ThunkDispatch<any, any, Action>,
     deleteMutation: MutationTrigger<any>,
     navigate: NavigateFunction,
-    toggleYoloMode: () => void,
+    toggleAutopilotMode: () => void,
 ) => {
     switch (e.detail.id) {
         case 'editMcpServer':
@@ -141,8 +141,8 @@ const ModelActionHandler = (
                 })
             );
             break;
-        case 'toggleYoloMode':
-            toggleYoloMode();
+        case 'toggleAutopilotMode':
+            toggleAutopilotMode();
             break;
         default:
             return;

--- a/lib/user-interface/react/src/components/mcp/McpServerDetails.tsx
+++ b/lib/user-interface/react/src/components/mcp/McpServerDetails.tsx
@@ -158,7 +158,6 @@ export function McpServerDetails () {
                 <Grid gridDefinition={[{ colspan:6 }, { colspan:6 }]}>
                     <Header counter={`(${tools.length.toString() ?? undefined})`}>
                         {data?.name} Tool Details
-
                     </Header>
                     <Box float='right' variant='div'>
                         <StatusIndicator type={state === 'ready' ? 'success' : state.endsWith('ing') ? 'pending' : 'error'}>

--- a/lib/user-interface/react/src/components/mcp/McpServerDetails.tsx
+++ b/lib/user-interface/react/src/components/mcp/McpServerDetails.tsx
@@ -20,10 +20,10 @@ import {
     Pagination,
     SpaceBetween,
     Table,
-    TextContent
+    TextContent, Toggle
 } from '@cloudscape-design/components';
 import 'react';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useCollection } from '@cloudscape-design/collection-hooks';
 import { useLazyGetMcpServerQuery } from '@/shared/reducers/mcp-server.reducer';
@@ -31,17 +31,94 @@ import { useMcp } from 'use-mcp/react';
 import StatusIndicator from '@cloudscape-design/components/status-indicator';
 import Box from '@cloudscape-design/components/box';
 import { setBreadcrumbs } from '@/shared/reducers/breadcrumbs.reducer';
-import { useAppDispatch } from '@/config/store';
+import { useAppDispatch, useAppSelector } from '@/config/store';
+import {
+    DefaultUserPreferences, McpPreferences,
+    useGetUserPreferencesQuery, UserPreferences,
+    useUpdateUserPreferencesMutation
+} from '@/shared/reducers/user-preferences.reducer';
+import { useNotificationService } from '@/shared/util/hooks';
+import { selectCurrentUsername } from '@/shared/reducers/user.reducer';
 
 export function McpServerDetails () {
     const { mcpServerId } = useParams();
     const dispatch = useAppDispatch();
     const [getMcpServerQuery, {isUninitialized, data, isFetching, isSuccess}] = useLazyGetMcpServerQuery();
+    const {data: userPreferences} = useGetUserPreferencesQuery();
+    const [preferences, setPreferences] = useState<UserPreferences>(undefined);
+    const userName = useAppSelector(selectCurrentUsername);
+    const [updatePreferences, {isSuccess: isUpdatingSuccess, isError: isUpdatingError, error: updateError}] = useUpdateUserPreferencesMutation();
+    const notificationService = useNotificationService(dispatch);
+
+    // create success notification
+    useEffect(() => {
+        if (isUpdatingSuccess) {
+            notificationService.generateNotification('Successfully updated tool preferences', 'success');
+        }
+    }, [isUpdatingSuccess, notificationService]);
+
+    // create failure notification
+    useEffect(() => {
+        if (isUpdatingError) {
+            const errorMessage = 'data' in updateError ? (updateError.data?.message ?? updateError.data) : updateError.message;
+            notificationService.generateNotification(`Error updating tool preferences: ${errorMessage}`, 'error');
+        }
+    }, [isUpdatingError, updateError, notificationService]);
+
+    useEffect(() => {
+        if (userPreferences) {
+            setPreferences(userPreferences);
+        } else {
+            setPreferences({...DefaultUserPreferences, user: userName});
+        }
+    }, [userPreferences, userName]);
+
+    const toggleTool = (toolName: string, enabled: boolean) => {
+        const existingMcpPrefs = preferences.preferences.mcp ?? {enabledServers: [], overrideAllApprovals: false};
+        const mcpPrefs: McpPreferences = {
+            ...existingMcpPrefs,
+            enabledServers: [...existingMcpPrefs.enabledServers]
+        };
+
+        const originalServer = mcpPrefs.enabledServers.find((server) => server.id === mcpServerId);
+        if (!originalServer) return; // Early return if server not found
+
+        // Create a deep copy of the server object with its nested arrays
+        const serverToUpdate = {
+            ...originalServer,
+            disabledTools: [...originalServer.disabledTools],
+        };
+
+        if (enabled) {
+            serverToUpdate.disabledTools = serverToUpdate.disabledTools.filter((item) => item !== toolName);
+        } else {
+            serverToUpdate.disabledTools = [...serverToUpdate.disabledTools, toolName];
+        }
+
+        mcpPrefs.enabledServers = [
+            ...mcpPrefs.enabledServers.filter((server) => server.id !== mcpServerId),
+            serverToUpdate
+        ];
+        updatePrefs(mcpPrefs);
+    };
+
+    const updatePrefs = (mcpPrefs: McpPreferences) => {
+        const updated = {...preferences,
+            preferences: {...preferences.preferences,
+                mcp: {
+                    ...preferences.preferences.mcp,
+                    ...mcpPrefs
+                }
+            }
+        };
+        setPreferences(updated);
+        updatePreferences(updated);
+    };
 
     if (isSuccess) {
         dispatch(setBreadcrumbs([
             { text: 'MCP Servers', href: '/mcp-connections' },
-            { text: data.name, href: '' }
+            { text: data?.name, href: '' }
         ]));
     }
 
@@ -103,6 +180,7 @@ export function McpServerDetails () {
             pagination={<Pagination {...paginationProps} />}
             items={items}
             columnDefinitions={[
+                { header: 'Use Tool', cell: (item) => <Toggle checked={!preferences?.preferences?.mcp?.enabledServers.find((server) => server.id === mcpServerId)?.disabledTools.includes(item.name) ?? false} onChange={({detail}) => toggleTool(item.name, detail.checked)}/>},
                 { header: 'Name', cell: (item) => item.name},
                 { header: 'Description', cell: (item) => item.description},
             ]}

--- a/lib/user-interface/react/src/components/mcp/McpServerForm.tsx
+++ b/lib/user-interface/react/src/components/mcp/McpServerForm.tsx
@@ -94,7 +94,7 @@ export function McpServerForm (props: McpServerFormProps) {
             if (response.isSuccess) {
                 setFields({ ...response.data,
                     customHeaders: response.data.customHeaders ? Object.entries(response.data.customHeaders).map(([key, value]) => ({ key, value })) : [],
-                    status: response.status ?? McpServerStatus.Inactive,
+                    status: response.data.status ?? McpServerStatus.Inactive,
                 });
                 setSharePublic(response.data.owner === 'lisa:public');
             }

--- a/lib/user-interface/react/src/components/mcp/McpServerForm.tsx
+++ b/lib/user-interface/react/src/components/mcp/McpServerForm.tsx
@@ -71,6 +71,7 @@ export function McpServerForm (props: McpServerFormProps) {
     const schema = z.object({
         name: z.string().trim().min(1, 'String cannot be empty.'),
         url: z.string().trim().min(1, 'String cannot be empty.'),
+        description: z.string().trim().optional(),
         status: z.string().trim(),
         clientConfig: z.object({
             name: z.string().trim(),
@@ -163,6 +164,13 @@ export function McpServerForm (props: McpServerFormProps) {
                         }}
                         disabled={disabled}
                         placeholder='Enter MCP connection name' />
+                    </FormField>
+                    <FormField label='Description' errorText={errors?.description} description={'A description that provides an overview of your connection.'}>
+                        <Input value={state.form.description} inputMode='text' onBlur={() => touchFields(['description'])} onChange={({ detail }) => {
+                            setFields({ 'description': detail.value });
+                        }}
+                        disabled={disabled}
+                        placeholder='Enter MCP connection description' />
                     </FormField>
                     <FormField label='URL' errorText={errors?.url} description={'The URL for your MCP server.'}>
                         <Input value={state.form.url} inputMode='text' onBlur={() => touchFields(['url'])} onChange={({ detail }) => {

--- a/lib/user-interface/react/src/components/mcp/McpServerManagementComponent.tsx
+++ b/lib/user-interface/react/src/components/mcp/McpServerManagementComponent.tsx
@@ -71,18 +71,19 @@ export function McpServerManagementComponent () {
     // create failure notification
     useEffect(() => {
         if (isUpdatingError) {
-            notificationService.generateNotification(`Error updating server preferences: ${updateError.data?.message ?? updateError.data}`, 'error');
+            const errorMessage = 'data' in updateError ? (updateError.data?.message ?? updateError.data) : updateError.message;
+            notificationService.generateNotification(`Error updating server preferences: ${errorMessage}`, 'error');
         }
     }, [isUpdatingError, updateError, notificationService]);
 
-    const toggleServer = (serverId: string, enabled: boolean) => {
+    const toggleServer = (serverId: string, serverName: string, enabled: boolean) => {
         const existingMcpPrefs = preferences.preferences.mcp ?? {enabledServers: [], overrideAllApprovals: false};
         const mcpPrefs: McpPreferences = {
             ...existingMcpPrefs,
             enabledServers: [...existingMcpPrefs.enabledServers]
         };
         if (enabled){
-            mcpPrefs.enabledServers.push({id: serverId, enabled: true, disabledTools: [], autoApprovedTools: []});
+            mcpPrefs.enabledServers.push({id: serverId, name: serverName, enabled: true, disabledTools: [], autoApprovedTools: []});
         } else {
             mcpPrefs.enabledServers = mcpPrefs.enabledServers.filter((server) => server.id !== serverId);
         }
@@ -90,8 +91,11 @@ export function McpServerManagementComponent () {
     };
 
     const toggleYoloMode = () => {
-        const mcpPrefs: McpPreferences = preferences.preferences.mcp ?? {enabledServers: [], overrideAllApprovals: false};
-        mcpPrefs.overrideAllApprovals = !mcpPrefs.overrideAllApprovals ?? true;
+        const existingMcpPrefs = preferences.preferences.mcp ?? {enabledServers: [], overrideAllApprovals: false};
+        const mcpPrefs: McpPreferences = {
+            ...existingMcpPrefs,
+            overrideAllApprovals: !existingMcpPrefs.overrideAllApprovals
+        };
         updatePrefs(mcpPrefs);
     };
 
@@ -159,7 +163,7 @@ export function McpServerManagementComponent () {
             pagination={<Pagination {...paginationProps} />}
             items={items}
             columnDefinitions={[
-                { header: 'Use Server', cell: (item) => <Toggle checked={preferences?.preferences?.mcp?.enabledServers.find((server) => server.id === item.id)?.enabled ?? false} onChange={({detail}) => toggleServer(item.id, detail.checked)}/>},
+                { header: 'Use Server', cell: (item) => <Toggle checked={preferences?.preferences?.mcp?.enabledServers.find((server) => server.id === item.id)?.enabled ?? false} onChange={({detail}) => toggleServer(item.id, item.name, detail.checked)}/>},
                 { header: 'Name', cell: (item) => <Link onClick={() => navigate(`./${item.id}`)}>{item.name}</Link>},
                 { header: 'URL', cell: (item) => item.url, id: 'url', sortingField: 'url'},
                 { header: 'Owner', cell: (item) => item.owner, id: 'owner', sortingField: 'owner'},

--- a/lib/user-interface/react/src/components/mcp/McpServerManagementComponent.tsx
+++ b/lib/user-interface/react/src/components/mcp/McpServerManagementComponent.tsx
@@ -20,10 +20,13 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useCollection } from '@cloudscape-design/collection-hooks';
 import {McpServerActions} from './McpServerActions';
-import { useListMcpServersQuery } from '@/shared/reducers/mcp-server.reducer';
+import { McpServerStatus, useListMcpServersQuery } from '@/shared/reducers/mcp-server.reducer';
+import { useAppSelector } from '@/config/store';
+import { selectCurrentUserIsAdmin } from '@/shared/reducers/user.reducer';
 
 export function McpServerManagementComponent () {
     const navigate = useNavigate();
+    const isUserAdmin = useAppSelector(selectCurrentUserIsAdmin);
 
     const { data: {Items: allItems} = {Items: []}, isFetching } = useListMcpServersQuery(undefined, {});
     const { paginationProps, items, collectionProps, filteredItemsCount, actions } = useCollection(allItems, {
@@ -79,6 +82,7 @@ export function McpServerManagementComponent () {
                 { header: 'URL', cell: (item) => item.url, id: 'url', sortingField: 'url'},
                 { header: 'Owner', cell: (item) => item.owner, id: 'owner', sortingField: 'owner'},
                 { header: 'Updated', cell: (item) => item.created, id: 'created', sortingField: 'created'},
+                ...(isUserAdmin ? [{ header: 'Status', cell: (item) => item.status ?? McpServerStatus.Inactive}] : [])
             ]}
         />
     );

--- a/lib/user-interface/react/src/components/mcp/McpServerManagementComponent.tsx
+++ b/lib/user-interface/react/src/components/mcp/McpServerManagementComponent.tsx
@@ -90,7 +90,7 @@ export function McpServerManagementComponent () {
         updatePrefs(mcpPrefs);
     };
 
-    const toggleYoloMode = () => {
+    const toggleAutopilotMode = () => {
         const existingMcpPrefs = preferences.preferences.mcp ?? {enabledServers: [], overrideAllApprovals: false};
         const mcpPrefs: McpPreferences = {
             ...existingMcpPrefs,
@@ -143,7 +143,7 @@ export function McpServerManagementComponent () {
                     selectedItems={collectionProps.selectedItems || []}
                     setSelectedItems={actions.setSelectedItems}
                     preferences={preferences?.preferences?.mcp}
-                    toggleYoloMode={toggleYoloMode}
+                    toggleAutopilotMode={toggleAutopilotMode}
                 />}>
                     MCP Connections
                 </Header>
@@ -165,6 +165,7 @@ export function McpServerManagementComponent () {
             columnDefinitions={[
                 { header: 'Use Server', cell: (item) => <Toggle checked={preferences?.preferences?.mcp?.enabledServers.find((server) => server.id === item.id)?.enabled ?? false} onChange={({detail}) => toggleServer(item.id, item.name, detail.checked)}/>},
                 { header: 'Name', cell: (item) => <Link onClick={() => navigate(`./${item.id}`)}>{item.name}</Link>},
+                { header: 'Description', cell: (item) => item.description, id: 'description', sortingField: 'description'},
                 { header: 'URL', cell: (item) => item.url, id: 'url', sortingField: 'url'},
                 { header: 'Owner', cell: (item) => item.owner, id: 'owner', sortingField: 'owner'},
                 { header: 'Updated', cell: (item) => item.created, id: 'created', sortingField: 'created'},

--- a/lib/user-interface/react/src/shared/reducers/index.ts
+++ b/lib/user-interface/react/src/shared/reducers/index.ts
@@ -26,6 +26,7 @@ import breadcrumbGroup from './breadcrumbs.reducer';
 import { ragApi } from './rag.reducer';
 import { promptTemplateApi } from './prompt-templates.reducer';
 import { mcpServerApi } from '@/shared/reducers/mcp-server.reducer';
+import { userPreferencesApi } from '@/shared/reducers/user-preferences.reducer';
 
 const rootReducer: ReducersMapObject = {
     user: userReducer,
@@ -37,9 +38,10 @@ const rootReducer: ReducersMapObject = {
     [sessionApi.reducerPath]: sessionApi.reducer,
     [ragApi.reducerPath]: ragApi.reducer,
     [promptTemplateApi.reducerPath]: promptTemplateApi.reducer,
-    [mcpServerApi.reducerPath]: mcpServerApi.reducer
+    [mcpServerApi.reducerPath]: mcpServerApi.reducer,
+    [userPreferencesApi.reducerPath]: userPreferencesApi.reducer,
 };
 
-export const rootMiddleware = [modelManagementApi.middleware, configurationApi.middleware, sessionApi.middleware, ragApi.middleware, promptTemplateApi.middleware, mcpServerApi.middleware];
+export const rootMiddleware = [modelManagementApi.middleware, configurationApi.middleware, sessionApi.middleware, ragApi.middleware, promptTemplateApi.middleware, mcpServerApi.middleware, userPreferencesApi.middleware, userPreferencesApi.middleware];
 
 export default rootReducer;

--- a/lib/user-interface/react/src/shared/reducers/mcp-server.reducer.ts
+++ b/lib/user-interface/react/src/shared/reducers/mcp-server.reducer.ts
@@ -33,6 +33,7 @@ export type McpServer = {
     owner: string;
     url: string;
     name: string;
+    description?: string;
     isOwner?: true;
     customHeaders?: Record<string, string>;
     clientConfig?: McpClientConfig;
@@ -44,6 +45,7 @@ export type NewMcpServer = Partial<McpServer> & Pick<McpServer, | 'name' | 'url'
 export const DefaultMcpServer: NewMcpServer = {
     name: '',
     url: '',
+    description: '',
     clientConfig: {},
     status: McpServerStatus.Active
 };

--- a/lib/user-interface/react/src/shared/reducers/mcp-server.reducer.ts
+++ b/lib/user-interface/react/src/shared/reducers/mcp-server.reducer.ts
@@ -18,6 +18,11 @@ import { createApi } from '@reduxjs/toolkit/query/react';
 import { lisaBaseQuery } from './reducer.utils';
 import { normalizeError } from '../util/validationUtils';
 
+export enum McpServerStatus {
+    Active = 'active',
+    Inactive = 'inactive'
+}
+
 export type McpClientConfig = {
     name?: string,
     version?: string
@@ -31,6 +36,7 @@ export type McpServer = {
     isOwner?: true;
     customHeaders?: Record<string, string>;
     clientConfig?: McpClientConfig;
+    status?:McpServerStatus;
 };
 
 export type NewMcpServer = Partial<McpServer> & Pick<McpServer, | 'name' | 'url'>;
@@ -39,6 +45,7 @@ export const DefaultMcpServer: NewMcpServer = {
     name: '',
     url: '',
     clientConfig: {},
+    status: McpServerStatus.Active
 };
 
 export type McpServerListResponse = {

--- a/lib/user-interface/react/src/shared/reducers/user-preferences.reducer.ts
+++ b/lib/user-interface/react/src/shared/reducers/user-preferences.reducer.ts
@@ -19,6 +19,7 @@ import { lisaBaseQuery } from './reducer.utils';
 import { normalizeError } from '../util/validationUtils';
 
 export type McpServerPreferences = {
+    id: string;
     enabled: boolean;
     disabledTools: string[];
     autoApprovedTools: string[];
@@ -53,7 +54,7 @@ export const userPreferencesApi = createApi({
         updateUserPreferences: builder.mutation<UserPreferences, UserPreferences>({
             query: (userPreferences) => ({
                 url: '/user-preferences',
-                method: 'POST',
+                method: 'PUT',
                 data: userPreferences
             }),
             transformErrorResponse: (baseQueryReturnValue) => normalizeError('Update User Preferences', baseQueryReturnValue),

--- a/lib/user-interface/react/src/shared/reducers/user-preferences.reducer.ts
+++ b/lib/user-interface/react/src/shared/reducers/user-preferences.reducer.ts
@@ -20,6 +20,7 @@ import { normalizeError } from '../util/validationUtils';
 
 export type McpServerPreferences = {
     id: string;
+    name: string;
     enabled: boolean;
     disabledTools: string[];
     autoApprovedTools: string[];

--- a/lib/user-interface/react/src/shared/reducers/user-preferences.reducer.ts
+++ b/lib/user-interface/react/src/shared/reducers/user-preferences.reducer.ts
@@ -1,0 +1,78 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import { createApi } from '@reduxjs/toolkit/query/react';
+import { lisaBaseQuery } from './reducer.utils';
+import { normalizeError } from '../util/validationUtils';
+
+export type McpServerPreferences = {
+    enabled: boolean;
+    disabledTools: string[];
+    autoApprovedTools: string[];
+};
+
+export type McpPreferences = {
+    overrideAllApprovals: boolean;
+    enabledServers: McpServerPreferences[];
+};
+
+export type Preferences = {
+    mcp?: McpPreferences;
+};
+
+export type UserPreferences = {
+    user: string;
+    preferences: Preferences;
+};
+
+export const DefaultUserPreferences: UserPreferences = {
+    user: '',
+    preferences: {},
+};
+
+export const userPreferencesApi = createApi({
+    reducerPath: 'userPreferences',
+    baseQuery: lisaBaseQuery(),
+    tagTypes: ['user-preferences'],
+    refetchOnFocus: true,
+    refetchOnReconnect: true,
+    endpoints: (builder) => ({
+        updateUserPreferences: builder.mutation<UserPreferences, UserPreferences>({
+            query: (userPreferences) => ({
+                url: '/user-preferences',
+                method: 'POST',
+                data: userPreferences
+            }),
+            transformErrorResponse: (baseQueryReturnValue) => normalizeError('Update User Preferences', baseQueryReturnValue),
+            invalidatesTags: ['user-preferences'],
+        }),
+        getUserPreferences: builder.query<UserPreferences, void>({
+            query () {
+                return {
+                    url: '/user-preferences',
+                    method: 'GET'
+                };
+            },
+            providesTags: ['user-preferences']
+        }),
+    })
+
+});
+
+export const {
+    useUpdateUserPreferencesMutation,
+    useGetUserPreferencesQuery,
+} = userPreferencesApi;

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,7 +136,7 @@
         "tailwindcss": "^3.4.17",
         "typescript": "~5.1.6",
         "unraw": "^3.0.0",
-        "use-mcp": "^0.0.9",
+        "use-mcp": "^0.0.14",
         "vitepress": "^1.6.3"
       },
       "devDependencies": {
@@ -15626,6 +15626,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/strict-url-sanitise": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/strict-url-sanitise/-/strict-url-sanitise-0.0.1.tgz",
+      "integrity": "sha512-nuFtF539K8jZg3FjaWH/L8eocCR6gegz5RDOsaWxfdbF5Jqr2VXWxZayjTwUzsWJDC91k2EbnJXp6FuWW+Z4hg==",
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -16749,11 +16755,12 @@
       }
     },
     "node_modules/use-mcp": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/use-mcp/-/use-mcp-0.0.9.tgz",
-      "integrity": "sha512-YzvVz+K/Clg8sO573RPXQdr7N/NFkVNeOetiX+yse62gcws8lY9wkoROdNkf6eAfN7kkrGvcHlfQW3mavpywlQ==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/use-mcp/-/use-mcp-0.0.14.tgz",
+      "integrity": "sha512-U+AC2X9BvYBQzi91latkeGTyqlKhUmvAHYtLVnQXI4k5XxagrYQlG+GXeSvktEsW1GsAZoJ+ojU7ct0X1ORZNw==",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.11.0"
+        "@modelcontextprotocol/sdk": "^1.13.1",
+        "strict-url-sanitise": "^0.0.1"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,7 +136,7 @@
         "tailwindcss": "^3.4.17",
         "typescript": "~5.1.6",
         "unraw": "^3.0.0",
-        "use-mcp": "^0.0.14",
+        "use-mcp": "^0.0.18",
         "vitepress": "^1.6.3"
       },
       "devDependencies": {
@@ -3576,9 +3576,9 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.13.2.tgz",
-      "integrity": "sha512-Vx7qOcmoKkR3qhaQ9qf3GxiVKCEu+zfJddHv6x3dY/9P6+uIwJnmuAur5aB+4FDXf41rRrDnOEGkviX5oYZ67w==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.13.3.tgz",
+      "integrity": "sha512-bGwA78F/U5G2jrnsdRkPY3IwIwZeWUEfb5o764b79lb0rJmMT76TLwKhdNZOWakOQtedYefwIR4emisEMvInKA==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",
@@ -3586,6 +3586,7 @@
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
         "pkce-challenge": "^5.0.0",
@@ -16755,11 +16756,11 @@
       }
     },
     "node_modules/use-mcp": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/use-mcp/-/use-mcp-0.0.14.tgz",
-      "integrity": "sha512-U+AC2X9BvYBQzi91latkeGTyqlKhUmvAHYtLVnQXI4k5XxagrYQlG+GXeSvktEsW1GsAZoJ+ojU7ct0X1ORZNw==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/use-mcp/-/use-mcp-0.0.18.tgz",
+      "integrity": "sha512-4NU93NElE3XT5gqskaPp68Eot6aOtRedooaPXmfB4dVqnlH2MiS6Q1J+d1HNPbYTEC9aa/OJPkf53uZNN5vNEA==",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.13.1",
+        "@modelcontextprotocol/sdk": "^1.13.3",
         "strict-url-sanitise": "^0.0.1"
       }
     },

--- a/test/cdk/stacks/nag.test.ts
+++ b/test/cdk/stacks/nag.test.ts
@@ -33,7 +33,7 @@ enum NagType {
 const nagResults: NagResult = {
     LisaApiBase: [1,7,0,7],
     LisaApiDeployment: [0,0,0,0],
-    LisaChat: [3,54,0,59],
+    LisaChat: [4,60,0,67],
     LisaCore: [0,1,0,6],
     LisaDocs: [1,22,0,12],
     LisaIAM: [0,14,0,0],

--- a/test/cdk/stacks/roleOverrides.test.ts
+++ b/test/cdk/stacks/roleOverrides.test.ts
@@ -35,7 +35,7 @@ const stackRoles: Record<string, number> = {
     'LisaServe': 5,
     'LisaUI': 3,
     'LisaNetworking': 0,
-    'LisaChat': 5,
+    'LisaChat': 6,
     'LisaCore': 1,
     'LisaApiDeployment': 0,
     'LisaIAM': 2,

--- a/test/lambda/test_create_model_state_machine.py
+++ b/test/lambda/test_create_model_state_machine.py
@@ -1,0 +1,663 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Unit tests for create_model state machine functions."""
+
+import json
+import os
+import sys
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from botocore.config import Config
+from moto import mock_aws
+
+# Add the lambda directory to the Python path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../"))
+
+# Set up mock AWS credentials
+os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+os.environ["AWS_SECURITY_TOKEN"] = "testing"
+os.environ["AWS_SESSION_TOKEN"] = "testing"
+os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+os.environ["AWS_REGION"] = "us-east-1"
+os.environ["MODEL_TABLE_NAME"] = "model-table"
+os.environ["ECR_REPOSITORY_NAME"] = "test-ecr-repo"
+os.environ["ECR_REPOSITORY_ARN"] = "arn:aws:ecr:us-east-1:123456789012:repository/test-ecr-repo"
+os.environ["DOCKER_IMAGE_BUILDER_FN_ARN"] = "arn:aws:lambda:us-east-1:123456789012:function:docker-image-builder"
+os.environ["ECS_MODEL_DEPLOYER_FN_ARN"] = "arn:aws:lambda:us-east-1:123456789012:function:ecs-model-deployer"
+os.environ["MANAGEMENT_KEY_NAME"] = "test-management-key"
+os.environ["LITELLM_CONFIG_OBJ"] = '{"litellm_settings": {"drop_params": true}}'
+
+# Create a real retry config
+retry_config = Config(retries=dict(max_attempts=3), defaults_mode="standard")
+
+# Create mock modules
+mock_common = MagicMock()
+mock_common.get_cert_path.return_value = None
+mock_common.get_rest_api_container_endpoint.return_value = "https://test-api.example.com"
+mock_common.retry_config = retry_config
+
+# Create mock LiteLLMClient
+mock_litellm_client = MagicMock()
+mock_litellm_client.add_model.return_value = {"model_info": {"id": "test-litellm-id"}}
+
+# First, patch sys.modules
+patch.dict(
+    "sys.modules",
+    {
+        "create_env_variables": MagicMock(),
+    },
+).start()
+
+# Then patch the specific functions
+patch("utilities.common_functions.get_cert_path", mock_common.get_cert_path).start()
+patch("utilities.common_functions.get_rest_api_container_endpoint", mock_common.get_rest_api_container_endpoint).start()
+patch("utilities.common_functions.retry_config", retry_config).start()
+patch("models.clients.litellm_client.LiteLLMClient", return_value=mock_litellm_client).start()
+
+# Mock boto3 clients
+mock_lambda = MagicMock()
+mock_ecr = MagicMock()
+mock_ec2 = MagicMock()
+mock_cfn = MagicMock()
+mock_iam = MagicMock()
+mock_secrets = MagicMock()
+
+
+# Create mock exception classes for ECR
+class MockECRExceptions:
+    class ImageNotFoundException(Exception):
+        pass
+
+
+mock_ecr.exceptions = MockECRExceptions()
+
+mock_lambda.invoke.return_value = {
+    "Payload": MagicMock(
+        read=lambda: json.dumps({"image_tag": "test-tag", "instance_id": "i-1234567890abcdef0"}).encode()
+    )
+}
+mock_ecr.describe_images.return_value = {"imageDetails": [{"imageTags": ["test-tag"]}]}
+mock_cfn.describe_stacks.return_value = {
+    "Stacks": [
+        {
+            "StackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/test-id",
+            "StackStatus": "CREATE_COMPLETE",
+            "Outputs": [
+                {"OutputKey": "modelEndpointUrl", "OutputValue": "https://test-model.example.com"},
+                {"OutputKey": "autoScalingGroup", "OutputValue": "test-asg"},
+            ],
+        }
+    ]
+}
+mock_secrets.get_secret_value.return_value = {"SecretString": "test-secret"}
+
+
+# Create comprehensive mock for boto3.client to handle all possible service requests
+def mock_boto3_client(service, **kwargs):
+    if service == "lambda":
+        return mock_lambda
+    elif service == "ecr":
+        return mock_ecr
+    elif service == "ec2":
+        return mock_ec2
+    elif service == "cloudformation":
+        return mock_cfn
+    elif service == "iam":
+        return mock_iam
+    elif service == "secretsmanager":
+        return mock_secrets
+    elif service == "ssm":
+        # Return a basic mock for SSM
+        mock_ssm = MagicMock()
+        mock_ssm.get_parameter.return_value = {"Parameter": {"Value": "mock-value"}}
+        return mock_ssm
+    elif service == "s3":
+        # Return a basic mock for S3
+        mock_s3 = MagicMock()
+        return mock_s3
+    else:
+        # Return a generic mock for any other services
+        return MagicMock()
+
+
+patch("boto3.client", side_effect=mock_boto3_client).start()
+
+# Patch the specific clients in the state machine module
+patch("models.state_machine.create_model.ecrClient", mock_ecr).start()
+patch("models.state_machine.create_model.ec2Client", mock_ec2).start()
+patch("models.state_machine.create_model.cfnClient", mock_cfn).start()
+patch("models.state_machine.create_model.lambdaClient", mock_lambda).start()
+
+from models.domain_objects import InferenceContainer, ModelStatus
+
+# Now import the state machine functions
+from models.state_machine.create_model import (
+    get_container_path,
+    handle_add_model_to_litellm,
+    handle_failure,
+    handle_poll_create_stack,
+    handle_poll_docker_image_available,
+    handle_set_model_to_creating,
+    handle_start_copy_docker_image,
+    handle_start_create_stack,
+)
+
+
+@pytest.fixture
+def lambda_context():
+    """Create a mock Lambda context."""
+    return SimpleNamespace(
+        function_name="test_function",
+        function_version="$LATEST",
+        invoked_function_arn="arn:aws:lambda:us-east-1:123456789012:function:test_function",
+        memory_limit_in_mb=128,
+        aws_request_id="test-request-id",
+        log_group_name="/aws/lambda/test_function",
+        log_stream_name="2024/03/27/[$LATEST]test123",
+    )
+
+
+@pytest.fixture(scope="function")
+def dynamodb():
+    """Create a mock DynamoDB service."""
+    with mock_aws():
+        yield boto3.resource("dynamodb", region_name="us-east-1")
+
+
+@pytest.fixture(scope="function")
+def model_table(dynamodb):
+    """Create a mock DynamoDB table for models."""
+    table = dynamodb.create_table(
+        TableName="model-table",
+        KeySchema=[{"AttributeName": "model_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "model_id", "AttributeType": "S"}],
+        ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+    )
+    return table
+
+
+@pytest.fixture
+def sample_event():
+    """Sample event for state machine functions."""
+    return {
+        "modelId": "test-model",
+        "modelName": "test-model-name",
+        "modelType": "textgen",
+        "streaming": True,
+        "autoScalingConfig": {
+            "minCapacity": 1,
+            "maxCapacity": 3,
+            "cooldown": 60,
+            "defaultInstanceWarmup": 300,
+            "metricConfig": {
+                "estimatedInstanceWarmup": 300,
+                "targetValue": 60,
+                "albMetricName": "RequestCountPerTarget",
+                "duration": 60,
+            },
+        },
+        "containerConfig": {
+            "image": {"baseImage": "test-image:latest", "type": "ecr"},
+            "environment": {"TEST_VAR": "test_value"},
+            "sharedMemorySize": 2048,
+            "healthCheckConfig": {
+                "command": "curl -f http://localhost:8080/health || exit 1",
+                "interval": 30,
+                "startPeriod": 30,
+                "timeout": 5,
+                "retries": 3,
+            },
+        },
+        "inferenceContainer": "vllm",
+        "instanceType": "t3.medium",
+        "loadBalancerConfig": {
+            "healthCheckConfig": {
+                "healthyThresholdCount": 2,
+                "unhealthyThresholdCount": 2,
+                "path": "/health",
+                "timeout": 5,
+                "interval": 10,
+            }
+        },
+    }
+
+
+def test_get_container_path():
+    """Test container path mapping for different inference containers."""
+    assert get_container_path(InferenceContainer.TEI) == "embedding/tei"
+    assert get_container_path(InferenceContainer.TGI) == "textgen/tgi"
+    assert get_container_path(InferenceContainer.VLLM) == "vllm"
+
+
+def test_handle_set_model_to_creating_lisa_managed(model_table, sample_event, lambda_context):
+    """Test setting model to creating status for LISA-managed model."""
+    with patch("models.state_machine.create_model.model_table", model_table):
+        result = handle_set_model_to_creating(sample_event, lambda_context)
+
+        assert result["create_infra"] is True
+        assert result["modelId"] == "test-model"
+
+        # Verify DDB update
+        item = model_table.get_item(Key={"model_id": "test-model"})["Item"]
+        assert item["model_status"] == ModelStatus.CREATING
+        assert item["model_config"] == sample_event
+
+
+def test_handle_set_model_to_creating_not_lisa_managed(model_table, lambda_context):
+    """Test setting model to creating status for non-LISA-managed model."""
+    event = {
+        "modelId": "test-model",
+        "modelName": "test-model-name",
+        "modelType": "textgen",
+        "streaming": True,
+    }
+
+    with patch("models.state_machine.create_model.model_table", model_table):
+        result = handle_set_model_to_creating(event, lambda_context)
+
+        assert result["create_infra"] is False
+        assert result["modelId"] == "test-model"
+
+
+def test_handle_start_copy_docker_image(sample_event, lambda_context):
+    """Test starting Docker image copy process."""
+    result = handle_start_copy_docker_image(sample_event, lambda_context)
+
+    assert result["containerConfig"]["image"]["path"] == "vllm"
+    assert "image_info" in result
+    assert result["image_info"]["image_tag"] == "test-tag"
+    assert result["image_info"]["instance_id"] == "i-1234567890abcdef0"
+    assert result["image_info"]["remaining_polls"] == 30
+
+    # Verify lambda invocation
+    mock_lambda.invoke.assert_called_once()
+    call_args = mock_lambda.invoke.call_args
+    assert call_args[1]["FunctionName"] == os.environ["DOCKER_IMAGE_BUILDER_FN_ARN"]
+
+
+def test_handle_poll_docker_image_available_success(sample_event, lambda_context):
+    """Test polling Docker image when image is available."""
+    event = deepcopy(sample_event)
+    event["image_info"] = {"image_tag": "test-tag", "instance_id": "i-1234567890abcdef0", "remaining_polls": 10}
+
+    # Mock image found
+    mock_ecr.describe_images.return_value = {"imageDetails": [{"imageTags": ["test-tag"]}]}
+
+    result = handle_poll_docker_image_available(event, lambda_context)
+
+    assert result["continue_polling_docker"] is False
+    mock_ec2.terminate_instances.assert_called_with(InstanceIds=["i-1234567890abcdef0"])
+
+
+def test_handle_poll_docker_image_available_not_ready(sample_event, lambda_context):
+    """Test polling Docker image when image is not yet available."""
+    event = deepcopy(sample_event)
+    event["image_info"] = {"image_tag": "test-tag", "instance_id": "i-1234567890abcdef0", "remaining_polls": 10}
+
+    # Mock image not found
+    mock_ecr.describe_images.side_effect = mock_ecr.exceptions.ImageNotFoundException()
+
+    result = handle_poll_docker_image_available(event, lambda_context)
+
+    assert result["continue_polling_docker"] is True
+    assert result["image_info"]["remaining_polls"] == 9
+
+
+def test_handle_poll_docker_image_available_max_polls_exceeded(sample_event, lambda_context):
+    """Test polling Docker image when max polls exceeded."""
+    event = deepcopy(sample_event)
+    event["image_info"] = {"image_tag": "test-tag", "instance_id": "i-1234567890abcdef0", "remaining_polls": 1}
+
+    # Mock image not found
+    mock_ecr.describe_images.side_effect = mock_ecr.exceptions.ImageNotFoundException()
+
+    from models.exception import MaxPollsExceededException
+
+    with pytest.raises(MaxPollsExceededException):
+        handle_poll_docker_image_available(event, lambda_context)
+
+    mock_ec2.terminate_instances.assert_called_with(InstanceIds=["i-1234567890abcdef0"])
+
+
+def test_handle_start_create_stack(model_table, sample_event, lambda_context):
+    """Test starting CloudFormation stack creation."""
+    event = deepcopy(sample_event)
+    event["image_info"] = {"image_tag": "test-tag"}
+
+    # Mock ECS model deployer response
+    mock_lambda.invoke.return_value = {
+        "Payload": MagicMock(read=lambda: json.dumps({"stackName": "test-stack"}).encode())
+    }
+
+    with patch("models.state_machine.create_model.model_table", model_table):
+        result = handle_start_create_stack(event, lambda_context)
+
+        assert result["stack_name"] == "test-stack"
+        assert result["stack_arn"] == "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/test-id"
+        assert result["remaining_polls_stack"] == 30
+
+        # Verify DDB update
+        item = model_table.get_item(Key={"model_id": "test-model"})["Item"]
+        assert item["cloudformation_stack_name"] == "test-stack"
+
+
+def test_handle_start_create_stack_no_stack_name(sample_event, lambda_context):
+    """Test starting CloudFormation stack creation when no stack name returned."""
+    event = deepcopy(sample_event)
+    event["image_info"] = {"image_tag": "test-tag"}
+
+    # Mock ECS model deployer response without stack name
+    mock_lambda.invoke.return_value = {"Payload": MagicMock(read=lambda: json.dumps({}).encode())}
+
+    from models.exception import StackFailedToCreateException
+
+    with pytest.raises(StackFailedToCreateException):
+        handle_start_create_stack(event, lambda_context)
+
+
+def test_handle_poll_create_stack_complete(sample_event, lambda_context):
+    """Test polling CloudFormation stack when creation is complete."""
+    event = deepcopy(sample_event)
+    event["stack_name"] = "test-stack"
+    event["remaining_polls_stack"] = 10
+
+    result = handle_poll_create_stack(event, lambda_context)
+
+    assert result["continue_polling_stack"] is False
+    assert result["modelUrl"] == "https://test-model.example.com"
+    assert result["autoScalingGroup"] == "test-asg"
+
+
+def test_handle_poll_create_stack_in_progress(sample_event, lambda_context):
+    """Test polling CloudFormation stack when creation is in progress."""
+    event = deepcopy(sample_event)
+    event["stack_name"] = "test-stack"
+    event["remaining_polls_stack"] = 10
+
+    # Mock stack in progress
+    mock_cfn.describe_stacks.return_value = {"Stacks": [{"StackStatus": "CREATE_IN_PROGRESS"}]}
+
+    result = handle_poll_create_stack(event, lambda_context)
+
+    assert result["continue_polling_stack"] is True
+    assert result["remaining_polls_stack"] == 9
+
+
+def test_handle_poll_create_stack_max_polls_exceeded(sample_event, lambda_context):
+    """Test polling CloudFormation stack when max polls exceeded."""
+    event = deepcopy(sample_event)
+    event["stack_name"] = "test-stack"
+    event["remaining_polls_stack"] = 1
+
+    # Mock stack in progress
+    mock_cfn.describe_stacks.return_value = {"Stacks": [{"StackStatus": "CREATE_IN_PROGRESS"}]}
+
+    from models.exception import MaxPollsExceededException
+
+    with pytest.raises(MaxPollsExceededException):
+        handle_poll_create_stack(event, lambda_context)
+
+
+def test_handle_poll_create_stack_unexpected_state(sample_event, lambda_context):
+    """Test polling CloudFormation stack with unexpected state."""
+    event = deepcopy(sample_event)
+    event["stack_name"] = "test-stack"
+
+    # Mock unexpected stack state
+    mock_cfn.describe_stacks.return_value = {"Stacks": [{"StackStatus": "DELETE_COMPLETE"}]}
+
+    from models.exception import UnexpectedCloudFormationStateException
+
+    with pytest.raises(UnexpectedCloudFormationStateException):
+        handle_poll_create_stack(event, lambda_context)
+
+
+def test_handle_add_model_to_litellm_lisa_managed(model_table, sample_event, lambda_context):
+    """Test adding LISA-managed model to LiteLLM."""
+    event = deepcopy(sample_event)
+    event["create_infra"] = True
+    event["modelUrl"] = "https://test-model.example.com"
+    event["autoScalingGroup"] = "test-asg"
+
+    with patch("models.state_machine.create_model.model_table", model_table):
+        result = handle_add_model_to_litellm(event, lambda_context)
+
+        assert result["litellm_id"] == "test-litellm-id"
+
+        # Verify LiteLLM client call
+        mock_litellm_client.add_model.assert_called_once()
+        call_args = mock_litellm_client.add_model.call_args
+        assert call_args[1]["model_name"] == "test-model"
+        assert "openai/test-model-name" in call_args[1]["litellm_params"]["model"]
+
+        # Verify DDB update
+        item = model_table.get_item(Key={"model_id": "test-model"})["Item"]
+        assert item["model_status"] == ModelStatus.IN_SERVICE
+        assert item["litellm_id"] == "test-litellm-id"
+
+
+def test_handle_add_model_to_litellm_not_lisa_managed(model_table, sample_event, lambda_context):
+    """Test adding non-LISA-managed model to LiteLLM."""
+    event = deepcopy(sample_event)
+    event["create_infra"] = False
+
+    with patch("models.state_machine.create_model.model_table", model_table):
+        result = handle_add_model_to_litellm(event, lambda_context)
+
+        assert result["litellm_id"] == "test-litellm-id"
+
+        # Verify LiteLLM client call
+        call_args = mock_litellm_client.add_model.call_args
+        assert call_args[1]["litellm_params"]["model"] == "test-model-name"
+
+
+def test_handle_failure_with_instance(model_table, sample_event, lambda_context):
+    """Test handling failure with EC2 instance to terminate."""
+    event = {
+        "Cause": json.dumps(
+            {
+                "errorMessage": json.dumps(
+                    {
+                        "error": "Test error",
+                        "event": {"modelId": "test-model", "image_info": {"instance_id": "i-1234567890abcdef0"}},
+                    }
+                )
+            }
+        )
+    }
+
+    with patch("models.state_machine.create_model.model_table", model_table):
+        result = handle_failure(event, lambda_context)
+
+        assert result == event
+
+        # Verify EC2 instance termination
+        mock_ec2.terminate_instances.assert_called_with(InstanceIds=["i-1234567890abcdef0"])
+
+        # Verify DDB update
+        item = model_table.get_item(Key={"model_id": "test-model"})["Item"]
+        assert item["model_status"] == ModelStatus.FAILED
+        assert item["failure_reason"] == "Test error"
+
+
+def test_handle_failure_without_instance(model_table, lambda_context):
+    """Test handling failure without EC2 instance."""
+    event = {
+        "Cause": json.dumps({"errorMessage": json.dumps({"error": "Test error", "event": {"modelId": "test-model"}})})
+    }
+
+    with patch("models.state_machine.create_model.model_table", model_table):
+        result = handle_failure(event, lambda_context)
+
+        assert result == event
+
+        # Verify DDB update
+        item = model_table.get_item(Key={"model_id": "test-model"})["Item"]
+        assert item["model_status"] == ModelStatus.FAILED
+        assert item["failure_reason"] == "Test error"
+
+
+def test_handle_start_copy_docker_image_tei(lambda_context):
+    """Test Docker image copy for TEI container."""
+    event = {
+        "modelId": "test-model",
+        "modelName": "test-model-name",
+        "modelType": "embedding",
+        "inferenceContainer": "tei",
+        "instanceType": "t3.medium",
+        "autoScalingConfig": {
+            "minCapacity": 1,
+            "maxCapacity": 3,
+            "cooldown": 60,
+            "defaultInstanceWarmup": 300,
+            "metricConfig": {
+                "estimatedInstanceWarmup": 300,
+                "targetValue": 60,
+                "albMetricName": "RequestCountPerTarget",
+                "duration": 60,
+            },
+        },
+        "containerConfig": {
+            "image": {"baseImage": "test-image:latest", "type": "ecr"},
+            "sharedMemorySize": 2048,
+            "healthCheckConfig": {
+                "command": "curl -f http://localhost:8080/health || exit 1",
+                "interval": 30,
+                "startPeriod": 30,
+                "timeout": 5,
+                "retries": 3,
+            },
+        },
+        "loadBalancerConfig": {
+            "healthCheckConfig": {
+                "healthyThresholdCount": 2,
+                "unhealthyThresholdCount": 2,
+                "path": "/health",
+                "timeout": 5,
+                "interval": 10,
+            }
+        },
+    }
+
+    result = handle_start_copy_docker_image(event, lambda_context)
+
+    assert result["containerConfig"]["image"]["path"] == "embedding/tei"
+
+
+def test_handle_start_copy_docker_image_tgi(lambda_context):
+    """Test Docker image copy for TGI container."""
+    event = {
+        "modelId": "test-model",
+        "modelName": "test-model-name",
+        "modelType": "textgen",
+        "inferenceContainer": "tgi",
+        "instanceType": "t3.medium",
+        "autoScalingConfig": {
+            "minCapacity": 1,
+            "maxCapacity": 3,
+            "cooldown": 60,
+            "defaultInstanceWarmup": 300,
+            "metricConfig": {
+                "estimatedInstanceWarmup": 300,
+                "targetValue": 60,
+                "albMetricName": "RequestCountPerTarget",
+                "duration": 60,
+            },
+        },
+        "containerConfig": {
+            "image": {"baseImage": "test-image:latest", "type": "ecr"},
+            "sharedMemorySize": 2048,
+            "healthCheckConfig": {
+                "command": "curl -f http://localhost:8080/health || exit 1",
+                "interval": 30,
+                "startPeriod": 30,
+                "timeout": 5,
+                "retries": 3,
+            },
+        },
+        "loadBalancerConfig": {
+            "healthCheckConfig": {
+                "healthyThresholdCount": 2,
+                "unhealthyThresholdCount": 2,
+                "path": "/health",
+                "timeout": 5,
+                "interval": 10,
+            }
+        },
+    }
+
+    result = handle_start_copy_docker_image(event, lambda_context)
+
+    assert result["containerConfig"]["image"]["path"] == "textgen/tgi"
+
+
+def test_handle_add_model_to_litellm_json_decode_error(model_table, sample_event, lambda_context):
+    """Test adding model to LiteLLM with invalid JSON config."""
+    event = deepcopy(sample_event)
+    event["create_infra"] = True
+    event["modelUrl"] = "https://test-model.example.com"
+
+    with patch("os.environ.get") as mock_env:
+        mock_env.return_value = "invalid-json"
+
+        with patch("models.state_machine.create_model.model_table", model_table):
+            result = handle_add_model_to_litellm(event, lambda_context)
+
+            assert result["litellm_id"] == "test-litellm-id"
+
+            # Should fallback to empty dict when JSON parsing fails
+            call_args = mock_litellm_client.add_model.call_args
+            assert call_args[1]["litellm_params"]["drop_params"] is True
+
+
+def test_handle_start_create_stack_camelize_function(sample_event, lambda_context):
+    """Test the internal camelize function in handle_start_create_stack."""
+    event = deepcopy(sample_event)
+    event["image_info"] = {"image_tag": "test-tag"}
+    event["TestKey"] = {"NestedKey": "value"}
+
+    # Reset mock_cfn for this test to include StackId
+    mock_cfn.describe_stacks.return_value = {
+        "Stacks": [
+            {
+                "StackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/test-id",
+                "StackStatus": "CREATE_COMPLETE",
+            }
+        ]
+    }
+
+    mock_lambda.invoke.return_value = {
+        "Payload": MagicMock(read=lambda: json.dumps({"stackName": "test-stack"}).encode())
+    }
+
+    with patch("models.state_machine.create_model.model_table"):
+        handle_start_create_stack(event, lambda_context)
+
+    # Verify lambda was called with camelized payload
+    call_args = mock_lambda.invoke.call_args
+    payload = json.loads(call_args[1]["Payload"])
+
+    # Check that keys are camelized
+    assert "testKey" in payload["modelConfig"]
+    assert "nestedKey" in payload["modelConfig"]["testKey"]
+
+    # Check that certain keys are preserved
+    assert payload["modelConfig"]["containerConfig"]["environment"] == {"TEST_VAR": "test_value"}
+    assert payload["modelConfig"]["containerConfig"]["image"]["type"] == "ecr"

--- a/test/lambda/test_delete_model_state_machine.py
+++ b/test/lambda/test_delete_model_state_machine.py
@@ -1,0 +1,451 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Unit tests for delete_model state machine functions."""
+
+import os
+import sys
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from botocore.config import Config
+from moto import mock_aws
+
+# Add the lambda directory to the Python path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../"))
+
+# Set up mock AWS credentials
+os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+os.environ["AWS_SECURITY_TOKEN"] = "testing"
+os.environ["AWS_SESSION_TOKEN"] = "testing"
+os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+os.environ["AWS_REGION"] = "us-east-1"
+os.environ["MODEL_TABLE_NAME"] = "model-table"
+os.environ["MANAGEMENT_KEY_NAME"] = "test-management-key"
+
+# Create a real retry config
+retry_config = Config(retries=dict(max_attempts=3), defaults_mode="standard")
+
+# Create mock modules
+mock_common = MagicMock()
+mock_common.get_cert_path.return_value = None
+mock_common.get_rest_api_container_endpoint.return_value = "https://test-api.example.com"
+mock_common.retry_config = retry_config
+
+# Create mock LiteLLMClient
+mock_litellm_client = MagicMock()
+mock_litellm_client.delete_model.return_value = {"status": "deleted"}
+
+# First, patch sys.modules
+patch.dict(
+    "sys.modules",
+    {
+        "create_env_variables": MagicMock(),
+    },
+).start()
+
+# Then patch the specific functions
+patch("utilities.common_functions.get_cert_path", mock_common.get_cert_path).start()
+patch("utilities.common_functions.get_rest_api_container_endpoint", mock_common.get_rest_api_container_endpoint).start()
+patch("utilities.common_functions.retry_config", retry_config).start()
+patch("models.clients.litellm_client.LiteLLMClient", return_value=mock_litellm_client).start()
+
+# Mock boto3 clients
+mock_cfn = MagicMock()
+mock_iam = MagicMock()
+mock_secrets = MagicMock()
+
+mock_cfn.describe_stacks.return_value = {"Stacks": [{"StackStatus": "DELETE_COMPLETE"}]}
+mock_cfn.delete_stack.return_value = {}
+mock_secrets.get_secret_value.return_value = {"SecretString": "test-secret"}
+
+
+# Create comprehensive mock for boto3.client to handle all possible service requests
+def mock_boto3_client(service, **kwargs):
+    if service == "cloudformation":
+        return mock_cfn
+    elif service == "iam":
+        return mock_iam
+    elif service == "secretsmanager":
+        return mock_secrets
+    elif service == "ssm":
+        # Return a basic mock for SSM
+        mock_ssm = MagicMock()
+        mock_ssm.get_parameter.return_value = {"Parameter": {"Value": "mock-value"}}
+        return mock_ssm
+    elif service == "s3":
+        # Return a basic mock for S3
+        mock_s3 = MagicMock()
+        return mock_s3
+    else:
+        # Return a generic mock for any other services
+        return MagicMock()
+
+
+patch("boto3.client", side_effect=mock_boto3_client).start()
+
+from models.domain_objects import ModelStatus
+
+# Now import the state machine functions
+from models.state_machine.delete_model import (
+    handle_delete_from_ddb,
+    handle_delete_from_litellm,
+    handle_delete_stack,
+    handle_monitor_delete_stack,
+    handle_set_model_to_deleting,
+)
+
+
+@pytest.fixture
+def lambda_context():
+    """Create a mock Lambda context."""
+    return SimpleNamespace(
+        function_name="test_function",
+        function_version="$LATEST",
+        invoked_function_arn="arn:aws:lambda:us-east-1:123456789012:function:test_function",
+        memory_limit_in_mb=128,
+        aws_request_id="test-request-id",
+        log_group_name="/aws/lambda/test_function",
+        log_stream_name="2024/03/27/[$LATEST]test123",
+    )
+
+
+@pytest.fixture(scope="function")
+def dynamodb():
+    """Create a mock DynamoDB service."""
+    with mock_aws():
+        yield boto3.resource("dynamodb", region_name="us-east-1")
+
+
+@pytest.fixture(scope="function")
+def model_table(dynamodb):
+    """Create a mock DynamoDB table for models."""
+    table = dynamodb.create_table(
+        TableName="model-table",
+        KeySchema=[{"AttributeName": "model_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "model_id", "AttributeType": "S"}],
+        ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+    )
+    return table
+
+
+@pytest.fixture
+def sample_model(model_table):
+    """Sample model in DynamoDB for testing."""
+    item = {
+        "model_id": "test-model",
+        "model_status": ModelStatus.IN_SERVICE,
+        "cloudformation_stack_arn": "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/test-id",
+        "litellm_id": "test-litellm-id",
+        "model_config": {
+            "modelId": "test-model",
+            "modelName": "test-model-name",
+            "modelType": "textgen",
+            "streaming": True,
+        },
+    }
+    model_table.put_item(Item=item)
+    return item
+
+
+@pytest.fixture
+def sample_event():
+    """Sample event for delete state machine functions."""
+    return {"modelId": "test-model"}
+
+
+def test_handle_set_model_to_deleting_success(model_table, sample_model, sample_event, lambda_context):
+    """Test setting model to deleting status successfully."""
+    with patch("models.state_machine.delete_model.ddb_table", model_table):
+        result = handle_set_model_to_deleting(sample_event, lambda_context)
+
+        assert result["cloudformation_stack_arn"] == sample_model["cloudformation_stack_arn"]
+        assert result["litellm_id"] == sample_model["litellm_id"]
+        assert result["modelId"] == "test-model"
+
+        # Verify DDB update
+        item = model_table.get_item(Key={"model_id": "test-model"})["Item"]
+        assert item["model_status"] == ModelStatus.DELETING
+
+
+def test_handle_set_model_to_deleting_model_not_found(model_table, sample_event, lambda_context):
+    """Test setting model to deleting status when model doesn't exist."""
+    with patch("models.state_machine.delete_model.ddb_table", model_table):
+        with pytest.raises(RuntimeError, match="Requested model 'test-model' was not found"):
+            handle_set_model_to_deleting(sample_event, lambda_context)
+
+
+def test_handle_set_model_to_deleting_model_without_stack(model_table, sample_event, lambda_context):
+    """Test setting model to deleting status for model without CloudFormation stack."""
+    # Create model without stack info
+    item = {
+        "model_id": "test-model",
+        "model_status": ModelStatus.IN_SERVICE,
+        "litellm_id": "test-litellm-id",
+        "model_config": {"modelId": "test-model", "modelName": "test-model-name"},
+    }
+    model_table.put_item(Item=item)
+
+    with patch("models.state_machine.delete_model.ddb_table", model_table):
+        result = handle_set_model_to_deleting(sample_event, lambda_context)
+
+        assert result["cloudformation_stack_arn"] is None
+        assert result["litellm_id"] == "test-litellm-id"
+        assert result["modelId"] == "test-model"
+
+
+def test_handle_delete_from_litellm_with_id(sample_event, lambda_context):
+    """Test deleting model from LiteLLM when litellm_id exists."""
+    event = deepcopy(sample_event)
+    event["litellm_id"] = "test-litellm-id"
+
+    result = handle_delete_from_litellm(event, lambda_context)
+
+    assert result == event
+    mock_litellm_client.delete_model.assert_called_once_with(identifier="test-litellm-id")
+
+
+def test_handle_delete_from_litellm_without_id(sample_event, lambda_context):
+    """Test deleting model from LiteLLM when litellm_id is None."""
+    # Reset mock call count for this test
+    mock_litellm_client.reset_mock()
+
+    event = deepcopy(sample_event)
+    event["litellm_id"] = None
+
+    result = handle_delete_from_litellm(event, lambda_context)
+
+    assert result == event
+    # LiteLLM client should not be called when ID is None
+    mock_litellm_client.delete_model.assert_not_called()
+
+
+def test_handle_delete_from_litellm_empty_id(sample_event, lambda_context):
+    """Test deleting model from LiteLLM when litellm_id is empty string."""
+    # Reset mock call count for this test
+    mock_litellm_client.reset_mock()
+
+    event = deepcopy(sample_event)
+    event["litellm_id"] = ""
+
+    result = handle_delete_from_litellm(event, lambda_context)
+
+    assert result == event
+    # LiteLLM client should not be called when ID is empty
+    mock_litellm_client.delete_model.assert_not_called()
+
+
+def test_handle_delete_stack(sample_event, lambda_context):
+    """Test initiating CloudFormation stack deletion."""
+    event = deepcopy(sample_event)
+    event["cloudformation_stack_arn"] = "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/test-id"
+
+    result = handle_delete_stack(event, lambda_context)
+
+    assert result == event
+    mock_cfn.delete_stack.assert_called_once()
+    call_args = mock_cfn.delete_stack.call_args
+    assert call_args[1]["StackName"] == event["cloudformation_stack_arn"]
+    assert "ClientRequestToken" in call_args[1]
+
+
+def test_handle_monitor_delete_stack_complete(sample_event, lambda_context):
+    """Test monitoring stack deletion when complete."""
+    event = deepcopy(sample_event)
+    event["cloudformation_stack_arn"] = "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/test-id"
+
+    # Mock stack deletion complete
+    mock_cfn.describe_stacks.return_value = {"Stacks": [{"StackStatus": "DELETE_COMPLETE"}]}
+
+    result = handle_monitor_delete_stack(event, lambda_context)
+
+    assert result["continue_polling"] is False
+    assert result["modelId"] == "test-model"
+
+
+def test_handle_monitor_delete_stack_in_progress(sample_event, lambda_context):
+    """Test monitoring stack deletion when in progress."""
+    event = deepcopy(sample_event)
+    event["cloudformation_stack_arn"] = "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/test-id"
+
+    # Mock stack deletion in progress
+    mock_cfn.describe_stacks.return_value = {"Stacks": [{"StackStatus": "DELETE_IN_PROGRESS"}]}
+
+    result = handle_monitor_delete_stack(event, lambda_context)
+
+    assert result["continue_polling"] is True
+    assert result["modelId"] == "test-model"
+
+
+def test_handle_monitor_delete_stack_unexpected_state(sample_event, lambda_context):
+    """Test monitoring stack deletion with unexpected terminal state."""
+    event = deepcopy(sample_event)
+    event["cloudformation_stack_arn"] = "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/test-id"
+
+    # Mock unexpected terminal state
+    mock_cfn.describe_stacks.return_value = {"Stacks": [{"StackStatus": "CREATE_COMPLETE"}]}
+
+    with pytest.raises(RuntimeError, match="Stack entered unexpected terminal state 'CREATE_COMPLETE'"):
+        handle_monitor_delete_stack(event, lambda_context)
+
+
+def test_handle_monitor_delete_stack_failed_state(sample_event, lambda_context):
+    """Test monitoring stack deletion with failed terminal state."""
+    event = deepcopy(sample_event)
+    event["cloudformation_stack_arn"] = "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/test-id"
+
+    # Mock failed state
+    mock_cfn.describe_stacks.return_value = {"Stacks": [{"StackStatus": "DELETE_FAILED"}]}
+
+    with pytest.raises(RuntimeError, match="Stack entered unexpected terminal state 'DELETE_FAILED'"):
+        handle_monitor_delete_stack(event, lambda_context)
+
+
+def test_handle_delete_from_ddb(model_table, sample_model, sample_event, lambda_context):
+    """Test deleting model from DynamoDB."""
+    with patch("models.state_machine.delete_model.ddb_table", model_table):
+        result = handle_delete_from_ddb(sample_event, lambda_context)
+
+        assert result == sample_event
+
+        # Verify model is deleted from DDB
+        response = model_table.get_item(Key={"model_id": "test-model"})
+        assert "Item" not in response
+
+
+def test_handle_delete_from_ddb_nonexistent_model(model_table, sample_event, lambda_context):
+    """Test deleting nonexistent model from DynamoDB."""
+    # Don't create the model item
+    with patch("models.state_machine.delete_model.ddb_table", model_table):
+        # Should not raise exception even if model doesn't exist
+        result = handle_delete_from_ddb(sample_event, lambda_context)
+
+        assert result == sample_event
+
+
+def test_handle_set_model_to_deleting_model_without_litellm_id(model_table, sample_event, lambda_context):
+    """Test setting model to deleting status for model without LiteLLM ID."""
+    # Create model without litellm_id
+    item = {
+        "model_id": "test-model",
+        "model_status": ModelStatus.IN_SERVICE,
+        "cloudformation_stack_arn": "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/test-id",
+        "model_config": {"modelId": "test-model", "modelName": "test-model-name"},
+    }
+    model_table.put_item(Item=item)
+
+    with patch("models.state_machine.delete_model.ddb_table", model_table):
+        result = handle_set_model_to_deleting(sample_event, lambda_context)
+
+        assert result["cloudformation_stack_arn"] == item["cloudformation_stack_arn"]
+        assert result["litellm_id"] is None
+        assert result["modelId"] == "test-model"
+
+
+def test_end_to_end_delete_workflow(model_table, sample_model, sample_event, lambda_context):
+    """Test complete delete workflow end-to-end."""
+    with patch("models.state_machine.delete_model.ddb_table", model_table):
+        # Step 1: Set model to deleting
+        event1 = handle_set_model_to_deleting(sample_event, lambda_context)
+        assert event1["litellm_id"] == "test-litellm-id"
+        assert event1["cloudformation_stack_arn"] is not None
+
+        # Step 2: Delete from LiteLLM
+        event2 = handle_delete_from_litellm(event1, lambda_context)
+        assert event2 == event1
+
+        # Step 3: Delete stack
+        event3 = handle_delete_stack(event2, lambda_context)
+        assert event3 == event2
+
+        # Step 4: Monitor stack deletion (complete)
+        mock_cfn.describe_stacks.return_value = {"Stacks": [{"StackStatus": "DELETE_COMPLETE"}]}
+        event4 = handle_monitor_delete_stack(event3, lambda_context)
+        assert event4["continue_polling"] is False
+
+        # Step 5: Delete from DDB
+        event5 = handle_delete_from_ddb(event4, lambda_context)
+        assert event5 == event4
+
+        # Verify model is deleted
+        response = model_table.get_item(Key={"model_id": "test-model"})
+        assert "Item" not in response
+
+
+def test_handle_monitor_delete_stack_rollback_state(sample_event, lambda_context):
+    """Test monitoring stack deletion with rollback state."""
+    event = deepcopy(sample_event)
+    event["cloudformation_stack_arn"] = "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/test-id"
+
+    # Mock rollback state
+    mock_cfn.describe_stacks.return_value = {"Stacks": [{"StackStatus": "ROLLBACK_COMPLETE"}]}
+
+    with pytest.raises(RuntimeError, match="Stack entered unexpected terminal state 'ROLLBACK_COMPLETE'"):
+        handle_monitor_delete_stack(event, lambda_context)
+
+
+def test_handle_monitor_delete_stack_update_state(sample_event, lambda_context):
+    """Test monitoring stack deletion with update state."""
+    event = deepcopy(sample_event)
+    event["cloudformation_stack_arn"] = "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/test-id"
+
+    # Mock update state (should continue polling)
+    mock_cfn.describe_stacks.return_value = {"Stacks": [{"StackStatus": "UPDATE_ROLLBACK_IN_PROGRESS"}]}
+
+    result = handle_monitor_delete_stack(event, lambda_context)
+
+    assert result["continue_polling"] is True
+
+
+def test_handle_delete_from_litellm_litellm_error(sample_event, lambda_context):
+    """Test handling LiteLLM deletion error."""
+    event = deepcopy(sample_event)
+    event["litellm_id"] = "test-litellm-id"
+
+    # Mock LiteLLM client to raise exception
+    mock_litellm_client.delete_model.side_effect = Exception("LiteLLM error")
+
+    # The function should still complete and propagate the exception
+    with pytest.raises(Exception, match="LiteLLM error"):
+        handle_delete_from_litellm(event, lambda_context)
+
+
+def test_handle_delete_stack_cloudformation_error(sample_event, lambda_context):
+    """Test handling CloudFormation deletion error."""
+    event = deepcopy(sample_event)
+    event["cloudformation_stack_arn"] = "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/test-id"
+
+    # Mock CloudFormation client to raise exception
+    mock_cfn.delete_stack.side_effect = Exception("CloudFormation error")
+
+    # The function should propagate the exception
+    with pytest.raises(Exception, match="CloudFormation error"):
+        handle_delete_stack(event, lambda_context)
+
+
+def test_handle_monitor_delete_stack_cloudformation_error(sample_event, lambda_context):
+    """Test handling CloudFormation monitoring error."""
+    event = deepcopy(sample_event)
+    event["cloudformation_stack_arn"] = "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/test-id"
+
+    # Mock CloudFormation client to raise exception
+    mock_cfn.describe_stacks.side_effect = Exception("CloudFormation describe error")
+
+    # The function should propagate the exception
+    with pytest.raises(Exception, match="CloudFormation describe error"):
+        handle_monitor_delete_stack(event, lambda_context)

--- a/test/lambda/test_metrics_lambda.py
+++ b/test/lambda/test_metrics_lambda.py
@@ -154,13 +154,15 @@ patch.dict(
     "sys.modules",
     {
         "create_env_variables": mock_create_env,
-        "utilities.common_functions": mock_common,
     },
 ).start()
 
-# Patch the specific functions
+# Patch the specific functions in utilities.common_functions
 patch("utilities.common_functions.retry_config", retry_config).start()
 patch("utilities.common_functions.api_wrapper", mock_api_wrapper).start()
+
+# Also patch the api_wrapper in the metrics module specifically
+patch("metrics.lambda_functions.api_wrapper", mock_api_wrapper).start()
 
 # Module to test can be imported now that dependencies are mocked
 from metrics.lambda_functions import (

--- a/test/lambda/test_update_model_state_machine.py
+++ b/test/lambda/test_update_model_state_machine.py
@@ -1,0 +1,676 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Unit tests for update_model state machine functions."""
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from botocore.config import Config
+from moto import mock_aws
+
+# Add the lambda directory to the Python path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../"))
+
+# Set up mock AWS credentials
+os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+os.environ["AWS_SECURITY_TOKEN"] = "testing"
+os.environ["AWS_SESSION_TOKEN"] = "testing"
+os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+os.environ["AWS_REGION"] = "us-east-1"
+os.environ["MODEL_TABLE_NAME"] = "model-table"
+os.environ["MANAGEMENT_KEY_NAME"] = "test-management-key"
+os.environ["LITELLM_CONFIG_OBJ"] = '{"litellm_settings": {"drop_params": true}}'
+
+# Create a real retry config
+retry_config = Config(retries=dict(max_attempts=3), defaults_mode="standard")
+
+# Create mock modules
+mock_common = MagicMock()
+mock_common.get_cert_path.return_value = None
+mock_common.get_rest_api_container_endpoint.return_value = "https://test-api.example.com"
+mock_common.retry_config = retry_config
+
+# Create mock LiteLLMClient
+mock_litellm_client = MagicMock()
+mock_litellm_client.add_model.return_value = {"model_info": {"id": "test-litellm-id"}}
+mock_litellm_client.delete_model.return_value = {"status": "deleted"}
+
+# First, patch sys.modules
+patch.dict(
+    "sys.modules",
+    {
+        "create_env_variables": MagicMock(),
+    },
+).start()
+
+# Then patch the specific functions
+patch("utilities.common_functions.get_cert_path", mock_common.get_cert_path).start()
+patch("utilities.common_functions.get_rest_api_container_endpoint", mock_common.get_rest_api_container_endpoint).start()
+patch("utilities.common_functions.retry_config", retry_config).start()
+patch("models.clients.litellm_client.LiteLLMClient", return_value=mock_litellm_client).start()
+
+# Mock boto3 clients
+mock_autoscaling = MagicMock()
+mock_iam = MagicMock()
+mock_secrets = MagicMock()
+
+mock_autoscaling.update_auto_scaling_group.return_value = {}
+mock_autoscaling.describe_auto_scaling_groups.return_value = {
+    "AutoScalingGroups": [
+        {"DesiredCapacity": 2, "Instances": [{"HealthStatus": "Healthy"}, {"HealthStatus": "Healthy"}]}
+    ]
+}
+mock_secrets.get_secret_value.return_value = {"SecretString": "test-secret"}
+
+
+# Create comprehensive mock for boto3.client to handle all possible service requests
+def mock_boto3_client(service, **kwargs):
+    if service == "autoscaling":
+        return mock_autoscaling
+    elif service == "iam":
+        return mock_iam
+    elif service == "secretsmanager":
+        return mock_secrets
+    elif service == "ssm":
+        # Return a basic mock for SSM
+        mock_ssm = MagicMock()
+        mock_ssm.get_parameter.return_value = {"Parameter": {"Value": "mock-value"}}
+        return mock_ssm
+    elif service == "s3":
+        # Return a basic mock for S3
+        mock_s3 = MagicMock()
+        return mock_s3
+    else:
+        # Return a generic mock for any other services
+        return MagicMock()
+
+
+patch("boto3.client", side_effect=mock_boto3_client).start()
+
+from models.domain_objects import ModelStatus
+
+# Now import the state machine functions
+from models.state_machine.update_model import handle_finish_update, handle_job_intake, handle_poll_capacity
+
+
+@pytest.fixture
+def lambda_context():
+    """Create a mock Lambda context."""
+    return SimpleNamespace(
+        function_name="test_function",
+        function_version="$LATEST",
+        invoked_function_arn="arn:aws:lambda:us-east-1:123456789012:function:test_function",
+        memory_limit_in_mb=128,
+        aws_request_id="test-request-id",
+        log_group_name="/aws/lambda/test_function",
+        log_stream_name="2024/03/27/[$LATEST]test123",
+    )
+
+
+@pytest.fixture(scope="function")
+def dynamodb():
+    """Create a mock DynamoDB service."""
+    with mock_aws():
+        yield boto3.resource("dynamodb", region_name="us-east-1")
+
+
+@pytest.fixture(scope="function")
+def model_table(dynamodb):
+    """Create a mock DynamoDB table for models."""
+    table = dynamodb.create_table(
+        TableName="model-table",
+        KeySchema=[{"AttributeName": "model_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "model_id", "AttributeType": "S"}],
+        ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+    )
+    return table
+
+
+@pytest.fixture
+def sample_model(model_table):
+    """Sample model in DynamoDB for testing."""
+    item = {
+        "model_id": "test-model",
+        "model_status": ModelStatus.IN_SERVICE,
+        "auto_scaling_group": "test-asg",
+        "litellm_id": "test-litellm-id",
+        "model_url": "https://test-model.example.com/v1",
+        "model_config": {
+            "modelId": "test-model",
+            "modelName": "test-model-name",
+            "modelType": "textgen",
+            "streaming": True,
+            "autoScalingConfig": {"minCapacity": 1, "maxCapacity": 3, "metricConfig": {"estimatedInstanceWarmup": 300}},
+        },
+    }
+    model_table.put_item(Item=item)
+    return item
+
+
+@pytest.fixture
+def stopped_model(model_table):
+    """Sample stopped model in DynamoDB for testing."""
+    item = {
+        "model_id": "stopped-model",
+        "model_status": ModelStatus.STOPPED,
+        "auto_scaling_group": "test-asg",
+        "model_url": "https://test-model.example.com/v1",
+        "model_config": {
+            "modelId": "stopped-model",
+            "modelName": "stopped-model-name",
+            "modelType": "textgen",
+            "streaming": True,
+            "autoScalingConfig": {"minCapacity": 1, "maxCapacity": 3, "metricConfig": {"estimatedInstanceWarmup": 300}},
+        },
+    }
+    model_table.put_item(Item=item)
+    return item
+
+
+@pytest.fixture
+def litellm_only_model(model_table):
+    """Sample LiteLLM-only model in DynamoDB for testing."""
+    item = {
+        "model_id": "litellm-model",
+        "model_status": ModelStatus.IN_SERVICE,
+        "litellm_id": "test-litellm-id",
+        "model_config": {
+            "modelId": "litellm-model",
+            "modelName": "litellm-model-name",
+            "modelType": "textgen",
+            "streaming": True,
+        },
+    }
+    model_table.put_item(Item=item)
+    return item
+
+
+def test_handle_job_intake_enable_model(model_table, stopped_model, lambda_context):
+    """Test enabling a stopped model."""
+    event = {"model_id": "stopped-model", "update_payload": {"enabled": True}}
+
+    with patch("models.state_machine.update_model.model_table", model_table):
+        result = handle_job_intake(event, lambda_context)
+
+        assert result["has_capacity_update"] is True
+        assert result["is_disable"] is False
+        assert result["asg_name"] == "test-asg"
+        assert result["model_warmup_seconds"] == 300
+        assert result["current_model_status"] == ModelStatus.STARTING
+
+        # Verify DDB update
+        item = model_table.get_item(Key={"model_id": "stopped-model"})["Item"]
+        assert item["model_status"] == ModelStatus.STARTING
+
+        # Verify ASG update call
+        mock_autoscaling.update_auto_scaling_group.assert_called_once()
+        call_args = mock_autoscaling.update_auto_scaling_group.call_args
+        assert call_args[1]["AutoScalingGroupName"] == "test-asg"
+        assert call_args[1]["MinSize"] == 1
+        assert call_args[1]["MaxSize"] == 3
+
+
+def test_handle_job_intake_disable_model(model_table, sample_model, lambda_context):
+    """Test disabling a running model."""
+    # Reset mocks for this test
+    mock_autoscaling.reset_mock()
+    mock_litellm_client.reset_mock()
+
+    event = {"model_id": "test-model", "update_payload": {"enabled": False}}
+
+    with patch("models.state_machine.update_model.model_table", model_table):
+        result = handle_job_intake(event, lambda_context)
+
+        assert result["has_capacity_update"] is False
+        assert result["is_disable"] is True
+        assert result["asg_name"] == "test-asg"
+        assert result["current_model_status"] == ModelStatus.STOPPING
+
+        # Verify DDB update
+        item = model_table.get_item(Key={"model_id": "test-model"})["Item"]
+        assert item["model_status"] == ModelStatus.STOPPING
+        assert item["litellm_id"] is None
+
+        # Verify LiteLLM deletion call
+        mock_litellm_client.delete_model.assert_called_once_with(identifier="test-litellm-id")
+
+        # Verify ASG update call
+        mock_autoscaling.update_auto_scaling_group.assert_called_once()
+        call_args = mock_autoscaling.update_auto_scaling_group.call_args
+        assert call_args[1]["AutoScalingGroupName"] == "test-asg"
+        assert call_args[1]["MinSize"] == 0
+        assert call_args[1]["MaxSize"] == 0
+        assert call_args[1]["DesiredCapacity"] == 0
+
+
+def test_handle_job_intake_autoscaling_update_running_model(model_table, sample_model, lambda_context):
+    """Test updating autoscaling configuration for a running model."""
+    # Reset mocks for this test
+    mock_autoscaling.reset_mock()
+
+    event = {
+        "model_id": "test-model",
+        "update_payload": {"autoScalingInstanceConfig": {"minCapacity": 2, "maxCapacity": 5, "desiredCapacity": 3}},
+    }
+
+    with patch("models.state_machine.update_model.model_table", model_table):
+        result = handle_job_intake(event, lambda_context)
+
+        assert result["has_capacity_update"] is False
+        assert result["is_disable"] is False
+        assert result["current_model_status"] == ModelStatus.UPDATING
+
+        # Verify model config update
+        item = model_table.get_item(Key={"model_id": "test-model"})["Item"]
+        assert item["model_config"]["autoScalingConfig"]["minCapacity"] == 2
+        assert item["model_config"]["autoScalingConfig"]["maxCapacity"] == 5
+
+        # Verify ASG update call
+        mock_autoscaling.update_auto_scaling_group.assert_called_once()
+        call_args = mock_autoscaling.update_auto_scaling_group.call_args
+        assert call_args[1]["MinSize"] == 2
+        assert call_args[1]["MaxSize"] == 5
+        assert call_args[1]["DesiredCapacity"] == 3
+
+
+def test_handle_job_intake_autoscaling_update_stopped_model(model_table, stopped_model, lambda_context):
+    """Test updating autoscaling configuration for a stopped model."""
+    # Reset mocks for this test
+    mock_autoscaling.reset_mock()
+
+    event = {
+        "model_id": "stopped-model",
+        "update_payload": {"autoScalingInstanceConfig": {"minCapacity": 2, "maxCapacity": 5}},
+    }
+
+    with patch("models.state_machine.update_model.model_table", model_table):
+        result = handle_job_intake(event, lambda_context)
+
+        assert result["has_capacity_update"] is False
+        assert result["is_disable"] is False
+        assert result["current_model_status"] == ModelStatus.UPDATING
+
+        # Verify model config update
+        item = model_table.get_item(Key={"model_id": "stopped-model"})["Item"]
+        assert item["model_config"]["autoScalingConfig"]["minCapacity"] == 2
+        assert item["model_config"]["autoScalingConfig"]["maxCapacity"] == 5
+
+        # ASG should not be updated for stopped model
+        mock_autoscaling.update_auto_scaling_group.assert_not_called()
+
+
+def test_handle_job_intake_metadata_update(model_table, sample_model, lambda_context):
+    """Test updating model metadata only."""
+    event = {"model_id": "test-model", "update_payload": {"streaming": False, "modelType": "embedding"}}
+
+    with patch("models.state_machine.update_model.model_table", model_table):
+        result = handle_job_intake(event, lambda_context)
+
+        assert result["has_capacity_update"] is False
+        assert result["is_disable"] is False
+        assert result["current_model_status"] == ModelStatus.UPDATING
+        assert result["initial_model_status"] == ModelStatus.IN_SERVICE
+
+        # Verify model config update
+        item = model_table.get_item(Key={"model_id": "test-model"})["Item"]
+        assert item["model_config"]["streaming"] is False
+        assert item["model_config"]["modelType"] == "embedding"
+
+
+def test_handle_job_intake_model_not_found(model_table, lambda_context):
+    """Test handling when model is not found."""
+    event = {"model_id": "nonexistent-model", "update_payload": {"enabled": True}}
+
+    with patch("models.state_machine.update_model.model_table", model_table):
+        with pytest.raises(RuntimeError, match="Requested model 'nonexistent-model' was not found"):
+            handle_job_intake(event, lambda_context)
+
+
+def test_handle_job_intake_litellm_only_model_activation_error(model_table, litellm_only_model, lambda_context):
+    """Test error when trying to activate/deactivate LiteLLM-only model."""
+    event = {"model_id": "litellm-model", "update_payload": {"enabled": False}}
+
+    with patch("models.state_machine.update_model.model_table", model_table):
+        with pytest.raises(
+            RuntimeError, match="Cannot request AutoScaling updates to models that are not hosted by LISA"
+        ):
+            handle_job_intake(event, lambda_context)
+
+
+def test_handle_job_intake_concurrent_activation_and_autoscaling_error(model_table, sample_model, lambda_context):
+    """Test error when trying to do activation and autoscaling updates simultaneously."""
+    event = {
+        "model_id": "test-model",
+        "update_payload": {"enabled": False, "autoScalingInstanceConfig": {"minCapacity": 2}},
+    }
+
+    with patch("models.state_machine.update_model.model_table", model_table):
+        with pytest.raises(
+            RuntimeError, match="Cannot request AutoScaling updates at the same time as an enable or disable operation"
+        ):
+            handle_job_intake(event, lambda_context)
+
+
+def test_handle_poll_capacity_healthy_instances(lambda_context):
+    """Test polling capacity when instances are healthy."""
+    event = {"model_id": "test-model", "asg_name": "test-asg", "remaining_capacity_polls": 20}
+
+    result = handle_poll_capacity(event, lambda_context)
+
+    assert result["should_continue_capacity_polling"] is False
+    assert result["remaining_capacity_polls"] == 19
+    assert "polling_error" not in result
+
+
+def test_handle_poll_capacity_unhealthy_instances(lambda_context):
+    """Test polling capacity when instances are not yet healthy."""
+    event = {"model_id": "test-model", "asg_name": "test-asg", "remaining_capacity_polls": 20}
+
+    # Mock unhealthy instances
+    mock_autoscaling.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [
+            {"DesiredCapacity": 2, "Instances": [{"HealthStatus": "Healthy"}, {"HealthStatus": "Unhealthy"}]}
+        ]
+    }
+
+    result = handle_poll_capacity(event, lambda_context)
+
+    assert result["should_continue_capacity_polling"] is True
+    assert result["remaining_capacity_polls"] == 19
+    assert "polling_error" not in result
+
+
+def test_handle_poll_capacity_max_polls_exceeded(lambda_context):
+    """Test polling capacity when max polls exceeded."""
+    event = {"model_id": "test-model", "asg_name": "test-asg", "remaining_capacity_polls": 1}
+
+    # Mock unhealthy instances
+    mock_autoscaling.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [
+            {"DesiredCapacity": 2, "Instances": [{"HealthStatus": "Healthy"}, {"HealthStatus": "Unhealthy"}]}
+        ]
+    }
+
+    result = handle_poll_capacity(event, lambda_context)
+
+    assert result["should_continue_capacity_polling"] is False
+    assert result["remaining_capacity_polls"] == 0
+    assert "polling_error" in result
+    assert "did not start healthy instances" in result["polling_error"]
+
+
+def test_handle_finish_update_enable_success(model_table, lambda_context):
+    """Test finishing update for successful model enable."""
+    # Create model without litellm_id (enabled model should get one)
+    item = {
+        "model_id": "test-model",
+        "model_status": ModelStatus.STARTING,
+        "auto_scaling_group": "test-asg",
+        "model_url": "https://test-model.example.com/v1",
+        "model_config": {"modelName": "test-model-name"},
+    }
+    model_table.put_item(Item=item)
+
+    event = {
+        "model_id": "test-model",
+        "asg_name": "test-asg",
+        "has_capacity_update": True,
+        "is_disable": False,
+        "initial_model_status": ModelStatus.STOPPED,
+    }
+
+    with patch("models.state_machine.update_model.model_table", model_table):
+        result = handle_finish_update(event, lambda_context)
+
+        assert result["litellm_id"] == "test-litellm-id"
+        assert result["current_model_status"] == ModelStatus.IN_SERVICE
+
+        # Verify DDB update
+        item = model_table.get_item(Key={"model_id": "test-model"})["Item"]
+        assert item["model_status"] == ModelStatus.IN_SERVICE
+        assert item["litellm_id"] == "test-litellm-id"
+
+        # Verify LiteLLM add call
+        mock_litellm_client.add_model.assert_called_once()
+        call_args = mock_litellm_client.add_model.call_args
+        assert call_args[1]["model_name"] == "test-model"
+
+
+def test_handle_finish_update_disable_success(model_table, lambda_context):
+    """Test finishing update for successful model disable."""
+    item = {
+        "model_id": "test-model",
+        "model_status": ModelStatus.STOPPING,
+        "auto_scaling_group": "test-asg",
+        "model_url": "https://test-model.example.com/v1",
+        "model_config": {"modelName": "test-model-name"},
+    }
+    model_table.put_item(Item=item)
+
+    event = {
+        "model_id": "test-model",
+        "asg_name": "test-asg",
+        "has_capacity_update": False,
+        "is_disable": True,
+        "initial_model_status": ModelStatus.IN_SERVICE,
+    }
+
+    with patch("models.state_machine.update_model.model_table", model_table):
+        result = handle_finish_update(event, lambda_context)
+
+        assert result["current_model_status"] == ModelStatus.STOPPED
+
+        # Verify DDB update
+        item = model_table.get_item(Key={"model_id": "test-model"})["Item"]
+        assert item["model_status"] == ModelStatus.STOPPED
+
+
+def test_handle_finish_update_metadata_only(model_table, lambda_context):
+    """Test finishing update for metadata-only update."""
+    item = {
+        "model_id": "test-model",
+        "model_status": ModelStatus.UPDATING,
+        "auto_scaling_group": "test-asg",
+        "model_url": "https://test-model.example.com/v1",
+        "model_config": {"modelName": "test-model-name"},
+    }
+    model_table.put_item(Item=item)
+
+    event = {
+        "model_id": "test-model",
+        "asg_name": "test-asg",
+        "has_capacity_update": False,
+        "is_disable": False,
+        "initial_model_status": ModelStatus.IN_SERVICE,
+    }
+
+    with patch("models.state_machine.update_model.model_table", model_table):
+        result = handle_finish_update(event, lambda_context)
+
+        assert result["current_model_status"] == ModelStatus.IN_SERVICE
+
+        # Verify DDB update - should restore initial status
+        item = model_table.get_item(Key={"model_id": "test-model"})["Item"]
+        assert item["model_status"] == ModelStatus.IN_SERVICE
+
+
+def test_handle_finish_update_polling_error(model_table, lambda_context):
+    """Test finishing update when there was a polling error."""
+    # Reset mocks for this test
+    mock_autoscaling.reset_mock()
+
+    item = {
+        "model_id": "test-model",
+        "model_status": ModelStatus.STARTING,
+        "auto_scaling_group": "test-asg",
+        "model_url": "https://test-model.example.com/v1",
+        "model_config": {"modelName": "test-model-name"},
+    }
+    model_table.put_item(Item=item)
+
+    event = {
+        "model_id": "test-model",
+        "asg_name": "test-asg",
+        "has_capacity_update": True,
+        "is_disable": False,
+        "polling_error": "Model did not start in time",
+        "initial_model_status": ModelStatus.STOPPED,
+    }
+
+    with patch("models.state_machine.update_model.model_table", model_table):
+        result = handle_finish_update(event, lambda_context)
+
+        assert result["current_model_status"] == ModelStatus.STOPPED
+
+        # Verify DDB update
+        item = model_table.get_item(Key={"model_id": "test-model"})["Item"]
+        assert item["model_status"] == ModelStatus.STOPPED
+
+        # Verify ASG is scaled down due to error
+        mock_autoscaling.update_auto_scaling_group.assert_called_once()
+        call_args = mock_autoscaling.update_auto_scaling_group.call_args
+        assert call_args[1]["MinSize"] == 0
+        assert call_args[1]["MaxSize"] == 0
+        assert call_args[1]["DesiredCapacity"] == 0
+
+
+def test_handle_finish_update_json_decode_error(model_table, lambda_context):
+    """Test finishing update with invalid LiteLLM config JSON."""
+    item = {
+        "model_id": "test-model",
+        "model_status": ModelStatus.STARTING,
+        "auto_scaling_group": "test-asg",
+        "model_url": "https://test-model.example.com/v1",
+        "model_config": {"modelName": "test-model-name"},
+    }
+    model_table.put_item(Item=item)
+
+    event = {
+        "model_id": "test-model",
+        "asg_name": "test-asg",
+        "has_capacity_update": True,
+        "is_disable": False,
+        "initial_model_status": ModelStatus.STOPPED,
+    }
+
+    with patch("os.environ.get") as mock_env:
+        mock_env.return_value = "invalid-json"
+
+        with patch("models.state_machine.update_model.model_table", model_table):
+            result = handle_finish_update(event, lambda_context)
+
+            assert result["litellm_id"] == "test-litellm-id"
+
+            # Should fallback to empty dict when JSON parsing fails
+            call_args = mock_litellm_client.add_model.call_args
+            assert call_args[1]["litellm_params"]["api_key"] == "ignored"
+
+
+def test_end_to_end_enable_workflow(model_table, stopped_model, lambda_context):
+    """Test complete enable workflow end-to-end."""
+    # Reset mocks for this test
+    mock_autoscaling.reset_mock()
+    mock_litellm_client.reset_mock()
+
+    # Ensure the autoscaling mock returns the expected values for this test
+    mock_autoscaling.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [
+            {"DesiredCapacity": 2, "Instances": [{"HealthStatus": "Healthy"}, {"HealthStatus": "Healthy"}]}
+        ]
+    }
+
+    with patch("models.state_machine.update_model.model_table", model_table):
+        # Step 1: Job intake for enable
+        event1 = {"model_id": "stopped-model", "update_payload": {"enabled": True}}
+        result1 = handle_job_intake(event1, lambda_context)
+        assert result1["has_capacity_update"] is True
+        assert result1["current_model_status"] == ModelStatus.STARTING
+
+        # Step 2: Poll capacity (healthy)
+        event2 = {"model_id": "stopped-model", "asg_name": "test-asg", "remaining_capacity_polls": 20}
+        result2 = handle_poll_capacity(event2, lambda_context)
+        assert result2["should_continue_capacity_polling"] is False
+
+        # Step 3: Finish update
+        event3 = {
+            "model_id": "stopped-model",
+            "asg_name": "test-asg",
+            "has_capacity_update": True,
+            "is_disable": False,
+            "initial_model_status": ModelStatus.STOPPED,
+        }
+        result3 = handle_finish_update(event3, lambda_context)
+        assert result3["current_model_status"] == ModelStatus.IN_SERVICE
+
+        # Verify final state
+        item = model_table.get_item(Key={"model_id": "stopped-model"})["Item"]
+        assert item["model_status"] == ModelStatus.IN_SERVICE
+
+
+def test_end_to_end_disable_workflow(model_table, sample_model, lambda_context):
+    """Test complete disable workflow end-to-end."""
+    with patch("models.state_machine.update_model.model_table", model_table):
+        # Step 1: Job intake for disable
+        event1 = {"model_id": "test-model", "update_payload": {"enabled": False}}
+        result1 = handle_job_intake(event1, lambda_context)
+        assert result1["is_disable"] is True
+        assert result1["current_model_status"] == ModelStatus.STOPPING
+
+        # Step 2: Finish update (no polling needed for disable)
+        event2 = {
+            "model_id": "test-model",
+            "asg_name": "test-asg",
+            "has_capacity_update": False,
+            "is_disable": True,
+            "initial_model_status": ModelStatus.IN_SERVICE,
+        }
+        result2 = handle_finish_update(event2, lambda_context)
+        assert result2["current_model_status"] == ModelStatus.STOPPED
+
+        # Verify final state
+        item = model_table.get_item(Key={"model_id": "test-model"})["Item"]
+        assert item["model_status"] == ModelStatus.STOPPED
+
+
+def test_handle_job_intake_partial_autoscaling_config(model_table, sample_model, lambda_context):
+    """Test updating only some autoscaling parameters."""
+    # Reset mocks for this test
+    mock_autoscaling.reset_mock()
+
+    event = {
+        "model_id": "test-model",
+        "update_payload": {"autoScalingInstanceConfig": {"maxCapacity": 5}},  # Only update max capacity
+    }
+
+    with patch("models.state_machine.update_model.model_table", model_table):
+        handle_job_intake(event, lambda_context)
+
+        # Verify model config update
+        item = model_table.get_item(Key={"model_id": "test-model"})["Item"]
+        assert item["model_config"]["autoScalingConfig"]["minCapacity"] == 1  # Unchanged
+        assert item["model_config"]["autoScalingConfig"]["maxCapacity"] == 5  # Updated
+
+        # Verify ASG update call only includes maxCapacity
+        mock_autoscaling.update_auto_scaling_group.assert_called_once()
+        call_args = mock_autoscaling.update_auto_scaling_group.call_args
+        assert "MaxSize" in call_args[1]
+        assert call_args[1]["MaxSize"] == 5
+        assert "MinSize" not in call_args[1]
+        assert "DesiredCapacity" not in call_args[1]

--- a/test/lambda/test_user_preferences_lambda.py
+++ b/test/lambda/test_user_preferences_lambda.py
@@ -1,0 +1,549 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Unit tests for user_preferences lambda functions."""
+
+import functools
+import json
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from botocore.config import Config
+from moto import mock_aws
+
+# Add the lambda directory to the Python path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../"))
+
+# Set up mock AWS credentials
+os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+os.environ["AWS_SECURITY_TOKEN"] = "testing"
+os.environ["AWS_SESSION_TOKEN"] = "testing"
+os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+os.environ["AWS_REGION"] = "us-east-1"
+os.environ["USER_PREFERENCES_TABLE_NAME"] = "user-preferences-table"
+
+# Create a real retry config
+retry_config = Config(retries=dict(max_attempts=3), defaults_mode="standard")
+
+
+def mock_api_wrapper(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            result = func(*args, **kwargs)
+            if isinstance(result, dict) and "statusCode" in result:
+                return result
+            return {
+                "statusCode": 200,
+                "headers": {"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
+                "body": json.dumps(result, default=str),
+            }
+        except ValueError as e:
+            error_msg = str(e)
+            # Determine status code based on error message
+            status_code = 400
+            if "not found" in error_msg.lower():
+                status_code = 404
+            elif "Not authorized" in error_msg:
+                status_code = 403
+
+            return {
+                "statusCode": status_code,
+                "headers": {"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
+                "body": json.dumps({"error": error_msg}),
+            }
+        except Exception as e:
+            return {
+                "statusCode": 500,
+                "headers": {"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
+                "body": json.dumps({"error": str(e)}),
+            }
+
+    return wrapper
+
+
+# Create mock modules
+mock_common = MagicMock()
+mock_common.get_username.return_value = "test-user"
+mock_common.retry_config = retry_config
+mock_common.api_wrapper = mock_api_wrapper
+mock_common.get_item.return_value = None
+
+# Create mock UserPreferencesModel
+mock_user_preferences_model = MagicMock()
+mock_model_instance = MagicMock()
+mock_model_instance.model_dump.return_value = {
+    "user": "test-user",
+    "preferences": {"theme": "dark", "notifications": True},
+}
+mock_user_preferences_model.return_value = mock_model_instance
+
+# First, patch sys.modules
+patch.dict(
+    "sys.modules",
+    {
+        "create_env_variables": MagicMock(),
+    },
+).start()
+
+# Then patch the specific functions
+patch("utilities.common_functions.get_username", mock_common.get_username).start()
+patch("utilities.common_functions.retry_config", retry_config).start()
+patch("utilities.common_functions.api_wrapper", mock_api_wrapper).start()
+patch("utilities.common_functions.get_item", mock_common.get_item).start()
+patch("user_preferences.models.UserPreferencesModel", mock_user_preferences_model).start()
+
+# Now import the lambda functions
+from user_preferences.lambda_functions import get, update
+
+
+@pytest.fixture
+def lambda_context():
+    """Create a mock Lambda context."""
+    return SimpleNamespace(
+        function_name="test_function",
+        function_version="$LATEST",
+        invoked_function_arn="arn:aws:lambda:us-east-1:123456789012:function:test_function",
+        memory_limit_in_mb=128,
+        aws_request_id="test-request-id",
+        log_group_name="/aws/lambda/test_function",
+        log_stream_name="2024/03/27/[$LATEST]test123",
+    )
+
+
+@pytest.fixture(scope="function")
+def dynamodb():
+    """Create a mock DynamoDB service."""
+    with mock_aws():
+        yield boto3.resource("dynamodb", region_name="us-east-1")
+
+
+@pytest.fixture(scope="function")
+def user_preferences_table(dynamodb):
+    """Create a mock DynamoDB table for user preferences."""
+    table = dynamodb.create_table(
+        TableName="user-preferences-table",
+        KeySchema=[{"AttributeName": "user", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "user", "AttributeType": "S"}],
+        ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+    )
+    return table
+
+
+@pytest.fixture
+def sample_user_preferences():
+    return {
+        "user": "test-user",
+        "preferences": {"theme": "dark", "notifications": True},
+        "created": "2024-01-01T00:00:00Z",
+        "modified": "2024-01-01T00:00:00Z",
+    }
+
+
+def test_get_user_preferences_success(user_preferences_table, sample_user_preferences, lambda_context):
+    """Test successfully getting user preferences."""
+    # Add sample preferences to table
+    user_preferences_table.put_item(Item=sample_user_preferences)
+
+    # Mock get_item to return the sample preferences
+    mock_common.get_item.return_value = sample_user_preferences
+
+    event = {"requestContext": {"authorizer": {"claims": {"username": "test-user"}}}}
+
+    response = get(event, lambda_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["user"] == "test-user"
+    assert body["preferences"]["theme"] == "dark"
+    assert body["preferences"]["notifications"] is True
+
+
+def test_get_user_preferences_not_found(user_preferences_table, lambda_context):
+    """Test getting user preferences when none exist."""
+    # Mock get_item to return None
+    mock_common.get_item.return_value = None
+
+    event = {"requestContext": {"authorizer": {"claims": {"username": "test-user"}}}}
+
+    response = get(event, lambda_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body is None
+
+
+def test_get_user_preferences_unauthorized(user_preferences_table, lambda_context):
+    """Test getting user preferences for unauthorized user."""
+    # Mock get_item to return preferences for a different user
+    other_user_preferences = {"user": "other-user", "preferences": {"theme": "light"}}
+    mock_common.get_item.return_value = other_user_preferences
+
+    event = {"requestContext": {"authorizer": {"claims": {"username": "test-user"}}}}
+
+    response = get(event, lambda_context)
+
+    assert response["statusCode"] == 403
+    body = json.loads(response["body"])
+    assert "Not authorized to get test-user's preferences" in body["error"]
+
+
+def test_update_user_preferences_new_user(user_preferences_table, lambda_context):
+    """Test updating user preferences for a new user (create new preferences)."""
+    # Mock get_item to return None (no existing preferences)
+    mock_common.get_item.return_value = None
+
+    preferences_data = {"theme": "dark", "notifications": True}
+    event = {
+        "requestContext": {"authorizer": {"claims": {"username": "test-user"}}},
+        "body": json.dumps(preferences_data),
+    }
+
+    response = update(event, lambda_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["user"] == "test-user"
+    assert body["preferences"]["theme"] == "dark"
+
+
+def test_update_user_preferences_existing_user(user_preferences_table, sample_user_preferences, lambda_context):
+    """Test updating user preferences for an existing user."""
+    # Mock get_item to return existing preferences
+    mock_common.get_item.return_value = sample_user_preferences
+
+    updated_preferences = {"theme": "light", "notifications": False}
+    event = {
+        "requestContext": {"authorizer": {"claims": {"username": "test-user"}}},
+        "body": json.dumps(updated_preferences),
+    }
+
+    response = update(event, lambda_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["user"] == "test-user"
+
+
+def test_update_user_preferences_unauthorized(user_preferences_table, lambda_context):
+    """Test updating user preferences when unauthorized."""
+    # Mock get_item to return preferences for a different user
+    other_user_preferences = {"user": "other-user", "preferences": {"theme": "light"}}
+    mock_common.get_item.return_value = other_user_preferences
+
+    preferences_data = {"theme": "dark"}
+    event = {
+        "requestContext": {"authorizer": {"claims": {"username": "test-user"}}},
+        "body": json.dumps(preferences_data),
+    }
+
+    response = update(event, lambda_context)
+
+    assert response["statusCode"] == 403
+    body = json.loads(response["body"])
+    assert "Not authorized to update test-user's preferences" in body["error"]
+
+
+def test_update_user_preferences_with_decimal_values(user_preferences_table, lambda_context):
+    """Test updating user preferences with decimal values in JSON."""
+    # Mock get_item to return None (new user)
+    mock_common.get_item.return_value = None
+
+    preferences_data = {"fontSize": 14.5, "maxItems": 100}
+    event = {
+        "requestContext": {"authorizer": {"claims": {"username": "test-user"}}},
+        "body": json.dumps(preferences_data),
+    }
+
+    response = update(event, lambda_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["user"] == "test-user"
+
+
+def test_update_user_preferences_invalid_json(user_preferences_table, lambda_context):
+    """Test updating user preferences with invalid JSON."""
+    event = {"requestContext": {"authorizer": {"claims": {"username": "test-user"}}}, "body": "invalid-json"}
+
+    response = update(event, lambda_context)
+
+    assert response["statusCode"] == 400  # JSON parsing errors are handled as ValueError, so 400
+    body = json.loads(response["body"])
+    assert "error" in body
+
+
+def test_get_user_preferences_missing_claims(lambda_context):
+    """Test getting user preferences with missing claims."""
+    # Mock get_username to raise ValueError
+    mock_common.get_username.side_effect = ValueError("Missing username")
+
+    event = {"requestContext": {"authorizer": {}}}
+
+    response = get(event, lambda_context)
+
+    assert response["statusCode"] == 400  # ValueError is treated as 400 in mock_api_wrapper
+    body = json.loads(response["body"])
+    assert "error" in body
+
+    # Reset the mock
+    mock_common.get_username.side_effect = None
+    mock_common.get_username.return_value = "test-user"
+
+
+def test_update_user_preferences_missing_claims(lambda_context):
+    """Test updating user preferences with missing claims."""
+    # Mock get_username to raise ValueError
+    mock_common.get_username.side_effect = ValueError("Missing username")
+
+    event = {"requestContext": {"authorizer": {}}, "body": json.dumps({"theme": "dark"})}
+
+    response = update(event, lambda_context)
+
+    assert response["statusCode"] == 400  # ValueError is treated as 400 in mock_api_wrapper
+    body = json.loads(response["body"])
+    assert "error" in body
+
+    # Reset the mock
+    mock_common.get_username.side_effect = None
+    mock_common.get_username.return_value = "test-user"
+
+
+def test_update_user_preferences_model_validation_error(user_preferences_table, lambda_context):
+    """Test updating user preferences with model validation error."""
+    # Mock get_item to return None (new user)
+    mock_common.get_item.return_value = None
+
+    # Mock UserPreferencesModel to raise validation error
+    mock_user_preferences_model.side_effect = ValueError("Validation error")
+
+    preferences_data = {"invalid": "data"}
+    event = {
+        "requestContext": {"authorizer": {"claims": {"username": "test-user"}}},
+        "body": json.dumps(preferences_data),
+    }
+
+    response = update(event, lambda_context)
+
+    assert response["statusCode"] == 400  # ValueError is treated as 400 in mock_api_wrapper
+    body = json.loads(response["body"])
+    assert "error" in body
+
+    # Reset the mock
+    mock_user_preferences_model.side_effect = None
+    mock_user_preferences_model.return_value = mock_model_instance
+
+
+def test_get_user_preferences_query_error(user_preferences_table, lambda_context):
+    """Test getting user preferences with database query error."""
+    # Mock the table.query method to raise an exception
+    with patch("user_preferences.lambda_functions.table") as mock_table:
+        mock_table.query.side_effect = Exception("Database error")
+
+        event = {"requestContext": {"authorizer": {"claims": {"username": "test-user"}}}}
+
+        response = get(event, lambda_context)
+
+        assert response["statusCode"] == 500  # General exceptions are 500
+        body = json.loads(response["body"])
+        assert "error" in body
+
+
+def test_update_user_preferences_put_error(user_preferences_table, lambda_context):
+    """Test updating user preferences with database put error."""
+    # Mock get_item to return None (new user)
+    mock_common.get_item.return_value = None
+
+    # Mock the table.put_item method to raise an exception
+    with patch("user_preferences.lambda_functions.table") as mock_table:
+        mock_table.put_item.side_effect = Exception("Database error")
+
+        preferences_data = {"theme": "dark"}
+        event = {
+            "requestContext": {"authorizer": {"claims": {"username": "test-user"}}},
+            "body": json.dumps(preferences_data),
+        }
+
+        response = update(event, lambda_context)
+
+        assert response["statusCode"] == 500  # General exceptions are 500
+        body = json.loads(response["body"])
+        assert "error" in body
+
+
+def test_update_user_preferences_empty_body(user_preferences_table, lambda_context):
+    """Test updating user preferences with empty body."""
+    # Mock get_item to return None (new user)
+    mock_common.get_item.return_value = None
+
+    event = {"requestContext": {"authorizer": {"claims": {"username": "test-user"}}}, "body": "{}"}
+
+    response = update(event, lambda_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["user"] == "test-user"
+
+
+def test_get_user_preferences_complex_data(user_preferences_table, lambda_context):
+    """Test getting user preferences with complex nested data."""
+    complex_preferences = {
+        "user": "test-user",
+        "preferences": {
+            "ui": {"theme": "dark", "sidebar": {"collapsed": True, "width": 300}},
+            "notifications": {"email": True, "push": False, "frequency": "daily"},
+            "features": ["feature1", "feature2"],
+        },
+    }
+
+    mock_common.get_item.return_value = complex_preferences
+
+    event = {"requestContext": {"authorizer": {"claims": {"username": "test-user"}}}}
+
+    response = get(event, lambda_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["user"] == "test-user"
+    assert body["preferences"]["ui"]["theme"] == "dark"
+    assert body["preferences"]["notifications"]["email"] is True
+    assert "feature1" in body["preferences"]["features"]
+
+
+def test_update_user_preferences_with_special_characters(user_preferences_table, lambda_context):
+    """Test updating user preferences with special characters and unicode."""
+    # Mock get_item to return None (new user)
+    mock_common.get_item.return_value = None
+
+    preferences_data = {
+        "displayName": "Test User 🚀",
+        "locale": "en-US",
+        "customText": "Special chars: àáâãäåæçèéêë",
+        "emoji": "👍",
+    }
+
+    event = {
+        "requestContext": {"authorizer": {"claims": {"username": "test-user"}}},
+        "body": json.dumps(preferences_data, ensure_ascii=False),
+    }
+
+    response = update(event, lambda_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["user"] == "test-user"
+
+
+def test_get_user_preferences_case_sensitivity(user_preferences_table, lambda_context):
+    """Test that user preferences are case sensitive for user IDs."""
+    # Mock get_item to return preferences for exact user match
+    user_preferences = {"user": "Test-User", "preferences": {"theme": "dark"}}  # Different case
+    mock_common.get_item.return_value = user_preferences
+
+    # User ID is "test-user" but preferences are for "Test-User"
+    event = {"requestContext": {"authorizer": {"claims": {"username": "test-user"}}}}
+
+    response = get(event, lambda_context)
+
+    assert response["statusCode"] == 403
+    body = json.loads(response["body"])
+    assert "Not authorized" in body["error"]
+
+
+def test_update_user_preferences_large_payload(user_preferences_table, lambda_context):
+    """Test updating user preferences with a large JSON payload."""
+    # Mock get_item to return None (new user)
+    mock_common.get_item.return_value = None
+
+    # Create a large preferences object
+    large_preferences = {
+        "settings": {f"setting_{i}": f"value_{i}" for i in range(100)},
+        "customizations": {f"custom_{i}": {"option": f"value_{i}"} for i in range(50)},
+        "history": [f"item_{i}" for i in range(200)],
+    }
+
+    event = {
+        "requestContext": {"authorizer": {"claims": {"username": "test-user"}}},
+        "body": json.dumps(large_preferences),
+    }
+
+    response = update(event, lambda_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["user"] == "test-user"
+
+
+def test_get_user_preferences_empty_table(user_preferences_table, lambda_context):
+    """Test getting user preferences from an empty table."""
+    # Mock get_item to return None (empty table)
+    mock_common.get_item.return_value = None
+
+    event = {"requestContext": {"authorizer": {"claims": {"username": "test-user"}}}}
+
+    response = get(event, lambda_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body is None
+
+
+def test_update_user_preferences_none_values(user_preferences_table, lambda_context):
+    """Test updating user preferences with None values."""
+    # Mock get_item to return None (new user)
+    mock_common.get_item.return_value = None
+
+    preferences_data = {"theme": None, "notifications": None, "validSetting": "value"}
+
+    event = {
+        "requestContext": {"authorizer": {"claims": {"username": "test-user"}}},
+        "body": json.dumps(preferences_data),
+    }
+
+    response = update(event, lambda_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["user"] == "test-user"
+
+
+def test_update_user_preferences_boolean_values(user_preferences_table, lambda_context):
+    """Test updating user preferences with various boolean values."""
+    # Mock get_item to return None (new user)
+    mock_common.get_item.return_value = None
+
+    preferences_data = {
+        "setting1": True,
+        "setting2": False,
+        "setting3": 0,
+        "setting4": 1,
+        "setting5": "true",
+        "setting6": "false",
+    }
+
+    event = {
+        "requestContext": {"authorizer": {"claims": {"username": "test-user"}}},
+        "body": json.dumps(preferences_data),
+    }
+
+    response = update(event, lambda_context)
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["user"] == "test-user"


### PR DESCRIPTION
*Description of changes:*

Cleaned up the following:
1. v1 Add a Server Description field to MCP servers so everyone can read that server purpose is in the library. Currently only tools have descriptions
2. v1 Confirmation pop up
    1. Add more spacing for better visual alignment
    2. Remove code block formatting and {} brackets, but keep the value displayed. This will look less intimidating for users
3. YOLO Mode -> Autopilot

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
