### PR TITLE
Download JSON export of model comparison results

### DIFF
--- a/lib/user-interface/react/src/components/model-management/components/ModelComparisonComponents.tsx
+++ b/lib/user-interface/react/src/components/model-management/components/ModelComparisonComponents.tsx
@@ -38,6 +38,7 @@ import {
 import { LisaChatMessage, MessageTypes } from '../../types';
 import Message from '../../chatbot/components/Message';
 import { IChatConfiguration } from '../../../shared/model/chat.configurations.model';
+import { downloadFile } from '@/shared/util/downloader';
 
 type ModelSelectionSectionProps = {
     modelSelections: ModelSelection[];
@@ -179,8 +180,43 @@ export const ComparisonResults = memo(function ComparisonResults ({
     const handleSendGenerateRequest = () => {};
     const setUserPrompt = () => {};
 
+    const handleDownloadResults = (): void => {
+        const results = responses.map((response) => {
+            const model = models.find((m) => m.modelId === response.modelId);
+            return {
+                modelId: response.modelId,
+                modelName: model?.modelName || response.modelId,
+                response: response.response,
+                error: response.error,
+                loading: response.loading
+            };
+        });
+
+        const data = {
+            prompt: prompt,
+            configuration: chatConfiguration,
+            results: results
+        };
+
+        const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+        const filename = `model-comparison-${timestamp}.json`;
+        const url = URL.createObjectURL(blob);
+        downloadFile(url, filename);
+    };
+
     return (
-        <Container header={<Header variant='h2'>Comparison Results</Header>}>
+        <Container header={<Header variant='h2' actions={
+            <SpaceBetween direction='horizontal' size='xs'>
+                <Button
+                    iconName='download'
+                    onClick={handleDownloadResults}
+                    disabled={responses.length === 0 || responses.some((r) => r.loading)}
+                >
+                    Download Results
+                </Button>
+            </SpaceBetween>
+        }>Comparison Results</Header>}>
             <SpaceBetween size='m'>
                 {/* Display user prompt */}
                 {prompt && (


### PR DESCRIPTION
*Description of changes:*

Adding ability to download JSON export of comparison page for future reference. This includes chat settings.

Button is disabled until results are returned.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
