### PR TITLE
fix:batch ingestion container module path after lambda refactor

### DIFF
--- a/lib/rag/ingestion/ingestion-job-construct.ts
+++ b/lib/rag/ingestion/ingestion-job-construct.ts
@@ -186,11 +186,11 @@ export class IngestionJobConstruct extends Construct {
             // Keep the name static so pipeline-ingest events reference latest
             jobDefinitionName: `${config.deploymentName}-${config.deploymentStage}-ingestion-job-def`,
             container: new batch.EcsFargateContainerDefinition(this, 'IngestionJobContainer', {
-                environment: baseEnvironment,
+                environment: { ...baseEnvironment, PYTHONPATH: '/workdir/shared/python' },
                 image,
                 memory: Size.mebibytes(4096),
                 cpu: 2,
-                command: ['-m', 'repository.pipeline_ingestion', 'Ref::ACTION', 'Ref::DOCUMENT_ID'],
+                command: ['-m', 'lisa.rag.pipeline_ingestion', 'Ref::ACTION', 'Ref::DOCUMENT_ID'],
                 jobRole: lambdaRole,
                 executionRole: executionRole,
                 logging: new ecs.AwsLogDriver({

--- a/test/cdk/stacks/__baselines__/LisaApiDeployment.json
+++ b/test/cdk/stacks/__baselines__/LisaApiDeployment.json
@@ -1,6 +1,6 @@
 {
   "Resources": {
-    "Deployment177704854026691957AE3": {
+    "Deployment178044076757980EEC674": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {

--- a/test/cdk/stacks/__baselines__/LisaModels.json
+++ b/test/cdk/stacks/__baselines__/LisaModels.json
@@ -20,6 +20,10 @@
       "Type": "AWS::SSM::Parameter::Value<String>",
       "Default": "/dev/test-lisa/lisa/layerVersion/cdk"
     },
+    "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Type": "AWS::SSM::Parameter::Value<String>",
+      "Default": "/dev/test-lisa/lisa/layerVersion/lisa-shared"
+    },
     "SsmParameterValuedevtestlisalisaappManagementKeySecretNameC96584B6F00A464EAD1953AFF4B05118Parameter": {
       "Type": "AWS::SSM::Parameter::Value<String>",
       "Default": "/dev/test-lisa/lisa/appManagementKeySecretName"
@@ -820,7 +824,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "e0abe7e129573de67fd96a0297ca15c2fb3dee475fb7c9086510d4bd59b908da.zip"
+          "S3Key": "75b0ffe3de7ccc7fc280e85cfa29e4f6c3d91915da97e93f0cd2c42553aca7fb.zip"
         },
         "Environment": {
           "Variables": {
@@ -830,7 +834,7 @@
             "LISA_SECURITY_GROUP_ID": {
               "Fn::ImportValue": "LisaNetworking:ExportsOutputFnGetAttVpcEcsModelAlbSg5FC4C18EGroupId3AE6D77A"
             },
-            "LISA_CONFIG": "{\"appName\":\"lisa\",\"deploymentName\":\"test-lisa\",\"deploymentPrefix\":\"/dev/test-lisa/lisa\",\"region\":\"us-iso-east-1\",\"deploymentStage\":\"dev\",\"removalPolicy\":\"destroy\",\"s3BucketModels\":\"hf-models-gaiic\",\"mountS3DebUrl\":\"https://s3.amazonaws.com/mountpoint-s3-release/latest/x86_64/mount-s3.deb\",\"certificateAuthorityBundle\":\"\",\"pypiConfig\":{\"indexUrl\":\"localhost:8080\",\"trustedHost\":\"localhost\"},\"nvmeContainerMountPath\":\"/nvme\",\"nvmeHostMountPath\":\"/nvme\",\"condaUrl\":\"\"}"
+            "LISA_CONFIG": "{\"appName\":\"lisa\",\"deploymentName\":\"test-lisa\",\"deploymentPrefix\":\"/dev/test-lisa/lisa\",\"region\":\"us-iso-east-1\",\"deploymentStage\":\"dev\",\"removalPolicy\":\"destroy\",\"s3BucketModels\":\"hf-models-gaiic\",\"mountS3DebUrl\":\"https://s3.amazonaws.com/mountpoint-s3-release/latest/x86_64/mount-s3.deb\",\"convertInlinePoliciesToManaged\":false,\"certificateAuthorityBundle\":\"\",\"pypiConfig\":{\"indexUrl\":\"localhost:8080\",\"trustedHost\":\"localhost\"},\"nvmeContainerMountPath\":\"/nvme\",\"nvmeHostMountPath\":\"/nvme\",\"condaUrl\":\"\"}"
           }
         },
         "EphemeralStorage": {
@@ -1041,7 +1045,7 @@
           "cdk-hnb659fds-assets-012345678901-us-iso-east-1"
         ],
         "SourceObjectKeys": [
-          "f87e32c3d678d7000fa7d5aa767f80feb781b448b1d87df4da6692d33d0439c2.zip"
+          "2643ee3205ccd1aabe5f366fd2d51979fe49e1539674787f771f2a770e0dea20.zip"
         ],
         "DestinationBucketName": {
           "Ref": "ModelsApidockerimagebuilderLisaModelsdockerimagebuilderec2bucketA3074A95"
@@ -1240,7 +1244,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "29cc0ee2358fae89979376b3aa5b080fde3ff61a4cb918636c41355087a64a3e.zip"
         },
         "Environment": {
           "Variables": {
@@ -1306,7 +1310,12 @@
           }
         },
         "FunctionName": "LisaModels-docker-image-builder",
-        "Handler": "dockerimagebuilder.handler",
+        "Handler": "lambda_functions.handler",
+        "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          }
+        ],
         "MemorySize": 1024,
         "Role": {
           "Fn::GetAtt": [
@@ -1600,7 +1609,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Description": "Manages Auto Scaling scheduled actions for LISA model scheduling",
         "Environment": {
@@ -1610,8 +1619,11 @@
             }
           }
         },
-        "Handler": "models.scheduling.schedule_management.lambda_handler",
+        "Handler": "lisa.domain.scheduling.schedule_management.lambda_handler",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -1619,6 +1631,7 @@
             "Ref": "SsmParameterValuedevtestlisalisalayerVersionfastapiC96584B6F00A464EAD1953AFF4B05118Parameter"
           }
         ],
+        "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
             "ModelsApiModelsSfnLambdaRoleF400F0BC",
@@ -1655,7 +1668,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Description": "Processes Auto Scaling Group CloudWatch events to update model status",
         "Environment": {
@@ -1671,8 +1684,11 @@
             "REST_API_VERSION": "v2"
           }
         },
-        "Handler": "models.scheduling.schedule_monitoring.lambda_handler",
+        "Handler": "lisa.domain.scheduling.schedule_monitoring.lambda_handler",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -1680,6 +1696,7 @@
             "Ref": "SsmParameterValuedevtestlisalisalayerVersionfastapiC96584B6F00A464EAD1953AFF4B05118Parameter"
           }
         ],
+        "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
             "ModelsApiModelsSfnLambdaRoleF400F0BC",
@@ -1788,7 +1805,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -1831,8 +1848,11 @@
             "MODELS_BUCKET_NAME": "hf-models-gaiic"
           }
         },
