### PR TITLE
Update scaling to cluster level

### DIFF
--- a/lib/api-base/fastApiContainer.ts
+++ b/lib/api-base/fastApiContainer.ts
@@ -195,7 +195,7 @@ export class FastApiContainer extends Construct {
             applicationTarget: {
                 port: 8080
             }
-        }, props.apiName);
+        });
 
         if (tokenTable) {
             // Grant token table access to REST API task role only

--- a/lib/serve/mcpWorkbenchServiceConstruct.ts
+++ b/lib/serve/mcpWorkbenchServiceConstruct.ts
@@ -76,7 +76,7 @@ export default class McpWorkbenchServiceConstruct extends Construct {
             }
         };
 
-        const { service } = apiCluster.addTask(ECSTasks.MCPWORKBENCH, mcpWorkbenchTaskDefinition, 'REST');
+        const { service } = apiCluster.addTask(ECSTasks.MCPWORKBENCH, mcpWorkbenchTaskDefinition);
         this.service = service;
 
         this.createS3EventHandler(config, service);


### PR DESCRIPTION
## Description

This PR refactors ECS cluster scaling configuration by removing per-task autoscaling and simplifying the target group creation logic.

## Changes

### ECSCluster (`lib/api-base/ecsCluster.ts`)
- **Removed per-task autoscaling**: Eliminated `autoScaleTaskCount()` and `scaleOnRequestCount()` calls that were previously configured for each individual task

## Impact

- **Scaling behavior**: Tasks no longer scale independently based on request count per target. Scaling is now managed at the cluster/ASG level only
- **Simplified architecture**: Reduces complexity by centralizing scaling logic rather than distributing it across individual tasks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
