### PR TITLE
fix: DynamoDB Decimal values serialized as strings in session API

### DIFF
--- a/lambda/shared/python/lisa/utilities/response_builder.py
+++ b/lambda/shared/python/lisa/utilities/response_builder.py
@@ -45,9 +45,10 @@ class DecimalEncoder(json.JSONEncoder):
             return float(obj)
         if isinstance(obj, datetime):
             return obj.isoformat()
-        # Handle Pydantic models
+        # Handle Pydantic models — use mode="python" so Decimal/datetime stay as
+        # native types and get handled by the isinstance checks above.
         if hasattr(obj, "model_dump"):
-            return obj.model_dump(mode="json")
+            return obj.model_dump(mode="python")
         return super().default(obj)
 
 
@@ -66,7 +67,7 @@ def _serialize_pydantic(obj: Any) -> Any:
         Serialized object.
     """
     if hasattr(obj, "model_dump"):
-        return obj.model_dump(mode="json")
+        return obj.model_dump(mode="python")
     if isinstance(obj, list):
         return [_serialize_pydantic(item) for item in obj]
     if isinstance(obj, dict):


### PR DESCRIPTION
*Issue #, if available:*

## Summary
Changes `model_dump(mode="json")` to `model_dump(mode="python")` in `response_builder.py` (2 call sites) so that DynamoDB `Decimal` values are properly serialized as JSON numbers instead of strings.

### Problem
All numbers stored in DynamoDB are returned by boto3 as Python `Decimal` objects. When a Pydantic model with `Any`-typed fields (e.g., `Session.history: list[dict[str, Any]]`) is serialized for an API response:
1. `_serialize_pydantic()` calls `model_dump(mode="json")`
2. Pydantic v2's `mode="json"` converts `Decimal` → `str` for `Any`-typed fields ([pydantic#7457](https://github.com/pydantic/pydantic/issues/7457))
3. `json.dumps(cls=DecimalEncoder)` sees strings — `DecimalEncoder.default()` never fires
4. Frontend receives `"similarityScore": "0.7"` instead of `0.7`

Affects all numeric values round-tripping through DynamoDB sessions: `similarityScore`, `promptTokens`, `completionTokens`, etc.

### Fix
With `mode="python"`, Pydantic returns native Python objects without type coercion. `Decimal` stays as `Decimal`, which `DecimalEncoder` converts to `float`. `DecimalEncoder` already handles `Decimal → float`, but `mode="json"` was converting Decimals to strings before `json.dumps` ran, making the encoder dead code for this case. `mode="python"` lets the encoder do its job.

### Testing
  - [x] Full lambda test suite passes (1816 tests)
  - [x] Deployed to dev account
  - [x] RAG chat → session reload → `similarityScore` arrives as number
  - [x] `promptTokens`/`completionTokens` also arrive as numbers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
