### PR TITLE
fix: Session naming shows RAG context instead of user prompt

### DIFF
--- a/cypress/src/smoke/support/index.ts
+++ b/cypress/src/smoke/support/index.ts
@@ -17,6 +17,8 @@
 import './commands';
 import '../../support/adminHelpers';
 
+Cypress.on('uncaught:exception', (err) => !err.message.includes('ResizeObserver loop'));
+
 declare global {
     // eslint-disable-next-line @typescript-eslint/no-namespace
     namespace Cypress {

--- a/lambda/session/lambda_functions.py
+++ b/lambda/session/lambda_functions.py
@@ -258,19 +258,24 @@ def _strip_context_from_display_text(text: str) -> str:
     if not any(cleaned.startswith(prefix) for prefix in context_prefixes):
         return cleaned
 
+    # File context in separate item from the prompt
     if cleaned.startswith(file_context_prefix):
         return ""
 
-    # Older sessions may have merged context + prompt into one text blob.
-    # Keep only the final user prompt for session list display.
-    parts = [part.strip() for part in cleaned.split("\n\n") if part.strip()]
-    if parts:
-        tail = parts[-1]
-        if not any(tail.startswith(prefix) for prefix in context_prefixes):
-            return tail
+    # RAG context handling - distinguish between modern (separate items) and legacy (merged) formats
+    if cleaned.startswith(rag_context_prefix):
+        parts = [part.strip() for part in cleaned.split("\n\n") if part.strip()]
+        if len(parts) > 1:
+            # check if last part is the user prompt
+            tail = parts[-1]
+            if not any(tail.startswith(prefix) for prefix in context_prefixes):
+                # Legacy merged format
+                return tail
 
-    lines = [line.strip() for line in cleaned.splitlines() if line.strip()]
-    return lines[-1] if lines else ""
+        # Modern format or context-only
+        return ""
+
+    return cleaned
 
 
 def _find_first_human_message(session: dict, user_id: str | None = None) -> str:

--- a/lambda/session/lambda_functions.py
+++ b/lambda/session/lambda_functions.py
@@ -251,28 +251,9 @@ def _map_session(
 
 def _strip_context_from_display_text(text: str) -> str:
     cleaned = text.strip()
-    file_context_prefix = "File context:"
-    rag_context_prefix = "Context from document search:"
-    context_prefixes = (file_context_prefix, rag_context_prefix)
+    context_prefixes = ("File context:", "Context from document search:")
 
-    if not any(cleaned.startswith(prefix) for prefix in context_prefixes):
-        return cleaned
-
-    # File context in separate item from the prompt
-    if cleaned.startswith(file_context_prefix):
-        return ""
-
-    # RAG context handling - distinguish between modern (separate items) and legacy (merged) formats
-    if cleaned.startswith(rag_context_prefix):
-        parts = [part.strip() for part in cleaned.split("\n\n") if part.strip()]
-        if len(parts) > 1:
-            # check if last part is the user prompt
-            tail = parts[-1]
-            if not any(tail.startswith(prefix) for prefix in context_prefixes):
-                # Legacy merged format
-                return tail
-
-        # Modern format or context-only
+    if any(cleaned.startswith(prefix) for prefix in context_prefixes):
         return ""
 
     return cleaned

--- a/test/lambda/test_session_lambda.py
+++ b/test/lambda/test_session_lambda.py
@@ -868,6 +868,47 @@ def test_find_first_human_message_unencrypted_list_content_with_file_context():
     assert result == "Actual question"
 
 
+def test_find_first_human_message_with_rag_context():
+    """Test _find_first_human_message with RAG context in separate text items (modern sessions)."""
+    session = {
+        "sessionId": "test-session",
+        "is_encrypted": False,
+        "history": [
+            {
+                "type": "human",
+                "content": [
+                    {"text": "Context from document search:\nDocument 1 content\nDocument 2 content"},
+                    {"text": "What is the answer to my question?"},
+                ],
+            }
+        ],
+    }
+
+    result = _find_first_human_message(session, "test-user")
+    assert result == "What is the answer to my question?"
+
+
+def test_find_first_human_message_with_rag_and_file_context():
+    """Test _find_first_human_message with both file context and RAG context."""
+    session = {
+        "sessionId": "test-session",
+        "is_encrypted": False,
+        "history": [
+            {
+                "type": "human",
+                "content": [
+                    {"text": "File context: uploaded_file.txt\nFile content here"},
+                    {"text": "Context from document search:\nRAG document content"},
+                    {"text": "User's actual prompt here"},
+                ],
+            }
+        ],
+    }
+
+    result = _find_first_human_message(session, "test-user")
+    assert result == "User's actual prompt here"
+
+
 def test_find_first_human_message_unencrypted_unhandled_content():
     """Test _find_first_human_message with unencrypted session and unhandled content type."""
     session = {

--- a/test/lambda/test_session_lambda.py
+++ b/test/lambda/test_session_lambda.py
@@ -1570,7 +1570,7 @@ def test_map_session_encrypted():
 
 
 def test_map_session_strips_merged_context_from_string_message():
-    """Session summary should hide merged context and show only prompt text."""
+    """Session summary should skip context-prefixed string entirely."""
     session = {
         "sessionId": "test-session",
         "history": [
@@ -1582,7 +1582,7 @@ def test_map_session_strips_merged_context_from_string_message():
     }
 
     result = _map_session(session, "test-user")
-    assert result.firstHumanMessage == "who is dustin?"
+    assert result.firstHumanMessage == ""
 
 
 def test_map_session_strips_context_from_list_message_items():


### PR DESCRIPTION
### Problem
Sessions with RAG enabled were being named with fragments from the RAG document context instead of the actual user prompt.

#### Before
```json
{
 "sessionId": "0cca79dd-b6cc-4ab8-9ba5-d26fa0401f3b",
 "name": null,
 "firstHumanMessage": "Context from document search:", 
 "startTime": "2026-04-14T21:02:34.009360+00:00", 
 "createTime": "2026-04-14T21:02:34.009360+00:00", 
 "lastUpdated": "2026-04-14T21:02:34.009360+00:00", 
 "isEncrypted": false, 
 "projectId": null
}, 
```

#### After
```json
{
 "sessionId": "0cca79dd-b6cc-4ab8-9ba5-d26fa0401f3b", 
 "name": null, 
 "firstHumanMessage": "Tell me about the Nearest Neighbor concept", 
 "startTime": "2026-04-14T21:02:34.009360+00:00", 
 "createTime": "2026-04-14T21:02:34.009360+00:00", 
 "lastUpdated": "2026-04-14T21:02:34.009360+00:00", 
 "isEncrypted": false, 
 "projectId": null
},
```
> See screenshots below for UI impact.

### Root Cause

When RAG is enabled, the frontend sends the first human message as an array with multiple text items:
1. `"Context from document search:\n<documents>"`
2. `"actual user prompt"`

The `_strip_context_from_display_text()` function was not returning empty for `"Context from document search:"` prefixed items, causing `_find_first_human_message()` to use the RAG context as the session name instead of continuing to the next text item containing the actual prompt.

### Fix

Simplified `_strip_context_from_display_text()` to return empty string for any context-prefixed text (`"File context:"` or `"Context from document search:"`), letting `_find_first_human_message()` iterate to the next content item where the actual user prompt lives.

Removed the legacy merged-format fallback that split on `\n\n` to extract a trailing prompt. Analysis of the git history confirmed this fallback was unnecessary:
- The UI has never merged the user prompt into the same text item as context — `userPrompt` is always a separate list item (since `54ce44de`, shipped in v6.4.0)
- The `\n\n` splitting could produce incorrect results if RAG document content itself contained double newlines
- No released version ever stored sessions in the "merged context + prompt" format for the `"Context from document search:"` prefix

### Testing
- Updated test coverage for RAG context scenarios
- Verified fix with actual session data from DynamoDB

#### Before Screenshot
<img width="1253" height="519" alt="Session Name from Rag Context" src="https://github.com/user-attachments/assets/93713cf6-bc8a-4ec9-8654-9267b0dc04e6" />

#### After Screenshot
<img width="1262" height="496" alt="Naming comes from firstHumanMessage" src="https://github.com/user-attachments/assets/be1ca89e-b1e2-4d2a-b9e0-e7da6186027a" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.