### PR TITLE
Adding support for MCP OAuth

### DIFF
--- a/lib/user-interface/react/src/components/chatbot/components/SessionConfiguration.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/SessionConfiguration.tsx
@@ -74,7 +74,7 @@ export const SessionConfiguration = ({
         setChatConfiguration(updatedConfiguration);
 
         // Immediately persist the configuration to the session if available
-        if (session && updateSession) {
+        if (session && updateSession && session.history.length > 0) {
             updateSession({
                 ...session,
                 configuration: {


### PR DESCRIPTION
Fixing:
- blank sessions created when updating settings before sending a prompt
- MCP Oauth support
- Refreshing on pages like #/prompt-templates doesn't reroute back to chat assistant


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