-        "Handler": "models.state_machine.create_model.handle_set_model_to_creating",
+        "Handler": "state_machine.create_model.handle_set_model_to_creating",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -1877,7 +1897,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -1920,8 +1940,11 @@
             "MODELS_BUCKET_NAME": "hf-models-gaiic"
           }
         },
-        "Handler": "models.state_machine.create_model.handle_start_copy_docker_image",
+        "Handler": "state_machine.create_model.handle_start_copy_docker_image",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -1966,7 +1989,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -2009,8 +2032,11 @@
             "MODELS_BUCKET_NAME": "hf-models-gaiic"
           }
         },
-        "Handler": "models.state_machine.create_model.handle_poll_docker_image_available",
+        "Handler": "state_machine.create_model.handle_poll_docker_image_available",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -2055,7 +2081,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -2098,8 +2124,11 @@
             "MODELS_BUCKET_NAME": "hf-models-gaiic"
           }
         },
-        "Handler": "models.state_machine.create_model.handle_failure",
+        "Handler": "state_machine.create_model.handle_failure",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -2144,7 +2173,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -2187,8 +2216,11 @@
             "MODELS_BUCKET_NAME": "hf-models-gaiic"
           }
         },
-        "Handler": "models.state_machine.create_model.handle_start_create_stack",
+        "Handler": "state_machine.create_model.handle_start_create_stack",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -2233,7 +2265,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -2276,8 +2308,11 @@
             "MODELS_BUCKET_NAME": "hf-models-gaiic"
           }
         },
-        "Handler": "models.state_machine.create_model.handle_poll_create_stack",
+        "Handler": "state_machine.create_model.handle_poll_create_stack",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -2322,7 +2357,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -2365,8 +2400,11 @@
             "MODELS_BUCKET_NAME": "hf-models-gaiic"
           }
         },
-        "Handler": "models.state_machine.create_model.handle_poll_model_ready",
+        "Handler": "state_machine.create_model.handle_poll_model_ready",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -2411,7 +2449,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -2457,8 +2495,11 @@
             }
           }
         },
-        "Handler": "models.state_machine.schedule_handlers.handle_schedule_creation",
+        "Handler": "state_machine.schedule_handlers.handle_schedule_creation",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -2503,7 +2544,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -2546,8 +2587,11 @@
             "MODELS_BUCKET_NAME": "hf-models-gaiic"
           }
         },
-        "Handler": "models.state_machine.create_model.handle_add_model_to_litellm",
+        "Handler": "state_machine.create_model.handle_add_model_to_litellm",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -2592,7 +2636,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -2635,8 +2679,11 @@
             "MODELS_BUCKET_NAME": "hf-models-gaiic"
           }
         },
