### PR TITLE
Add VLLM_ASYNC_SCHEDULING environment variable to enable vLLM's async…

### DIFF
--- a/lib/docs/config/vllm_variables.md
+++ b/lib/docs/config/vllm_variables.md
@@ -27,6 +27,7 @@ LISA Serve supports configuring vLLM model serving through environment variables
 | `VLLM_MAX_NUM_SEQS` | Maximum concurrent sequences | `256` | `128`, `512` |
 | `VLLM_ENABLE_PREFIX_CACHING` | Enable prefix caching for repeated prompts | `false` | `true` |
 | `VLLM_ENABLE_CHUNKED_PREFILL` | Enable chunked prefill | `false` | `true` |
+| `VLLM_ASYNC_SCHEDULING` | Adds --async-scheduling for higher performance if hardware supported | `false` | `true` |
 
 ## Parallel Processing
 

--- a/lib/serve/ecs-model/vllm/src/entrypoint.sh
+++ b/lib/serve/ecs-model/vllm/src/entrypoint.sh
@@ -43,6 +43,7 @@ declare -a vars=("S3_BUCKET_MODELS" "LOCAL_MODEL_PATH" "MODEL_NAME" "S3_MOUNT_PO
 #   VLLM_BLOCK_SIZE - Memory block size (8/16/32)
 #   VLLM_SEED - Random seed for reproducibility
 #   VLLM_FLOAT32_MATMUL_PRECISION - Float32 matmul precision (ieee/tf32)
+#   VLLM_ASYNC_SCHEDULING - Adds --async-scheduling for higher performance
 #
 # ATTENTION & BACKENDS:
 #   VLLM_ATTENTION_BACKEND - Attention backend (FLASH_ATTN/XFORMERS/ROCM_FLASH/TORCH_SDPA/FLASHINFER/etc)
@@ -257,6 +258,11 @@ fi
 if [[ -n "${VLLM_TOOL_CALL_PARSER}" ]]; then
     ADDITIONAL_ARGS="${ADDITIONAL_ARGS} --tool-call-parser ${VLLM_TOOL_CALL_PARSER}"
     echo "  --tool-call-parser ${VLLM_TOOL_CALL_PARSER}"
+fi
+
+if [[ "${VLLM_ASYNC_SCHEDULING}" == "true" ]]; then
+    ADDITIONAL_ARGS="${ADDITIONAL_ARGS} --async-scheduling"
+    echo "  --async-scheduling"
 fi
 
 echo "Starting vLLM with args: ${ADDITIONAL_ARGS}"


### PR DESCRIPTION
### Summary
- Add VLLM_ASYNC_SCHEDULING environment variable to enable vLLM's async scheduling mode for improved performance. When set to "true", the entrypoint script now passes the --async-scheduling flag to the vLLM server.
- **NOTE this was a recommended parameter for gpt-oss-20B and gpt-oss-120B**
  - Specifically on Ampere architecture, such as A10G (g5 instances)
- Also added relevant documentation updates

### References
- [vLLM Docs](https://docs.vllm.ai/projects/recipes/en/latest/OpenAI/GPT-OSS.html#quickstart)
- [g5 Instance Description](https://aws.amazon.com/ec2/instance-types/g5/)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
