### PR TITLE
Feature/rename sessions

### DIFF
--- a/lambda/session/lambda_functions.py
+++ b/lambda/session/lambda_functions.py
@@ -115,8 +115,8 @@ def _generate_presigned_image_url(key: str) -> str:
 
 def _map_session(session: dict) -> Dict[str, Any]:
     return {
-        "sessionId": session["sessionId"],
-        "name": session["name"],
+        "sessionId": session.get("sessionId", None),
+        "name": session.get("name", None),
         "firstHumanMessage": _find_first_human_message(session),
         "startTime": session.get("startTime", None),
         "createTime": session.get("createTime", None),
@@ -263,7 +263,7 @@ def update_session_name(event: dict, context: dict) -> dict:
         session_id = get_session_id(event)
 
         try:
-            body = json.loads(event["body"], parse_float=Decimal)
+            body = json.loads(event.get("body", {}), parse_float=Decimal)
         except json.JSONDecodeError as e:
             return {"statusCode": 400, "body": json.dumps({"error": f"Invalid JSON: {str(e)}"})}
 
@@ -274,7 +274,7 @@ def update_session_name(event: dict, context: dict) -> dict:
             Key={"sessionId": session_id, "userId": user_id},
             UpdateExpression="SET #name = :name",
             ExpressionAttributeNames={"#name": "name"},
-            ExpressionAttributeValues={":name": body["name"]},
+            ExpressionAttributeValues={":name": body.get("name")},
         )
         return {"statusCode": 200, "body": json.dumps({"message": "Session name updated successfully"})}
     except ValueError as e:

--- a/lambda/session/lambda_functions.py
+++ b/lambda/session/lambda_functions.py
@@ -256,7 +256,7 @@ def attach_image_to_session(event: dict, context: dict) -> dict:
 
 
 @api_wrapper
-def update_session_name(event: dict, context: dict) -> dict:
+def rename_session(event: dict, context: dict) -> dict:
     """Update session name in DynamoDB."""
     try:
         user_id = get_username(event)

--- a/lambda/utilities/bedrock_kb.py
+++ b/lambda/utilities/bedrock_kb.py
@@ -28,7 +28,7 @@ BEDROCK_KB_TYPE = "bedrock_knowledge_base"
 
 def is_bedrock_kb_repository(repository: Dict[str, Any]) -> bool:
     """Return True if the repository is a Bedrock Knowledge Base."""