-        "Handler": "models.state_machine.create_model.handle_enrich_context_window",
+        "Handler": "state_machine.create_model.handle_enrich_context_window",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -2681,7 +2728,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -2724,8 +2771,11 @@
             "MODELS_BUCKET_NAME": "hf-models-gaiic"
           }
         },
-        "Handler": "models.state_machine.create_model.handle_add_guardrails_to_litellm",
+        "Handler": "state_machine.create_model.handle_add_guardrails_to_litellm",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -3235,7 +3285,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -3253,8 +3303,11 @@
             "RESTAPI_SSL_CERT_ARN": "arn:aws:iam::012345678901:server-certificate/lisa-self-signed-dev"
           }
         },
-        "Handler": "models.state_machine.delete_model.handle_set_model_to_deleting",
+        "Handler": "state_machine.delete_model.handle_set_model_to_deleting",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -3299,7 +3352,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -3317,8 +3370,11 @@
             "RESTAPI_SSL_CERT_ARN": "arn:aws:iam::012345678901:server-certificate/lisa-self-signed-dev"
           }
         },
-        "Handler": "models.state_machine.delete_model.handle_delete_from_litellm",
+        "Handler": "state_machine.delete_model.handle_delete_from_litellm",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -3363,7 +3419,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -3381,8 +3437,11 @@
             "RESTAPI_SSL_CERT_ARN": "arn:aws:iam::012345678901:server-certificate/lisa-self-signed-dev"
           }
         },
-        "Handler": "models.state_machine.delete_model.handle_delete_stack",
+        "Handler": "state_machine.delete_model.handle_delete_stack",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -3427,7 +3486,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -3445,8 +3504,11 @@
             "RESTAPI_SSL_CERT_ARN": "arn:aws:iam::012345678901:server-certificate/lisa-self-signed-dev"
           }
         },
-        "Handler": "models.state_machine.delete_model.handle_monitor_delete_stack",
+        "Handler": "state_machine.delete_model.handle_monitor_delete_stack",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -3491,7 +3553,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -3509,8 +3571,11 @@
             "RESTAPI_SSL_CERT_ARN": "arn:aws:iam::012345678901:server-certificate/lisa-self-signed-dev"
           }
         },
-        "Handler": "models.state_machine.delete_model.handle_delete_from_ddb",
+        "Handler": "state_machine.delete_model.handle_delete_from_ddb",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -3555,7 +3620,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -3573,8 +3638,11 @@
             "RESTAPI_SSL_CERT_ARN": "arn:aws:iam::012345678901:server-certificate/lisa-self-signed-dev"
           }
         },
-        "Handler": "models.state_machine.delete_model.handle_delete_guardrails",
+        "Handler": "state_machine.delete_model.handle_delete_guardrails",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -3619,7 +3687,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -3637,8 +3705,11 @@
             "RESTAPI_SSL_CERT_ARN": "arn:aws:iam::012345678901:server-certificate/lisa-self-signed-dev"
           }
         },
-        "Handler": "models.state_machine.delete_model.handle_failure",
+        "Handler": "state_machine.delete_model.handle_failure",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -4000,7 +4071,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -4019,13 +4090,16 @@
             "LITELLM_CONFIG_OBJ": "{\"db_key\":\"sk-012345\"}"
           }
         },
-        "Handler": "models.state_machine.update_model.handle_job_intake",
+        "Handler": "state_machine.update_model.handle_job_intake",
         "Layers": [
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersionfastapiC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           }
         ],
         "MemorySize": 128,
@@ -4065,7 +4139,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -4084,13 +4158,16 @@
             "LITELLM_CONFIG_OBJ": "{\"db_key\":\"sk-012345\"}"
           }
         },
-        "Handler": "models.state_machine.update_model.handle_poll_capacity",
+        "Handler": "state_machine.update_model.handle_poll_capacity",
         "Layers": [
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersionfastapiC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           }
         ],
         "MemorySize": 128,
@@ -4130,7 +4207,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -4149,13 +4226,16 @@
             "LITELLM_CONFIG_OBJ": "{\"db_key\":\"sk-012345\"}"
           }
         },
-        "Handler": "models.state_machine.update_model.handle_ecs_update",
+        "Handler": "state_machine.update_model.handle_ecs_update",
         "Layers": [
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersionfastapiC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           }
         ],
         "MemorySize": 128,
@@ -4195,7 +4275,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -4214,13 +4294,16 @@
             "LITELLM_CONFIG_OBJ": "{\"db_key\":\"sk-012345\"}"
           }
         },
-        "Handler": "models.state_machine.update_model.handle_poll_ecs_deployment",
+        "Handler": "state_machine.update_model.handle_poll_ecs_deployment",
         "Layers": [
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersionfastapiC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           }
         ],
         "MemorySize": 128,
