### PR TITLE
MCP Execution Modal Clarity Update

### DIFF
--- a/lib/user-interface/react/src/components/chatbot/Chat.tsx
+++ b/lib/user-interface/react/src/components/chatbot/Chat.tsx
@@ -815,18 +815,16 @@ export default function Chat ({ sessionId }) {
             {toolApprovalModal && (
                 <ConfirmationModal
                     action='Execute'
-                    resourceName={`Tool: ${toolApprovalModal.tool.name}`}
+                    title={'Confirm MCP Tool Execution'}
                     onConfirm={handleToolApproval}
                     onDismiss={handleToolRejection}
                     description={
-                        <SpaceBetween size='m' direction='vertical'>
-                            <SpaceBetween size='s' direction='vertical'>
-                                <p>The AI is about to execute the following tool:</p>
-                                <p><strong>Tool Name:</strong> {toolApprovalModal.tool.name}</p>
-                                <p><strong>MCP Server:</strong> {toolToServerMap.get(toolApprovalModal.tool.name)}</p>
-                                <p><strong>Arguments:</strong></p>
+                        <SpaceBetween size='xs' direction='vertical'>
+                            <SpaceBetween size='xs' direction='vertical'>
+                                <div><strong>MCP Server:</strong> {toolToServerMap.get(toolApprovalModal.tool.name)}</div>
+                                <div><strong>MCP Tool:</strong> {toolApprovalModal.tool.name}</div>
+                                <div><strong>Details:</strong></div>
                                 {JSON.stringify(toolApprovalModal.tool.args).replace('{', '').replace('}', '')}
-                                <p><strong>Do you want to allow this tool execution?</strong></p>
                             </SpaceBetween>
                             <hr />
                             {updatingAutoApprovalForTool === toolApprovalModal.tool.name ? (


### PR DESCRIPTION
### Summary
- Update the MCP Tool Execution Modal to be more concise and remove duplicate information
    - Remove duplicate mention of the tool name
    - Remove excess spacing from content
    - Remove “do you want to allow this tool execution” as its already mentioned above
    - change "arguments" to "details"

### Example of Change Image
<img width="832" height="401" alt="image" src="https://github.com/user-attachments/assets/f23df02f-1955-44c8-9e12-8ef07731ca6f" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