-    return repository.get("type", "") == BEDROCK_KB_TYPE
+    return bool(repository.get("type", "") == BEDROCK_KB_TYPE)
 
 
 def retrieve_documents(

--- a/lib/chat/api/session.ts
+++ b/lib/chat/api/session.ts
@@ -191,6 +191,13 @@ export class SessionApi extends Construct {
                 path: 'session/{sessionId}',
                 method: 'PUT',
                 environment: env,
+            },{
+                name: 'rename_session',
+                resource: 'session',
+                description: 'Updates session name',
+                path: 'session/{sessionId}/name',
+                method: 'PUT',
+                environment: env,
             },
             {
                 name: 'attach_image_to_session',

--- a/lib/user-interface/react/src/components/chatbot/components/Sessions.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/Sessions.tsx
@@ -27,7 +27,7 @@ import {
     useDeleteSessionByIdMutation,
     useLazyGetSessionByIdQuery,
     useListSessionsQuery,
-    useUpdateSessionMutation,
+    useUpdateSessionNameMutation,
 } from '@/shared/reducers/session.reducer';
 import { useAppDispatch } from '@/config/store';
 import { useNotificationService } from '@/shared/util/hooks';
@@ -64,12 +64,12 @@ export function Sessions ({ newSession }) {
         error: deleteUserSessionsError,
         isLoading: isDeleteUserSessionsLoading,
     }] = useDeleteAllSessionsForUserMutation();
-    const [updateSession, {
-        isSuccess: isUpdateSessionSuccess,
-        isError: isUpdateSessionError,
-        error: updateSessionError,
-        isLoading: isUpdateSessionLoading,
-    }] = useUpdateSessionMutation();
+    const [updateSessionName, {
+        isSuccess: isUpdateSessionNameSuccess,
+        isError: isUpdateSessionNameError,
+        error: updateSessionNameError,
+        isLoading: isUpdateSessionNameLoading,
+    }] = useUpdateSessionNameMutation();
     const [getConfiguration] = useLazyGetConfigurationQuery();
     const [config, setConfig] = useState<IConfiguration>();
     const [searchQuery, setSearchQuery] = useState<string>('');
@@ -130,16 +130,16 @@ export function Sessions ({ newSession }) {
     }, [isDeleteUserSessionsSuccess, isDeleteUserSessionsError, deleteUserSessionsError, isDeleteUserSessionsLoading]);
 
     useEffect(() => {
-        if (!isUpdateSessionLoading && isUpdateSessionSuccess) {
+        if (!isUpdateSessionNameLoading && isUpdateSessionNameSuccess) {
             notificationService.generateNotification('Successfully renamed session', 'success');
             setRenameModalVisible(false);
             setSessionToRename(null);
             setNewSessionName('');
-        } else if (!isUpdateSessionLoading && isUpdateSessionError) {
-            notificationService.generateNotification(`Error renaming session: ${updateSessionError?.message || 'Unknown error'}`, 'error');
+        } else if (!isUpdateSessionNameLoading && isUpdateSessionNameError) {
+            notificationService.generateNotification(`Error renaming session: ${updateSessionNameError?.message || 'Unknown error'}`, 'error');
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isUpdateSessionSuccess, isUpdateSessionError, updateSessionError, isUpdateSessionLoading]);
+    }, [isUpdateSessionNameSuccess, isUpdateSessionNameError, updateSessionNameError, isUpdateSessionNameLoading]);
 
     const handleRenameSession = (session: LisaChatSession) => {
         setSessionToRename(session);
@@ -153,7 +153,7 @@ export function Sessions ({ newSession }) {
                 ...sessionToRename,
                 name: newSessionName.trim()
             };
-            updateSession(updatedSession);
+            updateSessionName(updatedSession);
         }
     };
 
