### PR TITLE
Add TIKTOKEN_CACHE to RAG layer

### DIFF
--- a/lib/rag/ragConstruct.ts
+++ b/lib/rag/ragConstruct.ts
@@ -225,8 +225,7 @@ export class LisaRagConstruct extends Construct {
             autoUpgrade: true,
             assetPath: config.lambdaLayerAssets?.ragLayerPath,
             afterBundle: (inputDir: string, outputDir: string) => [
-                `mkdir -p ${outputDir}/python/TIKTOKEN_CACHE`,
-                `cp -r ${inputDir}/TIKTOKEN_CACHE/* ${outputDir}/python/TIKTOKEN_CACHE/`
+                `cp -r ${inputDir}/TIKTOKEN_CACHE/* ${outputDir}/TIKTOKEN_CACHE/`
             ],
         });
 


### PR DESCRIPTION
Adding correct path for TIKTOKEN_CACHE in RAG lambda layer


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
