### PR TITLE
Bugfix/metrics usergroups

### DIFF
--- a/lambda/metrics/lambda_functions.py
+++ b/lambda/metrics/lambda_functions.py
@@ -49,7 +49,7 @@ def get_user_metrics(event: dict, context: dict) -> dict:
                 "ragUsageCount": item.get("ragUsageCount", 0),
                 "mcpToolCallsCount": item.get("mcpToolCallsCount", 0),
                 "mcpToolUsage": item.get("mcpToolUsage", {}),
-                "userGroups": list(item.get("userGroups", [])),
+                "userGroups": list(item.get("userGroups") or []),
                 "sessionMetrics": item.get("sessionMetrics", {}),
                 "firstSeen": item.get("firstSeen"),
                 "lastSeen": item.get("lastSeen"),
@@ -580,7 +580,7 @@ def update_user_metrics_by_session(
                     ":total_mcp": total_mcp_calls,
                     ":mcp_usage": aggregate_mcp_usage,
                     ":session_metrics": all_session_metrics,
-                    ":groups": set(user_groups) if user_groups else existing_item.get("userGroups", set()),
+                    ":groups": set(user_groups) if user_groups else (existing_item.get("userGroups") or set()),
                 },
             )
     except ClientError as e:


### PR DESCRIPTION
## Fix TypeError in get_user_metrics when userGroups is None

### Problem
The `get_user_metrics` Lambda function was throwing a `TypeError: 'NoneType' object is not iterable` error when retrieving user metrics for users whose `userGroups` field exists in DynamoDB but has a `None` value.

**Error Stack Trace:**
```
File "/var/task/metrics/lambda_functions.py", line 52, in get_user_metrics
"userGroups": list(item.get("userGroups", [])),
TypeError: 'NoneType' object is not iterable
```

### Root Cause
The issue occurred because `dict.get(key, default)` only returns the default value when the key is **missing** from the dictionary. If the key exists but its value is `None`, `get()` returns `None` instead of the default value. 

When `userGroups` existed in the DynamoDB item with a `None` value, `item.get("userGroups", [])` returned `None`, and then `list(None)` raised a `TypeError` because `None` is not iterable.

### Solution
Changed the code to use the `or` operator to handle `None` values explicitly:
- **Line 52**: Changed `list(item.get("userGroups", []))` to `list(item.get("userGroups") or [])`
- **Line 583**: Changed `existing_item.get("userGroups", set())` to `existing_item.get("userGroups") or set()` in the `update_user_metrics_by_session` function

This ensures that if `userGroups` is `None`, it defaults to an empty list/set instead of causing a runtime error.

### Impact
- ✅ Fixes the `TypeError` that was preventing user metrics from being retrieved for affected users
- ✅ Handles edge cases where `userGroups` may be `None` in the database
- ✅ Maintains backward compatibility with existing data structures
- ✅ No breaking changes to the API response format

### Testing
The fix handles three scenarios:
1. `userGroups` key is missing → defaults to `[]`
2. `userGroups` key exists with `None` value → defaults to `[]`
3. `userGroups` key exists with valid value → uses the actual value

### Related
This fix addresses errors seen in production logs where users with `None` values in their `userGroups` field were unable to retrieve their metrics via the `/metrics/users/{userId}` endpoint.