@@ -331,8 +331,8 @@ export function Sessions ({ newSession }) {
                             <Button
                                 variant='primary'
                                 onClick={handleRenameConfirm}
-                                disabled={!newSessionName.trim() || isUpdateSessionLoading}
-                                loading={isUpdateSessionLoading}
+                                disabled={!newSessionName.trim() || isUpdateSessionNameLoading}
+                                loading={isUpdateSessionNameLoading}
                             >
                                 Rename
                             </Button>
@@ -350,7 +350,7 @@ export function Sessions ({ newSession }) {
                             onChange={({ detail }) => setNewSessionName(detail.value)}
                             placeholder='Enter session name...'
                             onKeyDown={(e) => {
-                                if (e.detail.key === 'Enter' && newSessionName.trim() && !isUpdateSessionLoading) {
+                                if (e.detail.key === 'Enter' && newSessionName.trim() && !isUpdateSessionNameLoading) {
                                     handleRenameConfirm();
                                 }
                             }}

--- a/lib/user-interface/react/src/components/chatbot/components/Sessions.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/Sessions.tsx
@@ -35,7 +35,7 @@ import { useEffect, useState, useMemo } from 'react';
 import { useAuth } from 'react-oidc-context';
 import { IConfiguration } from '@/shared/model/configuration.model';
 import { useNavigate } from 'react-router-dom';
-import { fetchImage, getDisplayableMessage, getSessionDisplay, messageContainsImage } from '@/components/utils';
+import { fetchImage, getSessionDisplay, messageContainsImage } from '@/components/utils';
 import { LisaChatSession } from '@/components/types';
 import Box from '@cloudscape-design/components/box';
 import React from 'react';
@@ -143,7 +143,7 @@ export function Sessions ({ newSession }) {
 
     const handleRenameSession = (session: LisaChatSession) => {
         setSessionToRename(session);
-        setNewSessionName(getDisplayableMessage(session.firstHumanMessage ?? ''));
+        setNewSessionName(getSessionDisplay(session));
         setRenameModalVisible(true);
     };
 

--- a/lib/user-interface/react/src/components/chatbot/components/Sessions.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/Sessions.tsx
@@ -35,8 +35,7 @@ import { useEffect, useState, useMemo } from 'react';
 import { useAuth } from 'react-oidc-context';
 import { IConfiguration } from '@/shared/model/configuration.model';
 import { useNavigate } from 'react-router-dom';
-import { truncateText } from '@/shared/util/formats';
-import { fetchImage, getDisplayableMessage, messageContainsImage } from '@/components/utils';
+import { fetchImage, getDisplayableMessage, getSessionDisplay, messageContainsImage } from '@/components/utils';
 import { LisaChatSession } from '@/components/types';
 import Box from '@cloudscape-design/components/box';
 import React from 'react';
@@ -86,7 +85,7 @@ export function Sessions ({ newSession }) {
             return sessions || [];
         }
         return (sessions || [])
-            .filter((session) => getDisplayableMessage(session.firstHumanMessage ?? '').toLowerCase().includes(searchQuery.toLowerCase()));
+            .filter((session) => getSessionDisplay(session).toLowerCase().includes(searchQuery.toLowerCase()));
     }, [sessions, searchQuery]);
 
     const { items } = useCollection(filteredSessions, {
@@ -152,7 +151,7 @@ export function Sessions ({ newSession }) {
         if (sessionToRename && newSessionName.trim()) {
             const updatedSession = {
                 ...sessionToRename,
-                firstHumanMessage: newSessionName.trim()
+                name: newSessionName.trim()
             };
             updateSession(updatedSession);
         }
@@ -246,14 +245,14 @@ export function Sessions ({ newSession }) {
                                 <Link onClick={() => navigate(`ai-assistant/${item.sessionId}`)}>
                                     <Box color={item.sessionId === currentSessionId ? 'text-status-info' : 'text-status-inactive'}
                                         fontWeight={item.sessionId === currentSessionId ? 'bold' : 'normal'}>
-                                        {truncateText(getDisplayableMessage(item.firstHumanMessage ?? ''), 40, '...')}
+                                        {getSessionDisplay(item, 40)}
                                     </Box>
                                 </Link>
                             </SpaceBetween>
                             <SpaceBetween size={'s'} alignItems={'end'}>
                                 <ButtonDropdown
                                     items={[
-                                        // { id: 'rename-session', text: 'Rename Session', iconName: 'edit' },
+                                        { id: 'rename-session', text: 'Rename Session', iconName: 'edit' },
                                         { id: 'delete-session', text: 'Delete Session', iconName: 'delete-marker' },
                                         { id: 'download-session', text: 'Download Session', iconName: 'download' },
                                         { id: 'export-images', text: 'Export AI Images', iconName: 'folder' },

--- a/lib/user-interface/react/src/components/types.tsx
+++ b/lib/user-interface/react/src/components/types.tsx
@@ -102,6 +102,7 @@ export type LisaChatSession = {
     userId: string;
     startTime: string;
     history: LisaChatMessage[];
+    name?: string;
     firstHumanMessage?: MessageContent;
     configuration?: IChatConfiguration & IModelConfiguration;
 };

--- a/lib/user-interface/react/src/components/utils.ts
+++ b/lib/user-interface/react/src/components/utils.ts
@@ -15,6 +15,8 @@
 */
 import { S3UploadRequest } from '../shared/reducers/rag.reducer';
 import { MessageContent } from '@langchain/core/messages';
+import { LisaChatSession } from './types';
+import { truncateText } from '@/shared/util/formats';
 
 const stripTrailingSlash = (str) => {
     return str && str.endsWith('/') ? str.slice(0, -1) : str;
@@ -70,6 +72,11 @@ export const formatDocumentTitlesAsString = (docs: any): string => {
         docs.map((doc) => doc.Document.metadata.name)
     )];
     return uniqueNames.length !== 0 ? `\n*Source - ${uniqueNames.join(', ')}*` : undefined;
+};
+
+export const getSessionDisplay = (session: LisaChatSession, maxLength?: number) => {
+    const display = session.name || getDisplayableMessage(session.firstHumanMessage);
+    return maxLength ? truncateText(display, 40, '...') : display;
 };
 
 export const getDisplayableMessage = (content: MessageContent, ragCitations?: string) => {

--- a/lib/user-interface/react/src/shared/reducers/session.reducer.ts
+++ b/lib/user-interface/react/src/shared/reducers/session.reducer.ts
@@ -144,6 +144,7 @@ export const {
     useDeleteSessionByIdMutation,
     useDeleteAllSessionsForUserMutation,
     useUpdateSessionMutation,
+    useUpdateSessionNameMutation,
     useLazyGetSessionByIdQuery,
     useGetSessionHealthQuery,
     useAttachImageToSessionMutation

--- a/lib/user-interface/react/src/shared/reducers/session.reducer.ts
+++ b/lib/user-interface/react/src/shared/reducers/session.reducer.ts
@@ -61,7 +61,8 @@ export const sessionApi = createApi({
                         };
                         return message;
                     }),
-                    configuration: session.configuration
+                    configuration: session.configuration,
+                    name: session.name
                 }
             }),
             transformErrorResponse: (baseQueryReturnValue) => {
@@ -72,6 +73,23 @@ export const sessionApi = createApi({
                 };
             },
             invalidatesTags: ['sessions'],
+        }),
+        updateSessionName: builder.mutation<LisaChatSession, { sessionId: string, name: string }>({
+            query: (session) => ({
+                url: `/session/${session.sessionId}/name`,
+                method: 'PUT',
+                data: {
+                    name: session.name
+                }
+            }),
+            invalidatesTags: ['sessions'],
+            transformErrorResponse: (baseQueryReturnValue) => {
+                // transform into SerializedError
+                return {
+                    name: 'Rename Session Error',
+                    message: baseQueryReturnValue.data?.type === 'RequestValidationError' ? baseQueryReturnValue.data.detail.map((error) => error.msg).join(', ') : baseQueryReturnValue.data.message
+                };
+            },
         }),
         attachImageToSession: builder.mutation<LisaAttachImageResponse, LisaAttachImageRequest>({
             query: (attachImageRequest) => ({

--- a/test/cdk/stacks/nag.test.ts
+++ b/test/cdk/stacks/nag.test.ts
@@ -33,7 +33,7 @@ enum NagType {
 const nagResults: NagResult = {
     LisaApiBase: [1,7,0,7],
     LisaApiDeployment: [0,0,0,0],
-    LisaChat: [4,60,0,67],
+    LisaChat: [4,62,0,69],
     LisaCore: [0,1,0,6],
     LisaDocs: [1,22,0,12],
     LisaIAM: [0,14,0,0],


### PR DESCRIPTION
Summary
This PR enhances session management functionality by improving session display logic and adding a dedicated session rename API endpoint.

Changes Made:
Backend Changes
- Enhanced Session Display Logic (lambda/session/lambda_functions.py)
- New Session Rename Endpoint (lambda/session/lambda_functions.py)
- API Gateway Integration  /session/{sessionId}/name PUT endpoint for session renaming

Frontend Changes
Session Display Improvements (components/utils.ts)
- Added getSessionDisplay() utility function that prioritizes session name over first human message
- Updated session filtering to use new display logic
- Enabled session rename functionality in the UI in session action dropdown
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
