### PR TITLE
Claude code anthropic model fix

### DIFF
--- a/lib/serve/serveApplicationConstruct.ts
+++ b/lib/serve/serveApplicationConstruct.ts
@@ -314,6 +314,7 @@ export class LisaServeApplicationConstruct extends Construct {
             container.addEnvironment('LITELLM_DB_INFO_PS_NAME', litellmDbConnectionInfoPs.parameterName);
             container.addEnvironment('GUARDRAILS_TABLE_NAME', guardrailsTableName);
             container.addEnvironment('GENERATED_IMAGES_S3_BUCKET_NAME', imagesBucketName);
+            container.addEnvironment('MODEL_INFO_CACHE_TTL', '300');
             // Add metrics queue URL if provided
             if (props.metricsQueueUrl) {
                 // Get the queue URL from SSM parameter


### PR DESCRIPTION
## Summary

An issue with `max_tokens` handling for models routed through the Anthropic-compatible endpoint would prevent claude-code from working with anthropic models. 

## Problem

LISA dropped the max_tokens parameter from Anthropic requests so liteLLM handled the max_tokens.  This parameter is required for anthropic models however and would cause an error when talking to anthropic models provided by bedrock.

## Solution

- Added `get_model_info()` to fetch model provider from LiteLLM API
  - Used to extract the provider path from litellm
- Only reset `max_tokens` when model is **not** an Anthropic model (check for `.anthropic` substring)

## Testing

validated cache logs printed expected values:
- /v2/serve/chat/completions | NO_EVENT | NO_STATUS | Cached model info for sonnet-4-5-2
-  ...
- /v2/serve/chat/completions | NO_EVENT | NO_STATUS | Cache hit for model sonnet-4-5-2 (age: 165.6s)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