@@ -4260,7 +4343,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -4279,13 +4362,16 @@
             "LITELLM_CONFIG_OBJ": "{\"db_key\":\"sk-012345\"}"
           }
         },
-        "Handler": "models.state_machine.update_model.handle_update_guardrails",
+        "Handler": "state_machine.update_model.handle_update_guardrails",
         "Layers": [
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersionfastapiC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           }
         ],
         "MemorySize": 128,
@@ -4325,7 +4411,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -4344,13 +4430,16 @@
             "LITELLM_CONFIG_OBJ": "{\"db_key\":\"sk-012345\"}"
           }
         },
-        "Handler": "models.state_machine.update_model.handle_finish_update",
+        "Handler": "state_machine.update_model.handle_finish_update",
         "Layers": [
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersionfastapiC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           }
         ],
         "MemorySize": 128,
@@ -4390,7 +4479,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Environment": {
           "Variables": {
@@ -4409,13 +4498,16 @@
             "LITELLM_CONFIG_OBJ": "{\"db_key\":\"sk-012345\"}"
           }
         },
-        "Handler": "models.state_machine.update_model.handle_failure",
+        "Handler": "state_machine.update_model.handle_failure",
         "Layers": [
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersionfastapiC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           }
         ],
         "MemorySize": 128,
@@ -4891,7 +4983,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Description": "Manage model",
         "Environment": {
@@ -4933,8 +5025,11 @@
           }
         },
         "FunctionName": "LisaModels-models-handler",
-        "Handler": "models.lambda_functions.handler",
+        "Handler": "lambda_functions.handler",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -5022,7 +5117,7 @@
         ]
       }
     },
-    "ModelsApiLambdaInvokeAccessRemoteLisaModelsmodelshandler62c6CFCAD12C": {
+    "ModelsApiLambdaInvokeAccessRemoteLisaModelsmodelshandler8ef5C72976C2": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
@@ -5061,7 +5156,7 @@
         }
       }
     },
-    "ModelsApiLambdaInvokeAccessRemoteLisaModelsmodelshandlere40aF0599D01": {
+    "ModelsApiLambdaInvokeAccessRemoteLisaModelsmodelshandler5139141A9A79": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
@@ -5105,7 +5200,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Description": "Manage model",
         "Environment": {
@@ -5147,8 +5242,11 @@
           }
         },
         "FunctionName": "LisaModels-models-docs",
-        "Handler": "models.lambda_functions.docs",
+        "Handler": "lambda_functions.docs",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -5212,7 +5310,7 @@
         "RetentionInDays": 30
       }
     },
-    "ModelsApiLambdaInvokeAccessRemoteLisaModelsmodelshandler8e6aE5EDFD11": {
+    "ModelsApiLambdaInvokeAccessRemoteLisaModelsmodelshandler65402BF3BA05": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
@@ -5428,7 +5526,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Description": "Remove api_key from existing Bedrock models to fix Invalid API Key format errors",
         "Environment": {
@@ -5441,8 +5539,11 @@
             "DEPLOYMENT_PREFIX": "/dev/test-lisa/lisa"
           }
         },
-        "Handler": "models.model_api_key_cleanup.lambda_handler",
+        "Handler": "model_api_key_cleanup.lambda_handler",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -5450,6 +5551,7 @@
             "Ref": "SsmParameterValuedevtestlisalisalayerVersionfastapiC96584B6F00A464EAD1953AFF4B05118Parameter"
           }
         ],
+        "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
             "ModelsApiModelsSfnLambdaRoleF400F0BC",
@@ -5620,7 +5722,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Description": "One-time backfill of context_window for existing model DynamoDB records",
         "Environment": {
@@ -5637,8 +5739,11 @@
             "RESTAPI_SSL_CERT_ARN": "arn:aws:iam::012345678901:server-certificate/lisa-self-signed-dev"
           }
         },
-        "Handler": "models.model_context_window_backfill.lambda_handler",
+        "Handler": "model_context_window_backfill.lambda_handler",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -5646,6 +5751,7 @@
             "Ref": "SsmParameterValuedevtestlisalisalayerVersionfastapiC96584B6F00A464EAD1953AFF4B05118Parameter"
           }
         ],
+        "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
             "ModelsApiModelsSfnLambdaRoleF400F0BC",
@@ -5902,7 +6008,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "657e88d2c1c45af903bb701b3cb187703b8bf396116c8f5ae2b77b878f69f88e.zip"
         },
         "Description": "Sync all models from DynamoDB to LiteLLM when the LiteLLM database is created or updated",
         "Environment": {
@@ -5918,8 +6024,11 @@
             "RESTAPI_SSL_CERT_ARN": "arn:aws:iam::012345678901:server-certificate/lisa-self-signed-dev"
           }
         },
-        "Handler": "models.litellm_model_sync.handler",
+        "Handler": "litellm_model_sync.handler",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
@@ -5927,6 +6036,7 @@
             "Ref": "SsmParameterValuedevtestlisalisalayerVersionfastapiC96584B6F00A464EAD1953AFF4B05118Parameter"
           }
         ],
