### PR TITLE
Added documentation about vLLM variables LISA supports.

### DIFF
--- a/lib/docs/.vitepress/config.mts
+++ b/lib/docs/.vitepress/config.mts
@@ -54,7 +54,11 @@ const navLinks = [
     text: 'Advanced Configuration',
     items: [
       { text: 'API Token Management', link: '/config/api-tokens' },
-      { text: 'Model Compatibility', link: '/config/model-compatibility' },
+      { text: 'Model Compatibility', link: '/config/model-compatibility',
+        items: [
+          {text: "vLLM Variables", link: '/config/vllm_variables'}
+        ]
+      },
       { text: 'Model Management API', link: '/config/model-management-api' },
       { text: 'Model Management UI', link: '/config/model-management-ui' },
       { text: 'Bedrock Guardrails', link: '/config/guardrails' },

--- a/lib/docs/config/vllm_variables.md
+++ b/lib/docs/config/vllm_variables.md
@@ -1,0 +1,48 @@
+# vLLM Environment Variables
+
+LISA Serve supports configuring vLLM model serving through environment variables. These variables allow you to control performance, memory usage, parallelization, and advanced features when deploying models with vLLM.
+- **NOTE:** Standard vLLM environment variables are supported and passed directly into the VLLM container.  [See vLLM's documentation](https://docs.vllm.ai/en/latest/configuration/env_vars/)
+
+## Core Performance & Memory
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `VLLM_GPU_MEMORY_UTILIZATION` | Fraction of GPU memory to use (0.0-1.0) | `0.9` | `0.85` |
+| `VLLM_MAX_MODEL_LEN` | Maximum context length override | Auto | `4096` |
+| `MAX_TOTAL_TOKENS` | *Legacy alias for `VLLM_MAX_MODEL_LEN`* | Auto | `4096` |
+
+## Model Format & Loading
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `VLLM_DTYPE` | Model precision | `auto` | `half`, `float16`, `bfloat16`, `float32` |
+| `VLLM_QUANTIZATION` | Quantization method | - | `awq`, `gptq`, `squeezellm`, `fp8` |
+| `VLLM_TRUST_REMOTE_CODE` | Allow custom model code execution | `false` | `true` |
+
+## Performance Tuning
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `VLLM_MAX_NUM_BATCHED_TOKENS` | Maximum tokens per batch | Auto | `8192` |
+| `VLLM_MAX_NUM_SEQS` | Maximum concurrent sequences | `256` | `128`, `512` |
+| `VLLM_ENABLE_PREFIX_CACHING` | Enable prefix caching for repeated prompts | `false` | `true` |
+| `VLLM_ENABLE_CHUNKED_PREFILL` | Enable chunked prefill | `false` | `true` |
+
+## Parallel Processing
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `VLLM_TENSOR_PARALLEL_SIZE` | Split model across N GPUs | `1` | `2`, `4`, `8` |
+
+## Tool Calling / Function Calling
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `VLLM_ENABLE_AUTO_TOOL_CHOICE` | Enable automatic tool choice routing | `false` | `true` |
+| `VLLM_TOOL_CALL_PARSER` | Tool call parser implementation | - | `hermes`, `mistral`, `llama3_json`, `qwen` |
+
+> **Note**: Tool calling requires both `VLLM_ENABLE_AUTO_TOOL_CHOICE=true` and specifying an appropriate `VLLM_TOOL_CALL_PARSER` for your model. See [vLLM Tool Calling Documentation](https://docs.vllm.ai/en/stable/features/tool_calling/) for details.
+
+## Reference
+
+For more details on vLLM configuration, see the [official vLLM documentation](https://docs.vllm.ai/en/latest/configuration/env_vars/).


### PR DESCRIPTION
### Summary
- Add docs about the vLLM environments LISA Serve supports
- The vLLM Variables documentation describes the vLLM variables that our entrypoint.sh will use.
  - Removed docs about variables that are mentioned but not used by the entrypoint.sh script

### Example Image:
- Added the 'vLLM Variables' tab under 'Model Compatibility'
<img width="386" height="1008" alt="image" src="https://github.com/user-attachments/assets/7a660d33-163a-4b62-8c2c-74ad7194ea75" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
