### PR TITLE
fix: update devcontainer base image and unpin pip dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "LISA Dev Container",
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.13-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/base:bookworm",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"moby": true,
@@ -50,7 +50,7 @@
 
 	"mounts": [
 		"source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,readonly,type=bind"
-	 ],
+	],
 
 	"postCreateCommand": "./.devcontainer/post_create_command.sh",
 

--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -14,7 +14,7 @@ echo "alias deploylisa='make clean && npm ci && make deploy HEADLESS=true'" >> ~
 echo "alias deploylisa='make clean && npm ci && make deploy HEADLESS=true'" >> ~/.zshrc
 
 python -m pip install --upgrade pip
-pip3 install yq==3.4.3 huggingface_hub==0.26.3 s5cmd==2.2.2
+pip3 install yq huggingface_hub s5cmd
 make installPythonRequirements
 
 make createTypeScriptEnvironment


### PR DESCRIPTION
- Change base image from python:1-3.13-bookworm to base:bookworm
  since Python is already installed via the devcontainer feature
- Remove pinned versions for yq, huggingface_hub, and s5cmd to
  always use latest
- Fix whitespace in mounts array

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