+        "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
             "ModelsApiLiteLLMSyncLiteLLMModelSyncRoleD581AB58",
@@ -6088,7 +6198,7 @@
             "Arn"
           ]
         },
-        "timestamp": "2026-04-24T16:35:40.575Z"
+        "timestamp": "2026-06-02T22:52:47.853Z"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"

--- a/test/cdk/stacks/__baselines__/LisaRAG.json
+++ b/test/cdk/stacks/__baselines__/LisaRAG.json
@@ -20,6 +20,10 @@
       "Type": "AWS::SSM::Parameter::Value<String>",
       "Default": "/dev/test-lisa/lisa/layerVersion/common"
     },
+    "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Type": "AWS::SSM::Parameter::Value<String>",
+      "Default": "/dev/test-lisa/lisa/layerVersion/lisa-shared"
+    },
     "SsmParameterValuedevtestlisalisalayerVersioncdkC96584B6F00A464EAD1953AFF4B05118Parameter": {
       "Type": "AWS::SSM::Parameter::Value<String>",
       "Default": "/dev/test-lisa/lisa/layerVersion/cdk"
@@ -1066,7 +1070,7 @@
         ],
         "Content": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "73a5cffbd3baddd54341aa134a6a53e9d05c78c646cf56ad23af3d9919b5cd9a.zip"
+          "S3Key": "f5ea97ecf947aeca04b2da3917b8cf707b9632bf789f76edc6fc1e82108ce793.zip"
         },
         "Description": "Lambda dependencies for RAG API"
       },
@@ -1616,7 +1620,7 @@
         "ContainerProperties": {
           "Command": [
             "-m",
-            "repository.pipeline_ingestion",
+            "lisa.rag.pipeline_ingestion",
             "Ref::ACTION",
             "Ref::DOCUMENT_ID"
           ],
@@ -1678,10 +1682,6 @@
               "Value": {
                 "Ref": "testlisaRagSubDocumentTable76E4AE52"
               }
-            },
-            {
-              "Name": "REGISTERED_MODELS_PS_NAME",
-              "Value": "/dev/test-lisa/lisa/registeredModels"
             },
             {
               "Name": "REGISTERED_REPOSITORIES_PS_PREFIX",
@@ -1771,6 +1771,10 @@
                   }
                 ]
               }
+            },
+            {
+              "Name": "PYTHONPATH",
+              "Value": "/workdir/shared/python"
             }
           ],
           "ExecutionRoleArn": {
@@ -1781,7 +1785,7 @@
           },
           "FargatePlatformConfiguration": {},
           "Image": {
-            "Fn::Sub": "012345678901.dkr.ecr.us-iso-east-1.${AWS::URLSuffix}/cdk-hnb659fds-container-assets-012345678901-us-iso-east-1:0e8c7e01e383d9f275426cde9a0d54850d7cce4fb4e77cd7ab4eca4891452aee"
+            "Fn::Sub": "012345678901.dkr.ecr.us-iso-east-1.${AWS::URLSuffix}/cdk-hnb659fds-container-assets-012345678901-us-iso-east-1:b510152a4f2d3e4fc1b063da83e4fdacbcf4ea3a24fc20239b416508922f9237"
           },
           "JobRoleArn": {
             "Ref": "SsmParameterValuedevtestlisalisarolestestlisaLisaRagLambdaExecutionRoleC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -1846,7 +1850,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Environment": {
           "Variables": {
@@ -1934,7 +1938,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "RESTAPI_SSL_CERT_ARN": "arn:aws:iam::012345678901:server-certificate/lisa-self-signed-dev",
@@ -1943,8 +1946,11 @@
           }
         },
         "FunctionName": "test-lisa-dev-ingestion-ingest-schedule",
-        "Handler": "repository.pipeline_ingest_handlers.handle_pipline_ingest_schedule",
+        "Handler": "pipeline_ingest_handlers.handle_pipline_ingest_schedule",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "RagLayerF72F34A6"
           },
@@ -1984,7 +1990,7 @@
         "LisaRAGResourcesLisaRagLambdaExecutionRolePolicy1F0EBC60"
       ]
     },
-    "IngestionStackConstructhandlePipelineIngestScheduleCurrentVersion094270E595eb16b6a9c72a89de2a11229f451adf": {
+    "IngestionStackConstructhandlePipelineIngestScheduleCurrentVersion094270E54b704d49ce0cab6a052d5e9363416ddc": {
       "Type": "AWS::Lambda::Version",
       "Properties": {
         "FunctionName": {
@@ -2003,7 +2009,7 @@
         },
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "IngestionStackConstructhandlePipelineIngestScheduleCurrentVersion094270E595eb16b6a9c72a89de2a11229f451adf",
+            "IngestionStackConstructhandlePipelineIngestScheduleCurrentVersion094270E54b704d49ce0cab6a052d5e9363416ddc",
             "Version"
           ]
         },
@@ -2051,7 +2057,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Environment": {
           "Variables": {
@@ -2139,7 +2145,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "RESTAPI_SSL_CERT_ARN": "arn:aws:iam::012345678901:server-certificate/lisa-self-signed-dev",
@@ -2148,8 +2153,11 @@
           }
         },
         "FunctionName": "test-lisa-dev-ingestion-ingest-event",
