### PR TITLE
bug: remove duplicate timestamp

### DIFF
--- a/lib/user-interface/react/src/components/chatbot/Chat.tsx
+++ b/lib/user-interface/react/src/components/chatbot/Chat.tsx
@@ -999,16 +999,6 @@ export default function Chat ({ sessionId }) {
                             openModal={openModal}
                         />
                     )}
-                    {!loadingSession && session.history.length > 0 && session.lastUpdated && (
-                        <Box textAlign='center' padding='s'>
-                            <Box variant='small' color='text-status-inactive'>
-                                Last updated: {new Date(session.lastUpdated).toLocaleString(undefined, {
-                                    timeStyle: 'short',
-                                    dateStyle: 'medium'
-                                })}
-                            </Box>
-                        </Box>
-                    )}
                     <div ref={bottomRef} />
                 </SpaceBetween>
             </div>


### PR DESCRIPTION
## Fix duplicate session timestamp in chat messages pane

### Description:

- A bad rebase introduced a duplicate "Last updated" timestamp into the chat messages scroll pane. The timestamp was already correctly displayed below the user prompt input, so the copy inside the messages pane was redundant.

### Changes:

- Removed the duplicate session.lastUpdated timestamp block from the chat messages scroll container in Chat.tsx

### Testing:

- Verify the "Last updated" timestamp appears only once, below the prompt input
- Verify existing sessions load and display correctly with no timestamp in the message history pane

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
