### PR TITLE
Admin Chat Stack Configuration and Management Page Skeleton

### DIFF
--- a/lib/chat/api/configuration.ts
+++ b/lib/chat/api/configuration.ts
@@ -126,6 +126,7 @@ export class ConfigurationApi extends Construct {
                                         'mcpConnections': { 'BOOL': config.deployMcp ? 'True' : 'False' },
                                         'modelLibrary': { 'BOOL': 'True' },
                                         'encryptSession': { 'BOOL': 'False' },
+                                        'chatAssistantStacks': { 'BOOL': 'False' },
                                     }
                                 },
                                 'systemBanner': {

--- a/lib/user-interface/react/src/App.tsx
+++ b/lib/user-interface/react/src/App.tsx
@@ -36,6 +36,7 @@ import UserApiToken from './pages/UserApiToken';
 import NotificationBanner from './shared/notification/notification';
 import ConfirmationModal, { ConfirmationModalProps } from './shared/modal/confirmation-modal';
 import Configuration from './pages/Configuration';
+import ChatAssistantStacks from './pages/ChatAssistantStacks';
 import { useGetConfigurationQuery } from './shared/reducers/configuration.reducer';
 import { IConfiguration } from './shared/model/configuration.model';
 import DocumentLibrary from './pages/DocumentLibrary';
@@ -266,6 +267,14 @@ function App () {
                                     </AdminRoute>
                                 }
                             />
+                            {config?.configuration?.enabledComponents?.chatAssistantStacks && <Route
+                                path='chat-assistant-stacks'
+                                element={
+                                    <AdminRoute>
+                                        <ChatAssistantStacks setNav={setNav} />
+                                    </AdminRoute>
+                                }
+                            />}
                             {config?.configuration?.enabledComponents?.mcpConnections && <Route
                                 path='mcp-connections/*'
                                 element={

--- a/lib/user-interface/react/src/components/Topbar.tsx
+++ b/lib/user-interface/react/src/components/Topbar.tsx
@@ -190,6 +190,15 @@ function Topbar ({ configs }: TopbarProps): ReactElement {
                                     href: '/mcp-management',
                                 } as ButtonDropdownProps.Item,
                             ] : []),
+                            ...(configs?.configuration?.enabledComponents?.chatAssistantStacks ? [{
+                                id: 'chat-assistant-stacks',
+                                type: 'button',
+                                variant: 'link',
+                                text: 'Chat Assistant Stacks',
+                                disableUtilityCollapse: false,
+                                external: false,
+                                href: '/chat-assistant-stacks',
+                            } as ButtonDropdownProps.Item] : []),
                             ...(configs?.configuration.enabledComponents?.showMcpWorkbench ? [{
                                 id: 'mcp-workbench',
                                 type: 'button',

--- a/lib/user-interface/react/src/components/configuration/ActivatedUserComponents.tsx
+++ b/lib/user-interface/react/src/components/configuration/ActivatedUserComponents.tsx
@@ -42,6 +42,7 @@ const advancedOptions = {
     editChatHistoryBuffer: 'Edit chat history buffer',
     enableModelComparisonUtility: 'Model Comparison Utility',
     encryptSession: 'Session Encryption',
+    chatAssistantStacks: 'Chat Assistant Stacks',
 };
 
 const mcpOptions = {

--- a/lib/user-interface/react/src/components/configuration/ChatAssistantStacksConfiguration.tsx
+++ b/lib/user-interface/react/src/components/configuration/ChatAssistantStacksConfiguration.tsx
@@ -1,0 +1,150 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import React, { useMemo, useState } from 'react';
+import {
+    Box,
+    Button,
+    ButtonDropdown,
+    Cards,
+    Container,
+    Header,
+    SpaceBetween,
+    TextFilter,
+} from '@cloudscape-design/components';
+import { RefreshButton } from '@/components/common/RefreshButton';
+
+export type ChatAssistantStackPlaceholder = {
+    stackId: string;
+    name: string;
+    description: string;
+};
+
+const CARD_DEFINITION = {
+    header: (item: ChatAssistantStackPlaceholder) => item.name,
+    sections: [
+        {
+            id: 'description',
+            header: 'Description',
+            content: (item: ChatAssistantStackPlaceholder) => item.description || '—',
+        },
+    ],
+};
+
+export function ChatAssistantStacksConfiguration (): React.ReactElement {
+    const [searchText, setSearchText] = useState('');
+    const [isRefreshing, setIsRefreshing] = useState(false);
+    const [selectedItems, setSelectedItems] = useState<ChatAssistantStackPlaceholder[]>([]);
+
+    // Placeholder: no API yet – empty list. When API exists, replace with query and filter by name/description.
+    const stacks: ChatAssistantStackPlaceholder[] = [];
+    const filteredStacks = useMemo(() => {
+        if (!searchText.trim()) return stacks;
+        const lower = searchText.toLowerCase();
+        return stacks.filter(
+            (s) =>
+                s.name.toLowerCase().includes(lower) ||
+                (s.description && s.description.toLowerCase().includes(lower))
+        );
+    }, [searchText]);
+
+    const handleRefresh = () => {
+        setIsRefreshing(true);
+        // TODO: refetch stacks when API exists
+        setTimeout(() => setIsRefreshing(false), 500);
+    };
+
+    const handleCreateStack = () => {
+        // TODO: open Create Stack modal (AS-4)
+    };
+
+    const actionsDropdownItems = [
+        { id: 'update', text: 'Update', disabled: selectedItems.length !== 1 },
+        { id: 'delete', text: 'Delete', disabled: selectedItems.length !== 1 },
+        { id: 'activate', text: 'Activate', disabled: selectedItems.length !== 1 },
+        { id: 'deactivate', text: 'Deactivate', disabled: selectedItems.length !== 1 },
+    ];
+
+    return (
+        <Container
+            header={
+                <Header variant='h2'>
+                    Chat Assistant Stacks
+                </Header>
+            }
+        >
+            <Cards
+                variant='full-page'
+                trackBy='stackId'
+                cardDefinition={CARD_DEFINITION}
+                cardsPerRow={[{ cards: 3 }]}
+                items={filteredStacks}
+                selectedItems={selectedItems}
+                onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+                selectionType='single'
+                loading={isRefreshing}
+                loadingText='Loading stacks'
+                header={
+                    <Header
+                        counter={filteredStacks.length > 0 ? `(${filteredStacks.length})` : undefined}
+                        actions={
+                            <SpaceBetween direction='horizontal' size='xs'>
+                                <RefreshButton
+                                    isLoading={isRefreshing}
+                                    onClick={handleRefresh}
+                                    ariaLabel='Refresh stacks'
+                                />
+                                <ButtonDropdown
+                                    items={actionsDropdownItems}
+                                    variant='primary'
+                                    disabled={selectedItems.length === 0}
+                                    onItemClick={() => {
+                                        // TODO: handle Actions (AS-4–AS-7)
+                                    }}
+                                >
+                                    Actions
+                                </ButtonDropdown>
+                                <Button variant='primary' onClick={handleCreateStack}>
+                                    Create Stack
+                                </Button>
+                            </SpaceBetween>
+                        }
+                    >
+                        Stacks
+                    </Header>
+                }
+                filter={
+                    <TextFilter
+                        filteringText={searchText}
+                        filteringPlaceholder='Search by name or description'
+                        filteringAriaLabel='Search stacks'
+                        onChange={({ detail }) => setSearchText(detail.filteringText)}
+                    />
+                }
+                empty={
+                    <Box margin={{ vertical: 'xs' }} textAlign='center' color='inherit'>
+                        <SpaceBetween size='m'>
+                            <b>No stacks</b>
+                            <span>Create a stack to bundle models, repos, MCP servers, and prompts for users.</span>
+                        </SpaceBetween>
+                    </Box>
+                }
+            />
+        </Container>
+    );
+}
+
+export default ChatAssistantStacksConfiguration;

--- a/lib/user-interface/react/src/pages/ChatAssistantStacks.tsx
+++ b/lib/user-interface/react/src/pages/ChatAssistantStacks.tsx
@@ -1,0 +1,28 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import { ReactElement, useEffect } from 'react';
+import ChatAssistantStacksConfiguration from '../components/configuration/ChatAssistantStacksConfiguration';
+
+export function ChatAssistantStacks ({ setNav }): ReactElement {
+    useEffect(() => {
+        setNav(null);
+    }, [setNav]);
+
+    return <ChatAssistantStacksConfiguration />;
+}
+
+export default ChatAssistantStacks;

--- a/lib/user-interface/react/src/shared/model/configuration.model.ts
+++ b/lib/user-interface/react/src/shared/model/configuration.model.ts
@@ -39,6 +39,7 @@ export type IEnabledComponents = {
     modelLibrary: boolean;
     encryptSession: boolean;
     enableUserApiTokens: boolean;
+    chatAssistantStacks: boolean;
 };
 
 export type ISystemBannerConfiguration = {
@@ -91,6 +92,7 @@ export const enabledComponentsSchema = z.object({
     enableModelComparisonUtility: z.boolean().default(false),
     encryptSession: z.boolean().default(false),
     enableUserApiTokens: z.boolean().default(false),
+    chatAssistantStacks: z.boolean().default(false),
 });
 
 export const globalConfigSchema = z.object({

--- a/package-lock.json
+++ b/package-lock.json
@@ -270,6 +270,7 @@
       "version": "7.3.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -515,6 +516,7 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.47.0.tgz",
       "integrity": "sha512-b5hlU69CuhnS2Rqgsz7uSW0t4VqrLMLTPbUpEl0QVz56rsSwr1Sugyogrjb493sWDA+XU1FU5m9eB8uH7MoI0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.47.0",
         "@algolia/requester-browser-xhr": "5.47.0",
@@ -709,6 +711,7 @@
         "semver"
       ],
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "jsonschema": "~1.4.1",
         "semver": "^7.7.2"
@@ -1255,7 +1258,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.972.1.tgz",
       "integrity": "sha512-epXDCJWnaPraPQ8ZXE1AA6T/wMPw+jQqtQThuOTHFyvjAFezGAYqF+DHBUsJE7DqZXRLRR3v4ammtTaYC6uhvQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.0",
         "@smithy/core": "^3.21.0",
@@ -1276,7 +1278,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.1.tgz",
       "integrity": "sha512-w9TVoCUNwPG4njcbnZpSQaOZ1BF2z1Guox8NltoXm7oS1+q/8iHeG8eqY9TlGQsKLNA4KfnKUEAx4rlEc6Qv6w==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "mnemonist": "0.38.3",
         "tslib": "^2.6.2"
@@ -1290,7 +1291,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.1.tgz",
       "integrity": "sha512-3d6QaHQAjevuCioG0lZmZM/Nb8mT4JiF2mRmlh/aTM32Fc/YNGxp2Qbri8B8nfeYlfoi8GM12gH7SaIwkihuBQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/endpoint-cache": "^3.972.1",
         "@aws-sdk/types": "^3.973.0",
@@ -1616,6 +1616,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2127,7 +2128,8 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
       "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@chevrotain/cst-dts-gen": {
       "version": "11.0.3",
@@ -2219,6 +2221,7 @@
       "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.1181.tgz",
       "integrity": "sha512-znT/MKJCb0ANsa0Q/7KCFodaA9tTOJqipTIhvqvKLa9SL8kx9SY2va5tX/3eJVMefKoVzyKuWtzyRw0WZoS/pg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@cloudscape-design/collection-hooks": "^1.0.0",
         "@cloudscape-design/component-toolkit": "^1.0.0-beta",
@@ -2386,6 +2389,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2429,6 +2433,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2511,6 +2516,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -3374,6 +3380,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.1.0.tgz",
       "integrity": "sha512-fNxRUk1KhjSbnbuBxlWSnBLKLBNun52ZBTcs22H/xEEzM6Ap81ZFTQ4bZBxVQGQgVY0xugKGoRcCbaKjLQ3XZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "7.1.0"
       },
@@ -4093,6 +4100,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.16.tgz",
       "integrity": "sha512-2XKQKxvQdeQiuIo0tacAmDVojhSVAci8D2WDdmmyN+6CqDusLHEHyIDaOt4o+UBvpkyHXbCdrljzDTQY/AKeqg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -6266,7 +6274,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6277,7 +6284,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6291,7 +6297,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6306,8 +6311,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -6429,8 +6433,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.159",
@@ -6916,6 +6919,7 @@
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -6938,6 +6942,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6948,6 +6953,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -7117,6 +7123,7 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -7745,6 +7752,7 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -8066,6 +8074,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8181,6 +8190,7 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.47.0.tgz",
       "integrity": "sha512-AGtz2U7zOV4DlsuYV84tLp2tBbA7RPtLA44jbVH4TTpDcc1dIWmULjHSsunlhscbzDydnjuFlNhflR3nV4VJaQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.13.0",
         "@algolia/client-abtesting": "5.47.0",
@@ -8619,6 +8629,7 @@
         "mime-types"
       ],
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.263",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
@@ -9318,6 +9329,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10031,7 +10043,8 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.5.tgz",
       "integrity": "sha512-fOoP70YLevMZr5avJHx2DU3LNYmC6wM8OwdrNewMZou1kZnPGOeVzBrRjZNgFDHUlulYUjkpFRSpTE3D+n+ZSg==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -10633,6 +10646,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -11024,6 +11038,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11569,8 +11584,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -11942,6 +11956,7 @@
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -12012,6 +12027,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -12072,6 +12088,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -13018,6 +13035,7 @@
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
       "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tabbable": "^6.4.0"
       }
@@ -14986,6 +15004,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -16191,6 +16210,7 @@
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
       "devOptional": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -16836,7 +16856,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -17380,6 +17399,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -17415,6 +17435,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "decode-named-character-reference": "^1.0.0",
         "devlop": "^1.0.0",
@@ -18093,7 +18114,6 @@
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "obliterator": "^1.6.1"
       }
@@ -18395,8 +18415,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
       "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -18414,6 +18433,7 @@
       "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.4.1.tgz",
       "integrity": "sha512-jNdst/U28Iasukx/L5MP6b274Vr7ftQs6qAhPBCvz6Wt5rPCA+Q/tUmCzfCHHWweWw5szeMy2Gfrm1rITwUKrw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "jwt-decode": "^4.0.0"
       },
@@ -19223,6 +19243,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -19475,6 +19496,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19501,6 +19523,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -19571,6 +19594,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -19755,7 +19779,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-mock-store": {
       "version": "1.5.5",
@@ -21638,6 +21663,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -21724,6 +21750,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -21931,6 +21958,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22429,6 +22457,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -22502,6 +22531,7 @@
       "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
       "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docsearch/css": "3.8.2",
         "@docsearch/js": "3.8.2",
@@ -22555,6 +22585,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -22685,6 +22716,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -22808,6 +22840,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.27.tgz",
       "integrity": "sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.27",
         "@vue/compiler-sfc": "3.5.27",
@@ -23192,6 +23225,7 @@
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -23270,6 +23304,7 @@
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -23407,6 +23442,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -23416,6 +23452,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
       "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }
@@ -23468,6 +23505,7 @@
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }


### PR DESCRIPTION
*Description of changes:*
- Added admin toggle in configuration to turn on Chat Assistant Stacks
- Added chat assistant stack management page that will be used to:
  -  list out the current stacks
  - create stacks
  - update stacks
  - delete stacks
 - Added search bar to management page
 - Added conditional route rendering logic that will only route if user is an admin and if configuration item is enabled.

<img width="618" height="505" alt="Screenshot 2026-02-17 at 2 24 37 PM" src="https://github.com/user-attachments/assets/17a7bf46-8ce9-4b9e-9486-5f7a821cdb82" />

<img width="1708" height="419" alt="Screenshot 2026-02-17 at 2 24 57 PM" src="https://github.com/user-attachments/assets/9b7efccb-47d5-458b-9b9b-19a8600e5f9b" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
