### PR TITLE
Adds a retry button + text when a prompt error occurs.

### DIFF
--- a/lib/user-interface/react/src/components/chatbot/Chat.tsx
+++ b/lib/user-interface/react/src/components/chatbot/Chat.tsx
@@ -286,7 +286,7 @@ export default function Chat ({ sessionId }) {
         });
     }, [getRelevantDocuments, chatConfiguration.sessionConfiguration, ragConfig.repositoryId, ragConfig.collection, ragConfig.embeddingModel]);
 
-    const { isRunning, setIsRunning, isStreaming, generateResponse, stopGeneration } = useChatGeneration({
+    const { isRunning, setIsRunning, isStreaming, generateResponse, stopGeneration, retryResponse, errorState } = useChatGeneration({
         chatConfiguration,
         selectedModel,
         isImageGenerationMode,
@@ -782,6 +782,8 @@ export default function Chat ({ sessionId }) {
                             chatConfiguration={chatConfiguration}
                             setUserPrompt={setUserPrompt}
                             onMermaidRenderComplete={handleMermaidRenderComplete}
+                            retryResponse={retryResponse}
+                            errorState={errorState && idx === session.history.length - 1 }
                         />));
                     // eslint-disable-next-line react-hooks/exhaustive-deps
                     }, [session.history, chatConfiguration, loadingSession])}

--- a/lib/user-interface/react/src/components/chatbot/hooks/chat.hooks.tsx
+++ b/lib/user-interface/react/src/components/chatbot/hooks/chat.hooks.tsx
@@ -134,6 +134,8 @@ export const useChatGeneration = ({
     const dispatch = useAppDispatch();
     const [isRunning, setIsRunning] = useState(false);
     const [isStreaming, setIsStreaming] = useState(false);
+    const [lastRequest, setLastRequest] = useState<null | GenerateLLMRequestParams>(null);
+    const [errorState, setErrorState] = useState(false);
     const stopRequested = useRef(false);
     const modelSupportsTools = selectedModel?.features?.filter((feature) => feature.name === ModelFeatures.TOOL_CALLS)?.length && true;
     const modelSupportsReasoning = selectedModel?.features?.find((feature) => feature.name === ModelFeatures.REASONING) ? true : false;
@@ -160,8 +162,15 @@ export const useChatGeneration = ({
         return new ChatOpenAI(modelConfig);
     }, [selectedModel, auth, chatConfiguration]);
 
+    const retryResponse = async () => {
+        if (!lastRequest) return;
+        await generateResponse(lastRequest);
+    };
+
     const generateResponse = async (params: GenerateLLMRequestParams) => {
         setIsRunning(true);
+        setErrorState(false);
+        setLastRequest(params);
         stopRequested.current = false;
         const startTime = performance.now(); // Start client timer
 
@@ -580,6 +589,7 @@ export const useChatGeneration = ({
         } catch (error) {
             notificationService.generateNotification('An error occurred while processing your request.', 'error', undefined, error.error?.message ? <p>{JSON.stringify(error.error.message)}</p> : undefined);
             setIsRunning(false);
+            setErrorState(true);
             throw error;
         } finally {
             setIsRunning(false);
@@ -600,5 +610,5 @@ export const useChatGeneration = ({
         stopRequested.current = true;
     }, []);
 
-    return { isRunning, setIsRunning, isStreaming, setIsStreaming, generateResponse, createOpenAiClient, stopGeneration };
+    return { isRunning, setIsRunning, isStreaming, setIsStreaming, generateResponse, createOpenAiClient, stopGeneration, retryResponse, errorState };
 };


### PR DESCRIPTION
When the user enters a prompt and an error occurs, a retry button with text will be apparent for easy and quick prompt reattempts.

---
### bug noticed - This may have already existed
- When the message has an error, the next prompt sent will prepend the previously erred message.  
---
The retry button next to the copy icon can be seen in the following image.
<img width="254" height="101" alt="image" src="https://github.com/user-attachments/assets/6a8cb721-30f5-4ed4-a966-6ee4ea22081f" />


To force an error to occur so you can see the feature, you can throw an error in the try/catch block in the chat.hooks.tsx file.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