-        "Handler": "repository.pipeline_ingest_handlers.handle_pipeline_ingest_event",
+        "Handler": "pipeline_ingest_handlers.handle_pipeline_ingest_event",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "RagLayerF72F34A6"
           },
@@ -2189,7 +2197,7 @@
         "LisaRAGResourcesLisaRagLambdaExecutionRolePolicy1F0EBC60"
       ]
     },
-    "IngestionStackConstructhandlePipelineIngestEventCurrentVersion5A33ADBC5328cf9b80723780fea9912be252fc46": {
+    "IngestionStackConstructhandlePipelineIngestEventCurrentVersion5A33ADBC6176ba2e5ca615885f8c2b24523ca166": {
       "Type": "AWS::Lambda::Version",
       "Properties": {
         "FunctionName": {
@@ -2208,7 +2216,7 @@
         },
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "IngestionStackConstructhandlePipelineIngestEventCurrentVersion5A33ADBC5328cf9b80723780fea9912be252fc46",
+            "IngestionStackConstructhandlePipelineIngestEventCurrentVersion5A33ADBC6176ba2e5ca615885f8c2b24523ca166",
             "Version"
           ]
         },
@@ -2256,7 +2264,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Environment": {
           "Variables": {
@@ -2344,7 +2352,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "RESTAPI_SSL_CERT_ARN": "arn:aws:iam::012345678901:server-certificate/lisa-self-signed-dev",
@@ -2353,8 +2360,11 @@
           }
         },
         "FunctionName": "test-lisa-dev-ingestion-delete-event",
-        "Handler": "repository.pipeline_ingest_handlers.handle_pipeline_delete_event",
+        "Handler": "pipeline_ingest_handlers.handle_pipeline_delete_event",
         "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           {
             "Ref": "RagLayerF72F34A6"
           },
@@ -2394,7 +2404,7 @@
         "LisaRAGResourcesLisaRagLambdaExecutionRolePolicy1F0EBC60"
       ]
     },
-    "IngestionStackConstructhandlePipelineDeleteEventCurrentVersion74AC0E9533aee949475e44bcbf7bf5aec0c72baa": {
+    "IngestionStackConstructhandlePipelineDeleteEventCurrentVersion74AC0E95421bea5cf2e54e6303c65267cc02c842": {
       "Type": "AWS::Lambda::Version",
       "Properties": {
         "FunctionName": {
@@ -2413,7 +2423,7 @@
         },
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "IngestionStackConstructhandlePipelineDeleteEventCurrentVersion74AC0E9533aee949475e44bcbf7bf5aec0c72baa",
+            "IngestionStackConstructhandlePipelineDeleteEventCurrentVersion74AC0E95421bea5cf2e54e6303c65267cc02c842",
             "Version"
           ]
         },
@@ -2509,7 +2519,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "69aa0c61d54bff684723bc1ff9df739febd3ce77ab932b92c9a316cc3f2259b1.zip"
+          "S3Key": "b5ece4293fd407979f91f52eb46ee28ab489d28de00710086f6c1f8af19a0605.zip"
         },
         "Environment": {
           "Variables": {
@@ -2521,6 +2531,12 @@
         },
         "FunctionName": "test-lisa-dev-batch-job-metric",
         "Handler": "batch_job_metric.handler",
+        "Layers": [
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
+          }
+        ],
+        "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
             "IngestionStackConstructBatchJobMetricPublisherServiceRole73642CC3",
