### PR TITLE
Add missing named parameter to boto3 client creation for region name

### DIFF
--- a/lambda/repository/ingestion_service.py
+++ b/lambda/repository/ingestion_service.py
@@ -28,7 +28,7 @@ class IngestionAction(str, Enum):
 class DocumentIngestionService:
     def _submit_job(self, job: IngestionJob, action: IngestionAction) -> None:
         # Submit AWS Batch job
-        batch_client = boto3.client("batch")
+        batch_client = boto3.client("batch", region_name=os.environ["AWS_REGION"])
         response = batch_client.submit_job(
             jobName=f"document-{action.value}-{job.id}",
             jobQueue=os.environ["LISA_INGESTION_JOB_QUEUE_NAME"],

--- a/lambda/repository/rag_document_repo.py
+++ b/lambda/repository/rag_document_repo.py
@@ -12,6 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 import logging
+import os
 from typing import Generator, Optional
 
 import boto3
@@ -32,7 +33,7 @@ class RagDocumentRepository:
         dynamodb = boto3.resource("dynamodb")
         self.doc_table = dynamodb.Table(document_table_name)
         self.subdoc_table = dynamodb.Table(sub_document_table_name)
-        self.s3_client = boto3.client("s3")
+        self.s3_client = boto3.client("s3", region_name=os.environ["AWS_REGION"])
         self.vs_repo = VectorStoreRepository()
 
     def delete_by_id(self, document_id: str) -> None:

--- a/lambda/repository/state_machine/list_modified_objects.py
+++ b/lambda/repository/state_machine/list_modified_objects.py
@@ -15,6 +15,7 @@
 """Lambda handlers for ListModifiedObjects state machine."""
 
 import logging
+import os
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict
 
@@ -112,7 +113,7 @@ def handle_list_modified_objects(event: Dict[str, Any], context: Any) -> Dict[st
         validate_bucket_prefix(bucket, prefix)
 
         # Initialize S3 client
-        s3_client = boto3.client("s3")
+        s3_client = boto3.client("s3", region_name=os.environ["AWS_REGION"])
 
         # Calculate timestamp for 24 hours ago
         twenty_four_hours_ago = datetime.now(timezone.utc) - timedelta(hours=24)

--- a/lambda/utilities/common_functions.py
+++ b/lambda/utilities/common_functions.py
@@ -459,7 +459,7 @@ def _get_lambda_role_arn() -> str:
     str
         The full ARN of the Lambda execution role
     """
-    sts = boto3.client("sts")
+    sts = boto3.client("sts", region_name=os.environ["AWS_REGION"])
     identity = sts.get_caller_identity()
     return cast(str, identity["Arn"])  # This will include the role name
 

--- a/lambda/utilities/db_setup_iam_auth.py
+++ b/lambda/utilities/db_setup_iam_auth.py
@@ -22,7 +22,7 @@ from botocore.exceptions import ClientError
 
 def get_db_credentials(secret_arn: str) -> Any:
     """Retrieve database credentials from Secrets Manager"""
-    client = boto3.client("secretsmanager")
+    client = boto3.client("secretsmanager", region_name=os.environ["AWS_REGION"])
 
     try:
         response = client.get_secret_value(SecretId=secret_arn)

--- a/lambda/utilities/file_processing.py
+++ b/lambda/utilities/file_processing.py
@@ -32,7 +32,7 @@ from utilities.exceptions import RagUploadException
 
 logger = logging.getLogger(__name__)
 session = boto3.Session()
-s3 = session.client("s3")
+s3 = session.client("s3", region_name=os.environ["AWS_REGION"])
 
 
 def _get_metadata(s3_uri: str, name: str) -> dict:

--- a/lib/serve/rest-api/src/utils/rds_auth.py
+++ b/lib/serve/rest-api/src/utils/rds_auth.py
@@ -32,7 +32,7 @@ def _get_lambda_role_arn() -> str:
     str
         The full ARN of the Lambda execution role
     """
-    sts = boto3.client("sts")
+    sts = boto3.client("sts", region_name=os.environ["AWS_REGION"])
     identity = sts.get_caller_identity()
     return cast(str, identity["Arn"])  # This will include the role name
 

--- a/test/lambda/test_db_setup_iam_auth.py
+++ b/test/lambda/test_db_setup_iam_auth.py
@@ -90,7 +90,7 @@ def test_get_db_credentials_success():
         assert result == secret_value
 
         # Verify the client was called correctly
-        mock_client.assert_called_once_with("secretsmanager")
+        mock_client.assert_called_once_with("secretsmanager", region_name="us-east-1")
         mock_secretsmanager.get_secret_value.assert_called_once_with(SecretId=secret_arn)
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This pull request adds the missing `region_name` named parameter to the creation of boto3 clients. Previously, the region name was being inferred, but this can lead to issues when working with resources in different AWS regions. 

By explicitly specifying the `region_name` parameter, this ensures that the boto3 client is created with the correct AWS region, improving the reliability and portability of the code.

The changes include updating the existing boto3 client creation calls to include the `region_name` parameter, set to the appropriate value for the resource being accessed.

Resolves #356 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
