### PR TITLE
Fix/smoke tests

### DIFF
--- a/cypress/src/smoke/fixtures/project.json
+++ b/cypress/src/smoke/fixtures/project.json
@@ -2,13 +2,13 @@
   {
     "projectId": "proj-001",
     "name": "Research",
-    "createTime": "2026-01-15T10:00:00.000000+00:00",
-    "lastUpdated": "2026-01-15T10:00:00.000000+00:00"
+    "_createDaysAgo": 45,
+    "_updatedDaysAgo": 30
   },
   {
     "projectId": "proj-002",
     "name": "Product Dev",
-    "createTime": "2026-01-10T14:30:00.000000+00:00",
-    "lastUpdated": "2026-01-20T09:15:00.000000+00:00"
+    "_createDaysAgo": 50,
+    "_updatedDaysAgo": 35
   }
 ]

--- a/cypress/src/smoke/fixtures/session.json
+++ b/cypress/src/smoke/fixtures/session.json
@@ -3,9 +3,9 @@
     "sessionId": "f56fc284-629c-4ba7-ab3d-56f4a21c13ee",
     "name": "Technical Discussion",
     "firstHumanMessage": "What is the difference between REST and GraphQL?",
-    "startTime": "2026-01-02T08:30:00.000000+00:00",
-    "createTime": "2026-01-02T08:30:00.000000+00:00",
-    "lastUpdated": "2026-01-02T09:15:00.000000+00:00",
+    "_startDaysAgo": 46,
+    "_updatedDaysAgo": 45,
+    "_expectedBucket": "Last 3 Months",
     "projectId": "proj-001",
     "isEncrypted": false
   },
@@ -13,9 +13,9 @@
     "sessionId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
     "name": "Product Questions",
     "firstHumanMessage": "Tell me about the product features",
-    "startTime": "2026-01-01T14:20:00.000000+00:00",
-    "createTime": "2026-01-01T14:20:00.000000+00:00",
-    "lastUpdated": "2026-01-01T15:45:00.000000+00:00",
+    "_startDaysAgo": 61,
+    "_updatedDaysAgo": 60,
+    "_expectedBucket": "Last 3 Months",
     "projectId": "proj-001",
     "isEncrypted": false
   },
@@ -23,9 +23,9 @@
     "sessionId": "12345678-90ab-cdef-1234-567890abcdef",
     "name": null,
     "firstHumanMessage": "How do I get started with the platform?",
-    "startTime": "2025-12-28T10:00:00.000000+00:00",
-    "createTime": "2025-12-28T10:00:00.000000+00:00",
-    "lastUpdated": "2025-12-28T11:30:00.000000+00:00",
+    "_startDaysAgo": 51,
+    "_updatedDaysAgo": 50,
+    "_expectedBucket": "Last 3 Months",
     "isEncrypted": false
   }
 ]

--- a/cypress/src/smoke/support/commands.ts
+++ b/cypress/src/smoke/support/commands.ts
@@ -55,9 +55,9 @@ let mockSessions: Array<{
  * Setup stateful project stubs that track mutations.
  */
 function setupProjectStubs (apiBase: string) {
-    // Initialize from fixture
+    // Initialize from fixture with dynamic dates computed from _*DaysAgo metadata
     cy.fixture('project.json').then((fixtureProjects) => {
-        mockProjects = [...fixtureProjects];
+        mockProjects = fixtureProjects.map(applyDateOffsets) as typeof mockProjects;
     });
 
     // GET projects - returns current state
@@ -129,12 +129,54 @@ function setupProjectStubs (apiBase: string) {
 }
 
 /**
+ * Compute a date relative to now, offset by the given number of days.
+ */
+function daysAgo (days: number): string {
+    const date = new Date();
+    date.setDate(date.getDate() - days);
+    return date.toISOString();
+}
+
+/**
+ * Transforms a fixture entry by converting underscore-prefixed day-offset
+ * metadata fields (_startDaysAgo, _updatedDaysAgo, _createDaysAgo) into
+ * real ISO date strings, then strips the metadata fields.
+ *
+ * This keeps fixture JSON files as the single source of truth for both
+ * API shape and timing intent. See Sessions.tsx for bucket boundaries:
+ * Last Day (<=1), Last 7 Days (<=7), Last Month (<=30),
+ * Last 3 Months (<=90), Older (>90).
+ */
+function applyDateOffsets (fixture: Record<string, unknown>): Record<string, unknown> {
+    const result = { ...fixture };
+
+    if (typeof result._startDaysAgo === 'number') {
+        result.startTime = daysAgo(result._startDaysAgo as number);
+        result.createTime = daysAgo(result._startDaysAgo as number);
+    }
+    if (typeof result._createDaysAgo === 'number') {
+        result.createTime = daysAgo(result._createDaysAgo as number);
+    }
+    if (typeof result._updatedDaysAgo === 'number') {
+        result.lastUpdated = daysAgo(result._updatedDaysAgo as number);
+    }
+
+    // Strip metadata fields before using as mock API response
+    delete result._startDaysAgo;
+    delete result._createDaysAgo;
+    delete result._updatedDaysAgo;
+    delete result._expectedBucket;
+
+    return result;
+}
+
+/**
  * Setup stateful session stubs that track mutations.
  */
 function setupSessionStubs (apiBase: string) {
-    // Initialize from fixture
+    // Initialize from fixture with dynamic dates computed from _*DaysAgo metadata
     cy.fixture('session.json').then((fixtureSessions) => {
-        mockSessions = [...fixtureSessions];
+        mockSessions = fixtureSessions.map(applyDateOffsets) as typeof mockSessions;
     });
 
     // GET sessions - returns current state


### PR DESCRIPTION
 ## Summary
 - Replaced hardcoded dates in smoke test fixtures (`session.json`, `project.json`) with `_*DaysAgo` metadata fields that are computed relative to the current date at runtime
 - Added generic `applyDateOffsets()` helper in `commands.ts` that converts metadata fields to real ISO dates and strips them before serving mock API responses
 - Prevents smoke test failures caused by fixture dates drifting out of expected time-group buckets (Last Day, Last 7 Days, Last Month, Last 3 Months, Older)

 ## Test plan
 - [x] Ran smoke tests locally — all 18 passing, 0 failing
 - [x] Verify CI smoke tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
