### PR TITLE
Ensure permission boundary is applied on dynamic stacks

### DIFF
--- a/ecs_model_deployer/src/lib/index.ts
+++ b/ecs_model_deployer/src/lib/index.ts
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-import { AddPermissionBoundary } from '@cdklabs/cdk-enterprise-iac';
+import { AddPermissionBoundary, ConvertInlinePoliciesToManaged } from '@cdklabs/cdk-enterprise-iac';
 import { App, Aspects } from 'aws-cdk-lib';
 import { LisaModelStack, LisaModelStackProps } from './lisa_model_stack';
 
@@ -42,4 +42,8 @@ const lisaModelStack = new LisaModelStack(app, `${config.deploymentName}-${model
 
 if (config.permissionsBoundaryAspect) {
     Aspects.of(lisaModelStack).add(new AddPermissionBoundary(config.permissionsBoundaryAspect!));
+}
+
+if (config.convertInlinePoliciesToManaged) {
+    Aspects.of(lisaModelStack).add(new ConvertInlinePoliciesToManaged());
 }

--- a/lib/mcp/mcp-server-deployer.ts
+++ b/lib/mcp/mcp-server-deployer.ts
@@ -69,6 +69,8 @@ export class McpServerDeployer extends Construct {
             'taskRole': props.config.roles?.ECSModelTaskRole,
             'certificateAuthorityBundle': props.config.certificateAuthorityBundle,
             'pypiConfig': props.config.pypiConfig,
+            'permissionsBoundaryAspect': props.config.permissionsBoundaryAspect,
+            'convertInlinePoliciesToManaged': props.config.convertInlinePoliciesToManaged,
         };
 
         // Get CDK layer for deployer Lambda

--- a/lib/models/ecs-model-deployer.ts
+++ b/lib/models/ecs-model-deployer.ts
@@ -63,6 +63,7 @@ export class ECSModelDeployer extends Construct {
             's3BucketModels': props.config.s3BucketModels,
             'mountS3DebUrl': props.config.mountS3DebUrl,
             'permissionsBoundaryAspect': props.config.permissionsBoundaryAspect,
+            'convertInlinePoliciesToManaged': props.config.convertInlinePoliciesToManaged,
             'subnets': props.config.subnets,
             'taskRole': props.config.roles?.ECSModelTaskRole,
             'certificateAuthorityBundle': props.config.certificateAuthorityBundle,

--- a/lib/rag/vector-store/vector-store-creator.ts
+++ b/lib/rag/vector-store/vector-store-creator.ts
@@ -185,11 +185,13 @@ export class VectorStoreCreatorStack extends Construct {
             ...pickFields(props.config, [
                 'accountNumber',
                 'appName',
+                'convertInlinePoliciesToManaged',
                 'deploymentName',
                 'deploymentStage',
                 'deploymentPrefix',
                 'iamRdsAuth',
                 'partition',
+                'permissionsBoundaryAspect',
                 'region',
                 'removalPolicy',
                 'subnets',

--- a/mcp_server_deployer/src/lib/index.ts
+++ b/mcp_server_deployer/src/lib/index.ts
@@ -15,7 +15,7 @@
 */
 
 import { App, Aspects } from 'aws-cdk-lib';
-import { AddPermissionBoundary } from '@cdklabs/cdk-enterprise-iac';
+import { AddPermissionBoundary, ConvertInlinePoliciesToManaged } from '@cdklabs/cdk-enterprise-iac';
 import { PartialConfigSchema } from '../../../lib/schema';
 import { LisaMcpStack } from './lisa-mcp-stack';
 import { McpServerConfig } from './utils';
@@ -66,6 +66,10 @@ const stack = new LisaMcpStack(app, stackName!, mcpServerProps);
 
 if (config.permissionsBoundaryAspect) {
     Aspects.of(stack).add(new AddPermissionBoundary(config.permissionsBoundaryAspect!));
+}
+
+if (config.convertInlinePoliciesToManaged) {
+    Aspects.of(stack).add(new ConvertInlinePoliciesToManaged());
 }
 
 app.synth();

--- a/vector_store_deployer/src/lib/index.ts
+++ b/vector_store_deployer/src/lib/index.ts
@@ -64,11 +64,11 @@ if (ragConfig.type === RagRepositoryType.OPENSEARCH) {
 }
 
 
-if (stack && config.permissionsBoundaryAspect) {
+if (config.permissionsBoundaryAspect) {
     Aspects.of(stack).add(new AddPermissionBoundary(config.permissionsBoundaryAspect!));
 }
 
-if (stack && config.convertInlinePoliciesToManaged) {
+if (config.convertInlinePoliciesToManaged) {
     Aspects.of(stack).add(new ConvertInlinePoliciesToManaged());
 }
 

--- a/vector_store_deployer/src/lib/index.ts
+++ b/vector_store_deployer/src/lib/index.ts
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 import { App, Aspects, ValidationError } from 'aws-cdk-lib/core';
-import { AddPermissionBoundary } from '@cdklabs/cdk-enterprise-iac';
+import { AddPermissionBoundary, ConvertInlinePoliciesToManaged } from '@cdklabs/cdk-enterprise-iac';
 import { OpenSearchVectorStoreStack } from './opensearch';
 import { PGVectorStoreStack } from './pgvector';
 import { RagRepositoryDeploymentConfigSchema, RagRepositoryType, PartialConfigSchema } from '../../../lib/schema';
@@ -66,6 +66,10 @@ if (ragConfig.type === RagRepositoryType.OPENSEARCH) {
 
 if (stack && config.permissionsBoundaryAspect) {
     Aspects.of(stack).add(new AddPermissionBoundary(config.permissionsBoundaryAspect!));
+}
+
+if (stack && config.convertInlinePoliciesToManaged) {
+    Aspects.of(stack).add(new ConvertInlinePoliciesToManaged());
 }
 
 app.synth();


### PR DESCRIPTION
Adding inline policy conversion and ensuring permission boundary is applied on dynamic stacks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