@@ -5677,7 +5693,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "List all repositories",
         "Environment": {
@@ -5704,7 +5720,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -5775,10 +5790,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-list_all",
-        "Handler": "repository.lambda_functions.list_all",
+        "Handler": "lambda_functions.list_all",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -5841,7 +5859,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "List status for all repositories",
         "Environment": {
@@ -5868,7 +5886,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -5939,10 +5956,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-list_status",
-        "Handler": "repository.lambda_functions.list_status",
+        "Handler": "lambda_functions.list_status",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -6005,7 +6025,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "Generates a presigned url for uploading files to RAG",
         "Environment": {
@@ -6032,7 +6052,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -6103,10 +6122,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-presigned_url",
-        "Handler": "repository.lambda_functions.presigned_url",
+        "Handler": "lambda_functions.presigned_url",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -6169,7 +6191,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "Create a new repository",
         "Environment": {
@@ -6196,7 +6218,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -6267,10 +6288,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-create",
-        "Handler": "repository.lambda_functions.create",
+        "Handler": "lambda_functions.create",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -6333,7 +6357,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "Get a repository by ID",
         "Environment": {
@@ -6360,7 +6384,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -6431,10 +6454,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-get_repository_by_id",
-        "Handler": "repository.lambda_functions.get_repository_by_id",
+        "Handler": "lambda_functions.get_repository_by_id",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -6497,7 +6523,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "Update a repository",
         "Environment": {
@@ -6524,7 +6550,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -6595,10 +6620,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-update_repository",
-        "Handler": "repository.lambda_functions.update_repository",
+        "Handler": "lambda_functions.update_repository",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -6661,7 +6689,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "Delete a repository",
         "Environment": {
@@ -6688,7 +6716,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -6759,10 +6786,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-delete",
-        "Handler": "repository.lambda_functions.delete",
+        "Handler": "lambda_functions.delete",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -6825,7 +6855,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "Run a similarity search against the specified repository using the specified query",
         "Environment": {
@@ -6852,7 +6882,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -6923,10 +6952,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-similarity_search",
-        "Handler": "repository.lambda_functions.similarity_search",
+        "Handler": "lambda_functions.similarity_search",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -6989,7 +7021,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "Ingest a set of documents based on specified S3 path",
         "Environment": {
@@ -7016,7 +7048,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -7087,10 +7118,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-ingest_documents",
-        "Handler": "repository.lambda_functions.ingest_documents",
+        "Handler": "lambda_functions.ingest_documents",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -7153,7 +7187,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "List all docs for a repository",
         "Environment": {
@@ -7180,7 +7214,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -7251,10 +7284,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-list_docs",
-        "Handler": "repository.lambda_functions.list_docs",
+        "Handler": "lambda_functions.list_docs",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -7317,7 +7353,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "Get a document by ID",
         "Environment": {
@@ -7344,7 +7380,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -7415,10 +7450,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-get_document",
-        "Handler": "repository.lambda_functions.get_document",
+        "Handler": "lambda_functions.get_document",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -7481,7 +7519,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "Creates presigned url to download document within repository",
         "Environment": {
@@ -7508,7 +7546,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -7579,10 +7616,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-download_document",
-        "Handler": "repository.lambda_functions.download_document",
+        "Handler": "lambda_functions.download_document",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -7645,7 +7685,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "Deletes all records associated with documents from the repository",
         "Environment": {
@@ -7672,7 +7712,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -7743,10 +7782,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-delete_documents",
-        "Handler": "repository.lambda_functions.delete_documents",
+        "Handler": "lambda_functions.delete_documents",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -7809,7 +7851,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "List all ingestion jobs for a repository",
         "Environment": {
@@ -7836,7 +7878,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -7907,10 +7948,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-list_jobs",
-        "Handler": "repository.lambda_functions.list_jobs",
+        "Handler": "lambda_functions.list_jobs",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -7973,7 +8017,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "List all collections within a repository",
         "Environment": {
@@ -8000,7 +8044,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -8071,10 +8114,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-list_collections",
-        "Handler": "repository.lambda_functions.list_collections",
+        "Handler": "lambda_functions.list_collections",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -8137,7 +8183,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "List all collections user has access to across all repositories",
         "Environment": {
@@ -8164,7 +8210,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -8235,10 +8280,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-list_user_collections",
-        "Handler": "repository.lambda_functions.list_user_collections",
+        "Handler": "lambda_functions.list_user_collections",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -8301,7 +8349,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "Create a new collection within a repository",
         "Environment": {
@@ -8328,7 +8376,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -8399,10 +8446,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-create_collection",
-        "Handler": "repository.lambda_functions.create_collection",
+        "Handler": "lambda_functions.create_collection",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -8465,7 +8515,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "Get a collection by ID within a repository",
         "Environment": {
@@ -8492,7 +8542,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -8563,10 +8612,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-get_collection",
-        "Handler": "repository.lambda_functions.get_collection",
+        "Handler": "lambda_functions.get_collection",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -8629,7 +8681,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "Update a collection within a repository",
         "Environment": {
@@ -8656,7 +8708,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -8727,10 +8778,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-update_collection",
-        "Handler": "repository.lambda_functions.update_collection",
+        "Handler": "lambda_functions.update_collection",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -8793,7 +8847,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "Delete a collection within a repository",
         "Environment": {
@@ -8820,7 +8874,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -8891,10 +8944,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-delete_collection",
-        "Handler": "repository.lambda_functions.delete_collection",
+        "Handler": "lambda_functions.delete_collection",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -8957,7 +9013,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "List all ACTIVE Bedrock Knowledge Bases",
         "Environment": {
@@ -8984,7 +9040,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -9055,10 +9110,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-list_bedrock_knowledge_bases",
-        "Handler": "repository.lambda_functions.list_bedrock_knowledge_bases",
+        "Handler": "lambda_functions.list_bedrock_knowledge_bases",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -9121,7 +9179,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Description": "List data sources for a Bedrock Knowledge Base",
         "Environment": {
@@ -9148,7 +9206,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -9219,10 +9276,13 @@
           }
         },
         "FunctionName": "LisaRAG-repository-list_bedrock_data_sources",
-        "Handler": "repository.lambda_functions.list_bedrock_data_sources",
+        "Handler": "lambda_functions.list_bedrock_data_sources",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -10011,7 +10071,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "36da753b63b761f1395efaa515425d2a992bd71a7bef284d7891cfcb263999c1.zip"
+          "S3Key": "f278ea47726c4608b5a9921a7830176e9d91f9ce125825560c0a97d45e7aa49c.zip"
         },
         "Environment": {
           "Variables": {
@@ -10019,7 +10079,7 @@
               "Fn::Join": [
                 "",
                 [
-                  "{\"accountNumber\":\"012345678901\",\"appName\":\"lisa\",\"deploymentName\":\"test-lisa\",\"deploymentStage\":\"dev\",\"deploymentPrefix\":\"/dev/test-lisa/lisa\",\"iamRdsAuth\":true,\"partition\":\"aws\",\"region\":\"us-iso-east-1\",\"removalPolicy\":\"destroy\",\"profile\":\"\",\"vpcId\":\"",
+                  "{\"accountNumber\":\"012345678901\",\"appName\":\"lisa\",\"convertInlinePoliciesToManaged\":false,\"deploymentName\":\"test-lisa\",\"deploymentStage\":\"dev\",\"deploymentPrefix\":\"/dev/test-lisa/lisa\",\"iamRdsAuth\":true,\"partition\":\"aws\",\"region\":\"us-iso-east-1\",\"removalPolicy\":\"destroy\",\"profile\":\"\",\"vpcId\":\"",
                   {
                     "Fn::ImportValue": "LisaNetworking:ExportsOutputRefVpcVPC8B8C4E4BB8544CDA"
                   },
@@ -10103,7 +10163,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Environment": {
           "Variables": {
@@ -10129,7 +10189,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -10200,10 +10259,13 @@
           }
         },
         "FunctionName": "test-lisa-dev-create_bedrock_collection",
-        "Handler": "repository.lambda_functions.create_bedrock_collection",
+        "Handler": "lambda_functions.create_bedrock_collection",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -10243,7 +10305,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Environment": {
           "Variables": {
@@ -10269,7 +10331,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -10340,10 +10401,13 @@
           }
         },
         "FunctionName": "test-lisa-dev-create_default_collection",
-        "Handler": "repository.lambda_functions.create_default_collection",
+        "Handler": "lambda_functions.create_default_collection",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -10608,7 +10672,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Environment": {
           "Variables": {
@@ -10634,7 +10698,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -10704,10 +10767,13 @@
             }
           }
         },
-        "Handler": "repository.state_machine.cleanup_repo_docs.lambda_handler",
+        "Handler": "state_machine.cleanup_repo_docs.lambda_handler",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"
@@ -10766,7 +10832,7 @@
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-012345678901-us-iso-east-1",
-          "S3Key": "1168f99fcbb47580048d30d01fade537ef4c6786fe3cc572fba4f1441f013735.zip"
+          "S3Key": "a14e515f6b8c93a772d77b419ae72462df60d4e1f3d016802127014245d92192.zip"
         },
         "Environment": {
           "Variables": {
@@ -10792,7 +10858,6 @@
             "RAG_SUB_DOCUMENT_TABLE": {
               "Ref": "testlisaRagSubDocumentTable76E4AE52"
             },
-            "REGISTERED_MODELS_PS_NAME": "/dev/test-lisa/lisa/registeredModels",
             "REGISTERED_REPOSITORIES_PS_PREFIX": "/dev/test-lisa/lisa/LisaServeRagConnectionInfo/",
             "REGISTERED_REPOSITORIES_PS": "/dev/test-lisa/lisa/registeredRepositories",
             "REST_API_VERSION": "v2",
@@ -10862,10 +10927,13 @@
             }
           }
         },
-        "Handler": "repository.state_machine.wait_for_collection_deletions.lambda_handler",
+        "Handler": "state_machine.wait_for_collection_deletions.lambda_handler",
         "Layers": [
           {
             "Ref": "RagLayerF72F34A6"
+          },
+          {
+            "Ref": "SsmParameterValuedevtestlisalisalayerVersionlisasharedC96584B6F00A464EAD1953AFF4B05118Parameter"
           },
           {
             "Ref": "SsmParameterValuedevtestlisalisalayerVersioncommonC96584B6F00A464EAD1953AFF4B05118Parameter"


### PR DESCRIPTION
*Issue #, if available:*

## Summary
- Updates the Batch ingestion job container command from `-m repository.pipeline_ingestion` to `-m lisa.rag.pipeline_ingestion` to match the lambda refactor's new module layout
- Adds `PYTHONPATH: '/workdir/shared/python'` to the container environment so the shared `lisa` package is importable

### Testing
  - [x] CDK snapshot baselines updated (LisaApiDeployment, LisaModels, LisaRAG)
  - [x] Deploy to dev account and trigger a document ingestion job
  - [x] Verify batch job container starts successfully and processes documents

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
