### PR TITLE
feat/opensearch hybrid

### DIFF
--- a/lambda/handlers/repository/lambda_functions.py
+++ b/lambda/handlers/repository/lambda_functions.py
@@ -263,7 +263,7 @@ def similarity_search(event: dict, context: dict) -> dict[str, Any]:
     use_hybrid = search_mode == "hybrid" and service.supports_hybrid_search()
 
     if use_hybrid:
-        docs, retrieval_metadata = service.hybrid_retrieve(
+        result = service.hybrid_retrieve(
             query=query,
             collection_id=search_collection_id,
             top_k=top_k,
@@ -271,10 +271,8 @@ def similarity_search(event: dict, context: dict) -> dict[str, Any]:
             include_score=include_score,
             bedrock_agent_client=bedrock_client,
         )
-        actual_mode = retrieval_metadata.get("actual_mode_used", "hybrid")
-        hybrid_supported = retrieval_metadata.get("hybrid_supported", True)
     else:
-        docs = service.retrieve_documents(
+        result = service.retrieve_documents(
             query=query,
             collection_id=search_collection_id,
             top_k=top_k,
@@ -282,19 +280,15 @@ def similarity_search(event: dict, context: dict) -> dict[str, Any]:
             include_score=include_score,
             bedrock_agent_client=bedrock_client,
         )
-        actual_mode = "vector"
-        hybrid_supported = service.supports_hybrid_search()
 
     response_metadata = {
         "search_mode": search_mode,
-        "actual_mode_used": actual_mode,
+        "actual_mode_used": result.actual_mode_used,
         "backend": repo_type,
-        "hybrid_supported": hybrid_supported,
+        "hybrid_supported": result.hybrid_supported,
     }
 
-    # Enrich metadata with documentId for documents that don't have it
-    # Pass the actual search_collection_id (not the metadata's collectionId which may be "default")
-    docs = enrich_metadata_with_document_id(docs, repository_id, search_collection_id)
+    docs = enrich_metadata_with_document_id(result.documents, repository_id, search_collection_id)
 
     doc_content = [
         {

--- a/lambda/handlers/repository/lambda_functions.py
+++ b/lambda/handlers/repository/lambda_functions.py
@@ -26,6 +26,7 @@ from boto3.dynamodb.types import TypeSerializer
 from botocore.config import Config
 from lisa.domain.domain_objects import (
     FilterParams,
+    HybridWeights,
     IngestDocumentRequest,
     IngestionJob,
     IngestionStatus,
@@ -222,21 +223,8 @@ def similarity_search(event: dict, context: dict) -> dict[str, Any]:
     if search_mode not in ("vector", "hybrid"):
         raise ValidationError("Invalid searchMode. Must be 'vector' or 'hybrid'")
 
-    vector_weight = 0.7
-    lexical_weight = 0.3
-    if search_mode == "hybrid":
-        raw_vector = query_string_params.get("vectorWeight")
-        raw_lexical = query_string_params.get("lexicalWeight")
-        if raw_vector is not None or raw_lexical is not None:
-            try:
-                vector_weight = float(raw_vector) if raw_vector is not None else 0.7
-                lexical_weight = float(raw_lexical) if raw_lexical is not None else 0.3
-            except (TypeError, ValueError):
-                raise ValidationError("vectorWeight and lexicalWeight must be numeric values between 0 and 1")
-            if not (0.0 <= vector_weight <= 1.0) or not (0.0 <= lexical_weight <= 1.0):
-                raise ValidationError("vectorWeight and lexicalWeight must be between 0 and 1")
-            if abs(vector_weight + lexical_weight - 1.0) > 1e-9:
-                raise ValidationError("vectorWeight and lexicalWeight must sum to 1")
+    weight_params = {k: v for k, v in query_string_params.items() if k in ("vectorWeight", "lexicalWeight")}
+    weights = HybridWeights(**weight_params)
 
     if not isinstance(repository_id, str) or not repository_id:
         raise ValidationError("repositoryId is required")
@@ -286,8 +274,8 @@ def similarity_search(event: dict, context: dict) -> dict[str, Any]:
             model_name=model_name,
             include_score=include_score,
             bedrock_agent_client=bedrock_client,
-            vector_weight=vector_weight,
-            lexical_weight=lexical_weight,
+            vector_weight=weights.vector_weight,
+            lexical_weight=weights.lexical_weight,
         )
     else:
         result = service.retrieve_documents(

--- a/lambda/handlers/repository/lambda_functions.py
+++ b/lambda/handlers/repository/lambda_functions.py
@@ -222,6 +222,22 @@ def similarity_search(event: dict, context: dict) -> dict[str, Any]:
     if search_mode not in ("vector", "hybrid"):
         raise ValidationError("Invalid searchMode. Must be 'vector' or 'hybrid'")
 
+    vector_weight = 0.7
+    lexical_weight = 0.3
+    if search_mode == "hybrid":
+        raw_vector = query_string_params.get("vectorWeight")
+        raw_lexical = query_string_params.get("lexicalWeight")
+        if raw_vector is not None or raw_lexical is not None:
+            try:
+                vector_weight = float(raw_vector) if raw_vector is not None else 0.7
+                lexical_weight = float(raw_lexical) if raw_lexical is not None else 0.3
+            except (TypeError, ValueError):
+                raise ValidationError("vectorWeight and lexicalWeight must be numeric values between 0 and 1")
+            if not (0.0 <= vector_weight <= 1.0) or not (0.0 <= lexical_weight <= 1.0):
+                raise ValidationError("vectorWeight and lexicalWeight must be between 0 and 1")
+            if abs(vector_weight + lexical_weight - 1.0) > 1e-9:
+                raise ValidationError("vectorWeight and lexicalWeight must sum to 1")
+
     if not isinstance(repository_id, str) or not repository_id:
         raise ValidationError("repositoryId is required")
     repository = get_repository(event, repository_id=repository_id)
@@ -270,6 +286,8 @@ def similarity_search(event: dict, context: dict) -> dict[str, Any]:
             model_name=model_name,
             include_score=include_score,
             bedrock_agent_client=bedrock_client,
+            vector_weight=vector_weight,
+            lexical_weight=lexical_weight,
         )
     else:
         result = service.retrieve_documents(

--- a/lambda/handlers/repository/lambda_functions.py
+++ b/lambda/handlers/repository/lambda_functions.py
@@ -223,9 +223,6 @@ def similarity_search(event: dict, context: dict) -> dict[str, Any]:
     if search_mode not in ("vector", "hybrid"):
         raise ValidationError("Invalid searchMode. Must be 'vector' or 'hybrid'")
 
-    weight_params = {k: v for k, v in query_string_params.items() if k in ("vectorWeight", "lexicalWeight")}
-    weights = HybridWeights(**weight_params)
-
     if not isinstance(repository_id, str) or not repository_id:
         raise ValidationError("repositoryId is required")
     repository = get_repository(event, repository_id=repository_id)
@@ -267,6 +264,8 @@ def similarity_search(event: dict, context: dict) -> dict[str, Any]:
     use_hybrid = search_mode == "hybrid" and service.supports_hybrid_search()
 
     if use_hybrid:
+        weight_params = {k: v for k, v in query_string_params.items() if k in ("vectorWeight", "lexicalWeight")}
+        weights = HybridWeights(**weight_params)
         result = service.hybrid_retrieve(
             query=query,
             collection_id=search_collection_id,

--- a/lambda/shared/python/lisa/domain/domain_objects.py
+++ b/lambda/shared/python/lisa/domain/domain_objects.py
@@ -1589,9 +1589,9 @@ class HybridWeights(BaseModel):
     @classmethod
     def require_both_or_neither(cls, data: Any) -> Any:
         if isinstance(data, dict):
-            v = data.get("vectorWeight")
-            l = data.get("lexicalWeight")
-            if (v is not None) != (l is not None):
+            vec = data.get("vectorWeight")
+            lex = data.get("lexicalWeight")
+            if (vec is not None) != (lex is not None):
                 raise ValueError("Both vectorWeight and lexicalWeight must be provided together")
         return data
 

--- a/lambda/shared/python/lisa/domain/domain_objects.py
+++ b/lambda/shared/python/lisa/domain/domain_objects.py
@@ -1577,6 +1577,31 @@ class InvokeBedrockAgentRequest(BaseModel):
         return self
 
 
+class HybridWeights(BaseModel):
+    """Validated hybrid search weight pair parsed from query string params."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    vector_weight: float = Field(default=0.7, ge=0.0, le=1.0, alias="vectorWeight")
+    lexical_weight: float = Field(default=0.3, ge=0.0, le=1.0, alias="lexicalWeight")
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_both_or_neither(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            v = data.get("vectorWeight")
+            l = data.get("lexicalWeight")
+            if (v is not None) != (l is not None):
+                raise ValueError("Both vectorWeight and lexicalWeight must be provided together")
+        return data
+
+    @model_validator(mode="after")
+    def weights_sum_to_one(self) -> Self:
+        if abs(self.vector_weight + self.lexical_weight - 1.0) > 1e-9:
+            raise ValueError("vectorWeight and lexicalWeight must sum to 1")
+        return self
+
+
 @dataclass
 class RetrieveResult:
     """Unified return type for retrieve_documents() and hybrid_retrieve().

--- a/lambda/shared/python/lisa/domain/domain_objects.py
+++ b/lambda/shared/python/lisa/domain/domain_objects.py
@@ -1575,3 +1575,16 @@ class InvokeBedrockAgentRequest(BaseModel):
         if has_fn and not (self.actionGroupId and str(self.actionGroupId).strip()):
             raise ValueError("actionGroupId is required when functionName is set")
         return self
+
+
+@dataclass
+class RetrieveResult:
+    """Unified return type for retrieve_documents() and hybrid_retrieve().
+
+    Both retrieval paths return this so the handler has one contract regardless
+    of mode. The fields self-report what actually happened at the service layer.
+    """
+
+    documents: list[dict[str, Any]]
+    actual_mode_used: str
+    hybrid_supported: bool

--- a/lambda/shared/python/lisa/rag/services/bedrock_kb_repository_service.py
+++ b/lambda/shared/python/lisa/rag/services/bedrock_kb_repository_service.py
@@ -29,6 +29,7 @@ from lisa.domain.domain_objects import (
     NoneChunkingStrategy,
     RagCollectionConfig,
     RagDocument,
+    RetrieveResult,
 )
 from lisa.rag.rag_document_repo import RagDocumentRepository
 from lisa.utilities.bedrock_kb import bulk_delete_documents_from_kb, delete_document_from_kb
@@ -361,14 +362,15 @@ class BedrockKBRepositoryService(RepositoryService):
         model_name: str,
         include_score: bool = False,
         bedrock_agent_client: Any | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> RetrieveResult:
         """Retrieve documents from Bedrock KB using retrieve API."""
         retrieve_params, kb_id = self._build_retrieve_params(query, collection_id, top_k, bedrock_agent_client)
 
         logger.info(f"Retrieving from KB: kb_id={kb_id}, data_source={collection_id}, query={query[:50]}...")
 
         response = self._call_retrieve_api(bedrock_agent_client, retrieve_params, kb_id)
-        return self._transform_retrieve_results(response, include_score)
+        docs = self._transform_retrieve_results(response, include_score)
+        return RetrieveResult(documents=docs, actual_mode_used="vector", hybrid_supported=True)
 
     def _semantic_fallback(
         self,
@@ -392,14 +394,10 @@ class BedrockKBRepositoryService(RepositoryService):
         model_name: str,
         include_score: bool = False,
         bedrock_agent_client: Any | None = None,
-    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    ) -> RetrieveResult:
         """Retrieve documents using hybrid (semantic + lexical) search.
 
         Falls back to semantic search if the KB does not support hybrid.
-
-        Returns:
-            Tuple of (docs, retrieval_metadata) where retrieval_metadata.actual_mode_used
-            is 'hybrid' on success or 'vector' on fallback.
         """
         retrieve_params, kb_id = self._build_retrieve_params(query, collection_id, top_k, bedrock_agent_client)
 
@@ -411,7 +409,7 @@ class BedrockKBRepositoryService(RepositoryService):
         try:
             response = self._call_retrieve_api(bedrock_agent_client, retrieve_params, kb_id)
             docs = self._transform_retrieve_results(response, include_score)
-            return docs, {"actual_mode_used": "hybrid", "hybrid_supported": True}
+            return RetrieveResult(documents=docs, actual_mode_used="hybrid", hybrid_supported=True)
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "")
             if error_code != "ValidationException":
@@ -424,7 +422,7 @@ class BedrockKBRepositoryService(RepositoryService):
 
             logger.warning(f"KB {kb_id} does not support hybrid search, falling back to semantic")
             docs = self._semantic_fallback(query, collection_id, top_k, include_score, bedrock_agent_client)
-            return docs, {"actual_mode_used": "vector", "hybrid_supported": False}
+            return RetrieveResult(documents=docs, actual_mode_used="vector", hybrid_supported=False)
 
     def validate_document_source(self, s3_path: str) -> str:
         """Validate document is from KB data source bucket."""

--- a/lambda/shared/python/lisa/rag/services/bedrock_kb_repository_service.py
+++ b/lambda/shared/python/lisa/rag/services/bedrock_kb_repository_service.py
@@ -394,10 +394,13 @@ class BedrockKBRepositoryService(RepositoryService):
         model_name: str,
         include_score: bool = False,
         bedrock_agent_client: Any | None = None,
+        vector_weight: float = 0.7,
+        lexical_weight: float = 0.3,
     ) -> RetrieveResult:
         """Retrieve documents using hybrid (semantic + lexical) search.
 
         Falls back to semantic search if the KB does not support hybrid.
+        Bedrock KB does not support weight tuning — weights are ignored.
         """
         retrieve_params, kb_id = self._build_retrieve_params(query, collection_id, top_k, bedrock_agent_client)
 

--- a/lambda/shared/python/lisa/rag/services/opensearch_repository_service.py
+++ b/lambda/shared/python/lisa/rag/services/opensearch_repository_service.py
@@ -52,6 +52,97 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
         """
         return True
 
+    def hybrid_retrieve(
+        self,
+        query: str,
+        collection_id: str,
+        top_k: int,
+        model_name: str,
+        include_score: bool = False,
+        bedrock_agent_client: Any = None,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        """Retrieve documents using hybrid (BM25 + kNN) search via inline search pipeline.
+
+        Sends the search pipeline definition inline in the request body — no persistent
+        pipeline, no admin state, one round-trip. Requires OpenSearch 2.13+; older
+        clusters trip the narrow-exception fallback to vector search (slice 2.2.4).
+
+        Args:
+            query: Search query text
+            collection_id: Index/collection to search
+            top_k: Number of results to return
+            model_name: Embedding model name (used for query vector)
+            include_score: When True, copies hit['_score'] (already 0-1 from min_max
+                normalization) to metadata['similarity_score']
+            bedrock_agent_client: Unused for OpenSearch (kept for base-class signature parity)
+
+        Returns:
+            Tuple of (docs, retrieval_metadata) where retrieval_metadata reports
+            ``actual_mode_used='hybrid'`` and ``hybrid_supported=True`` on success.
+        """
+        embeddings = RagEmbeddings(model_name=model_name)
+        vector_store = self._get_vector_store_client(
+            collection_id=collection_id,
+            embeddings=embeddings,
+        )
+
+        query_vector = embeddings.embed_query(query)
+        body = self._build_hybrid_body(query=query, query_vector=query_vector, top_k=top_k)
+
+        logger.info(f"Hybrid retrieving from OpenSearch: collection={collection_id}, query={query[:50]}...")
+        response = vector_store.client.search(index=collection_id, body=body)
+
+        docs = self._extract_hits(response, include_score)
+        return docs, {"actual_mode_used": "hybrid", "hybrid_supported": True}
+
+    @staticmethod
+    def _build_hybrid_body(query: str, query_vector: list[float], top_k: int) -> dict[str, Any]:
+        """Construct the OpenSearch hybrid query + inline search_pipeline body.
+
+        Built as a Python dict — no string interpolation — to prevent DSL injection
+        (OWASP A03). Weights ``[0.3, 0.7]`` are hardcoded in slice 2.2.2; phase 2.3
+        wires per-request weight overrides.
+        """
+        return {
+            "size": top_k,
+            "query": {
+                "hybrid": {
+                    "queries": [
+                        {"match": {"text": {"query": query}}},
+                        {"knn": {"vector_field": {"vector": query_vector, "k": top_k}}},
+                    ]
+                }
+            },
+            "search_pipeline": {
+                "phase_results_processors": [
+                    {
+                        "normalization-processor": {
+                            "normalization": {"technique": "min_max"},
+                            "combination": {
+                                "technique": "arithmetic_mean",
+                                "parameters": {"weights": [0.3, 0.7]},
+                            },
+                        }
+                    }
+                ]
+            },
+        }
+
+    @staticmethod
+    def _extract_hits(response: dict[str, Any], include_score: bool) -> list[dict[str, Any]]:
+        """Transform OpenSearch hits into the {page_content, metadata} doc shape."""
+        documents: list[dict[str, Any]] = []
+        for hit in response.get("hits", {}).get("hits", []):
+            source = hit.get("_source", {})
+            metadata = dict(source.get("metadata", {}) or {})
+            if include_score:
+                # Already 0-1 from min_max normalization in the search pipeline.
+                # Intentionally overwrites any pre-existing similarity_score in source metadata
+                # so retrieval-time scoring is authoritative over ingest-time fields.
+                metadata["similarity_score"] = hit.get("_score")
+            documents.append({"page_content": source.get("text", ""), "metadata": metadata})
+        return documents
+
     def retrieve_documents(
         self,
         query: str,

--- a/lambda/shared/python/lisa/rag/services/opensearch_repository_service.py
+++ b/lambda/shared/python/lisa/rag/services/opensearch_repository_service.py
@@ -143,7 +143,8 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
                 # Already 0-1 from min_max normalization in the search pipeline.
                 # Intentionally overwrites any pre-existing similarity_score in source metadata
                 # so retrieval-time scoring is authoritative over ingest-time fields.
-                metadata["similarity_score"] = hit.get("_score")
+                raw_score = hit.get("_score")
+                metadata["similarity_score"] = float(raw_score) if raw_score is not None else None
             documents.append({"page_content": source.get("text", ""), "metadata": metadata})
         return documents
 

--- a/lambda/shared/python/lisa/rag/services/opensearch_repository_service.py
+++ b/lambda/shared/python/lisa/rag/services/opensearch_repository_service.py
@@ -23,6 +23,7 @@ import boto3
 from langchain_community.vectorstores import OpenSearchVectorSearch
 from langchain_core.embeddings import Embeddings
 from langchain_core.vectorstores import VectorStore
+from lisa.domain.domain_objects import RetrieveResult
 from lisa.rag.embeddings import RagEmbeddings
 from lisa.utilities.common_functions import retry_config
 from lisa.utilities.repository_types import RepositoryType
@@ -60,12 +61,11 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
         model_name: str,
         include_score: bool = False,
         bedrock_agent_client: Any = None,
-    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    ) -> RetrieveResult:
         """Retrieve documents using hybrid (BM25 + kNN) search via inline search pipeline.
 
         Sends the search pipeline definition inline in the request body — no persistent
-        pipeline, no admin state, one round-trip. Requires OpenSearch 2.13+; older
-        clusters trip the narrow-exception fallback to vector search (slice 2.2.4).
+        pipeline, no admin state, one round-trip. Requires OpenSearch 2.13+.
 
         Args:
             query: Search query text
@@ -77,8 +77,7 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
             bedrock_agent_client: Unused for OpenSearch (kept for base-class signature parity)
 
         Returns:
-            Tuple of (docs, retrieval_metadata) where retrieval_metadata reports
-            ``actual_mode_used='hybrid'`` and ``hybrid_supported=True`` on success.
+            RetrieveResult with actual_mode_used="hybrid" and hybrid_supported=True.
         """
         embeddings = RagEmbeddings(model_name=model_name)
         vector_store = self._get_vector_store_client(
@@ -89,7 +88,7 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
         if hasattr(vector_store, "client") and hasattr(vector_store.client, "indices"):
             if not vector_store.client.indices.exists(index=collection_id):
                 logger.info(f"Collection {collection_id} does not exist. Returning empty docs.")
-                return [], {"actual_mode_used": "hybrid", "hybrid_supported": True}
+                return RetrieveResult(documents=[], actual_mode_used="hybrid", hybrid_supported=True)
 
         query_vector = embeddings.embed_query(query)
         body = self._build_hybrid_body(query=query, query_vector=query_vector, top_k=top_k)
@@ -98,7 +97,7 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
         response = vector_store.client.search(index=collection_id, body=body)
 
         docs = self._extract_hits(response, include_score)
-        return docs, {"actual_mode_used": "hybrid", "hybrid_supported": True}
+        return RetrieveResult(documents=docs, actual_mode_used="hybrid", hybrid_supported=True)
 
     @staticmethod
     def _build_hybrid_body(query: str, query_vector: list[float], top_k: int) -> dict[str, Any]:
@@ -156,7 +155,7 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
         model_name: str,
         include_score: bool = False,
         bedrock_agent_client: Any = None,
-    ) -> list[dict[str, Any]]:
+    ) -> RetrieveResult:
         """Retrieve documents from OpenSearch with index existence check.
 
         Args:
@@ -168,22 +167,19 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
             bedrock_agent_client: Not used for OpenSearch
 
         Returns:
-            List of documents with page_content and metadata
+            RetrieveResult with actual_mode_used="vector" and hybrid_supported=True.
         """
-        # Create embeddings and vector store client once
         embeddings = RagEmbeddings(model_name=model_name)
         vector_store = self._get_vector_store_client(
             collection_id=collection_id,
             embeddings=embeddings,
         )
 
-        # Check if index exists before searching
         if hasattr(vector_store, "client") and hasattr(vector_store.client, "indices"):
             if not vector_store.client.indices.exists(index=collection_id):
                 logger.info(f"Collection {collection_id} does not exist. Returning empty docs.")
-                return []
+                return RetrieveResult(documents=[], actual_mode_used="vector", hybrid_supported=True)
 
-        # Perform similarity search
         results = vector_store.similarity_search_with_score(query, k=top_k)
 
         documents = []
@@ -194,7 +190,6 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
             }
 
             if include_score:
-                # OpenSearch scores are already normalized (0-1 range)
                 normalized_score = self._normalize_similarity_score(score)
                 doc_dict["metadata"]["similarity_score"] = normalized_score
 
@@ -206,7 +201,6 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
 
             documents.append(doc_dict)
 
-        # Warn if all scores are low (possible embedding model mismatch)
         if include_score and results:
             max_score = max(self._normalize_similarity_score(score) for _, score in results)
             if max_score < 0.3:
@@ -214,7 +208,7 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
                     f"All similarity scores < 0.3 for query '{query}' - " "possible embedding model mismatch"
                 )
 
-        return documents
+        return RetrieveResult(documents=documents, actual_mode_used="vector", hybrid_supported=True)
 
     def _drop_collection_index(self, collection_id: str) -> None:
         """Drop OpenSearch index for collection."""

--- a/lambda/shared/python/lisa/rag/services/opensearch_repository_service.py
+++ b/lambda/shared/python/lisa/rag/services/opensearch_repository_service.py
@@ -61,6 +61,8 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
         model_name: str,
         include_score: bool = False,
         bedrock_agent_client: Any = None,
+        vector_weight: float = 0.7,
+        lexical_weight: float = 0.3,
     ) -> RetrieveResult:
         """Retrieve documents using hybrid (BM25 + kNN) search via inline search pipeline.
 
@@ -75,10 +77,17 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
             include_score: When True, copies hit['_score'] (already 0-1 from min_max
                 normalization) to metadata['similarity_score']
             bedrock_agent_client: Unused for OpenSearch (kept for base-class signature parity)
+            vector_weight: Weight for vector (semantic) results (0-1)
+            lexical_weight: Weight for lexical (keyword) results (0-1)
 
         Returns:
             RetrieveResult with actual_mode_used="hybrid" and hybrid_supported=True.
         """
+        if not (0.0 <= vector_weight <= 1.0) or not (0.0 <= lexical_weight <= 1.0):
+            raise ValueError("vector_weight and lexical_weight must be between 0 and 1")
+        if abs(vector_weight + lexical_weight - 1.0) > 1e-9:
+            raise ValueError("vector_weight and lexical_weight must sum to 1")
+
         embeddings = RagEmbeddings(model_name=model_name)
         vector_store = self._get_vector_store_client(
             collection_id=collection_id,
@@ -91,21 +100,35 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
                 return RetrieveResult(documents=[], actual_mode_used="hybrid", hybrid_supported=True)
 
         query_vector = embeddings.embed_query(query)
-        body = self._build_hybrid_body(query=query, query_vector=query_vector, top_k=top_k)
+        body = self._build_hybrid_body(
+            query=query,
+            query_vector=query_vector,
+            top_k=top_k,
+            vector_weight=vector_weight,
+            lexical_weight=lexical_weight,
+        )
 
-        logger.info(f"Hybrid retrieving from OpenSearch: collection={collection_id}, query={query[:50]}...")
+        logger.info(
+            f"Hybrid retrieving from OpenSearch: collection={collection_id}, "
+            f"weights=[{lexical_weight},{vector_weight}], query={query[:50]}..."
+        )
         response = vector_store.client.search(index=collection_id, body=body)
 
         docs = self._extract_hits(response, include_score)
         return RetrieveResult(documents=docs, actual_mode_used="hybrid", hybrid_supported=True)
 
     @staticmethod
-    def _build_hybrid_body(query: str, query_vector: list[float], top_k: int) -> dict[str, Any]:
+    def _build_hybrid_body(
+        query: str,
+        query_vector: list[float],
+        top_k: int,
+        vector_weight: float = 0.7,
+        lexical_weight: float = 0.3,
+    ) -> dict[str, Any]:
         """Construct the OpenSearch hybrid query + inline search_pipeline body.
 
-        Built as a Python dict — no string interpolation — to prevent DSL injection
-        (OWASP A03). Weights ``[0.3, 0.7]`` are hardcoded in slice 2.2.2; phase 2.3
-        wires per-request weight overrides.
+        Built as a Python dict — no string interpolation — to prevent DSL injection (OWASP A03).
+        OpenSearch weights order is [lexical, vector] matching the queries array order.
         """
         return {
             "size": top_k,
@@ -124,7 +147,7 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
                             "normalization": {"technique": "min_max"},
                             "combination": {
                                 "technique": "arithmetic_mean",
-                                "parameters": {"weights": [0.3, 0.7]},
+                                "parameters": {"weights": [lexical_weight, vector_weight]},
                             },
                         }
                     }

--- a/lambda/shared/python/lisa/rag/services/opensearch_repository_service.py
+++ b/lambda/shared/python/lisa/rag/services/opensearch_repository_service.py
@@ -45,11 +45,10 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
     """
 
     def supports_hybrid_search(self) -> bool:
-        """OpenSearch repositories support hybrid search.
+        """OpenSearch >= 2.13 supports hybrid search via inline search pipelines.
 
-        Implementation: see ``OpenSearchRepositoryService.hybrid_retrieve()``,
-        which transparently falls back to vector search if the cluster does
-        not support hybrid (e.g., OpenSearch < 2.13).
+        If the cluster is older than 2.13, hybrid_retrieve() will propagate the
+        resulting RequestError — no silent fallback.
         """
         return True
 
@@ -163,11 +162,9 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
             source = hit.get("_source", {})
             metadata = dict(source.get("metadata", {}) or {})
             if include_score:
-                # Already 0-1 from min_max normalization in the search pipeline.
-                # Intentionally overwrites any pre-existing similarity_score in source metadata
-                # so retrieval-time scoring is authoritative over ingest-time fields.
                 raw_score = hit.get("_score")
-                metadata["similarity_score"] = float(raw_score) if raw_score is not None else None
+                if raw_score is not None:
+                    metadata["similarity_score"] = float(raw_score)
             documents.append({"page_content": source.get("text", ""), "metadata": metadata})
         return documents
 

--- a/lambda/shared/python/lisa/rag/services/opensearch_repository_service.py
+++ b/lambda/shared/python/lisa/rag/services/opensearch_repository_service.py
@@ -86,6 +86,11 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
             embeddings=embeddings,
         )
 
+        if hasattr(vector_store, "client") and hasattr(vector_store.client, "indices"):
+            if not vector_store.client.indices.exists(index=collection_id):
+                logger.info(f"Collection {collection_id} does not exist. Returning empty docs.")
+                return [], {"actual_mode_used": "hybrid", "hybrid_supported": True}
+
         query_vector = embeddings.embed_query(query)
         body = self._build_hybrid_body(query=query, query_vector=query_vector, top_k=top_k)
 

--- a/lambda/shared/python/lisa/rag/services/opensearch_repository_service.py
+++ b/lambda/shared/python/lisa/rag/services/opensearch_repository_service.py
@@ -43,6 +43,15 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
     Only implements OpenSearch-specific index management.
     """
 
+    def supports_hybrid_search(self) -> bool:
+        """OpenSearch repositories support hybrid search.
+
+        Implementation: see ``OpenSearchRepositoryService.hybrid_retrieve()``,
+        which transparently falls back to vector search if the cluster does
+        not support hybrid (e.g., OpenSearch < 2.13).
+        """
+        return True
+
     def retrieve_documents(
         self,
         query: str,

--- a/lambda/shared/python/lisa/rag/services/opensearch_repository_service.py
+++ b/lambda/shared/python/lisa/rag/services/opensearch_repository_service.py
@@ -82,11 +82,6 @@ class OpenSearchRepositoryService(VectorStoreRepositoryService):
         Returns:
             RetrieveResult with actual_mode_used="hybrid" and hybrid_supported=True.
         """
-        if not (0.0 <= vector_weight <= 1.0) or not (0.0 <= lexical_weight <= 1.0):
-            raise ValueError("vector_weight and lexical_weight must be between 0 and 1")
-        if abs(vector_weight + lexical_weight - 1.0) > 1e-9:
-            raise ValueError("vector_weight and lexical_weight must sum to 1")
-
         embeddings = RagEmbeddings(model_name=model_name)
         vector_store = self._get_vector_store_client(
             collection_id=collection_id,

--- a/lambda/shared/python/lisa/rag/services/repository_service.py
+++ b/lambda/shared/python/lisa/rag/services/repository_service.py
@@ -196,6 +196,8 @@ class RepositoryService(ABC):
         model_name: str,
         include_score: bool = False,
         bedrock_agent_client: Any | None = None,
+        vector_weight: float = 0.7,
+        lexical_weight: float = 0.3,
     ) -> RetrieveResult:
         """Retrieve documents using hybrid (semantic + lexical) search.
 
@@ -206,6 +208,8 @@ class RepositoryService(ABC):
             model_name: Embedding model name to use for query embedding
             include_score: Whether to include similarity scores in results
             bedrock_agent_client: Bedrock agent client (for Bedrock KB only)
+            vector_weight: Weight for vector (semantic) results (0-1, must sum to 1 with lexical_weight)
+            lexical_weight: Weight for lexical (keyword) results (0-1, must sum to 1 with vector_weight)
 
         Returns:
             RetrieveResult with documents, actual_mode_used, and hybrid_supported.

--- a/lambda/shared/python/lisa/rag/services/repository_service.py
+++ b/lambda/shared/python/lisa/rag/services/repository_service.py
@@ -17,7 +17,7 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-from lisa.domain.domain_objects import IngestionJob, RagCollectionConfig, RagDocument
+from lisa.domain.domain_objects import IngestionJob, RagCollectionConfig, RagDocument, RetrieveResult
 
 
 class RepositoryService(ABC):
@@ -126,7 +126,7 @@ class RepositoryService(ABC):
         model_name: str,
         include_score: bool = False,
         bedrock_agent_client: Any | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> RetrieveResult:
         """Retrieve documents matching a query.
 
         Args:
@@ -138,7 +138,8 @@ class RepositoryService(ABC):
             bedrock_agent_client: Bedrock agent client (for Bedrock KB only)
 
         Returns:
-            List of matching documents with page_content and metadata
+            RetrieveResult with documents, actual_mode_used="vector",
+            and hybrid_supported reflecting this service's capability.
         """
         pass
 
@@ -195,7 +196,7 @@ class RepositoryService(ABC):
         model_name: str,
         include_score: bool = False,
         bedrock_agent_client: Any | None = None,
-    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    ) -> RetrieveResult:
         """Retrieve documents using hybrid (semantic + lexical) search.
 
         Args:
@@ -207,11 +208,7 @@ class RepositoryService(ABC):
             bedrock_agent_client: Bedrock agent client (for Bedrock KB only)
 
         Returns:
-            Tuple of (docs, retrieval_metadata):
-              - docs: list of matching documents with page_content and metadata
-              - retrieval_metadata: dict with at least 'actual_mode_used' ('hybrid' or
-                'vector') and 'hybrid_supported' (bool). Reported even when docs is empty
-                so callers can distinguish "ran hybrid, found nothing" from "fell back".
+            RetrieveResult with documents, actual_mode_used, and hybrid_supported.
 
         Raises:
             NotImplementedError: If the repository does not support hybrid search

--- a/lambda/shared/python/lisa/rag/services/vector_store_repository_service.py
+++ b/lambda/shared/python/lisa/rag/services/vector_store_repository_service.py
@@ -32,6 +32,7 @@ from lisa.domain.domain_objects import (
     IngestionJob,
     RagCollectionConfig,
     RagDocument,
+    RetrieveResult,
     VectorStoreStatus,
 )
 from lisa.rag.embeddings import RagEmbeddings
@@ -151,7 +152,7 @@ class VectorStoreRepositoryService(RepositoryService):
         model_name: str,
         include_score: bool = False,
         bedrock_agent_client: Any | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> RetrieveResult:
         """Retrieve documents from vector store using similarity search.
 
         Args:
@@ -163,7 +164,8 @@ class VectorStoreRepositoryService(RepositoryService):
             bedrock_agent_client: Not used for vector stores
 
         Returns:
-            List of documents with page_content and metadata
+            RetrieveResult with documents, actual_mode_used="vector",
+            and hybrid_supported reflecting this service's capability.
         """
         embeddings = RagEmbeddings(model_name=model_name)
         vector_store = self._get_vector_store_client(
@@ -201,7 +203,11 @@ class VectorStoreRepositoryService(RepositoryService):
                     f"All similarity scores < 0.3 for query '{query}' - " "possible embedding model mismatch"
                 )
 
-        return documents
+        return RetrieveResult(
+            documents=documents,
+            actual_mode_used="vector",
+            hybrid_supported=self.supports_hybrid_search(),
+        )
 
     def validate_document_source(self, s3_path: str) -> str:
         """Vector stores accept any valid S3 path."""

--- a/lambda/shared/python/lisa/session/models.py
+++ b/lambda/shared/python/lisa/session/models.py
@@ -72,6 +72,8 @@ class SessionConfiguration(BaseModel):
     chatHistoryBufferSize: int = 7
     ragTopK: int = 3
     ragSearchMode: Literal["vector", "hybrid"] | None = None
+    vectorWeight: float | None = None
+    lexicalWeight: float | None = None
     modelArgs: ModelArgs = Field(default_factory=ModelArgs)
     imageGenerationArgs: ImageGenerationArgs = Field(default_factory=ImageGenerationArgs)
     videoGenerationArgs: VideoGenerationArgs = Field(default_factory=VideoGenerationArgs)

--- a/lib/user-interface/react/src/components/chatbot/Chat.tsx
+++ b/lib/user-interface/react/src/components/chatbot/Chat.tsx
@@ -754,7 +754,7 @@ export default function Chat ({ sessionId, initialStack }) {
     }, [userPreferences?.preferences?.bedrockAgents?.enabledAgents, bedrockFunctionToolIndex]);
 
     const fetchRelevantDocuments = useCallback(async (query: string) => {
-        const { ragTopK = 3 } = chatConfiguration.sessionConfiguration;
+        const { ragTopK = 3, vectorWeight, lexicalWeight } = chatConfiguration.sessionConfiguration;
 
         return getRelevantDocuments({
             query,
@@ -763,6 +763,8 @@ export default function Chat ({ sessionId, initialStack }) {
             topK: ragTopK,
             modelName: !ragConfig.collection?.collectionId ? ragConfig.embeddingModel?.modelId : undefined,
             searchMode: effectiveRagSearchMode,
+            ...(effectiveRagSearchMode === 'hybrid' && vectorWeight != null && { vectorWeight }),
+            ...(effectiveRagSearchMode === 'hybrid' && lexicalWeight != null && { lexicalWeight }),
         });
     }, [getRelevantDocuments, chatConfiguration.sessionConfiguration, ragConfig.repositoryId, ragConfig.collection, ragConfig.embeddingModel, effectiveRagSearchMode]);
 

--- a/lib/user-interface/react/src/components/chatbot/components/HybridSearchControls.test.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/HybridSearchControls.test.tsx
@@ -1,0 +1,142 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import HybridSearchControls, { HybridSearchControlsProps } from './HybridSearchControls';
+
+function renderControls (overrides: Partial<HybridSearchControlsProps> = {}) {
+    const defaultProps: HybridSearchControlsProps = {
+        vectorWeight: 0.7,
+        lexicalWeight: 0.3,
+        onChange: vi.fn(),
+        disabled: false,
+        ...overrides,
+    };
+    const result = render(<HybridSearchControls {...defaultProps} />);
+    return { ...result, props: defaultProps };
+}
+
+describe('HybridSearchControls', () => {
+    describe('rendering', () => {
+        it('renders vector slider and input with initial value', () => {
+            const { container } = renderControls({ vectorWeight: 0.7, lexicalWeight: 0.3 });
+            const vectorSlider = screen.getByRole('slider', { name: /vector weight/i });
+            expect(vectorSlider).toBeInTheDocument();
+            const numberInputs = container.querySelectorAll('input[type="number"]');
+            expect(numberInputs[0]).toHaveValue(0.7);
+        });
+
+        it('renders lexical slider and input with complementary value', () => {
+            const { container } = renderControls({ vectorWeight: 0.7, lexicalWeight: 0.3 });
+            const lexicalSlider = screen.getByRole('slider', { name: /lexical weight/i });
+            expect(lexicalSlider).toBeInTheDocument();
+            const numberInputs = container.querySelectorAll('input[type="number"]');
+            expect(numberInputs[1]).toHaveValue(0.3);
+        });
+    });
+
+    describe('slider linkage (sum-to-1 invariant)', () => {
+        it('calls onChange with complementary weights when vector slider changes', () => {
+            const onChange = vi.fn();
+            renderControls({ vectorWeight: 0.7, lexicalWeight: 0.3, onChange });
+            const vectorSlider = screen.getByRole('slider', { name: /vector weight/i });
+            fireEvent.change(vectorSlider, { target: { value: '0.6' } });
+            expect(onChange).toHaveBeenCalledWith({ vectorWeight: 0.6, lexicalWeight: 0.4 });
+        });
+
+        it('calls onChange with complementary weights when lexical slider changes', () => {
+            const onChange = vi.fn();
+            renderControls({ vectorWeight: 0.7, lexicalWeight: 0.3, onChange });
+            const lexicalSlider = screen.getByRole('slider', { name: /lexical weight/i });
+            fireEvent.change(lexicalSlider, { target: { value: '0.5' } });
+            expect(onChange).toHaveBeenCalledWith({ vectorWeight: 0.5, lexicalWeight: 0.5 });
+        });
+
+        it('clamps vector weight to 0-1 range', () => {
+            const onChange = vi.fn();
+            renderControls({ vectorWeight: 0.7, lexicalWeight: 0.3, onChange });
+            const vectorSlider = screen.getByRole('slider', { name: /vector weight/i });
+            fireEvent.change(vectorSlider, { target: { value: '1' } });
+            expect(onChange).toHaveBeenCalledWith({ vectorWeight: 1.0, lexicalWeight: 0.0 });
+        });
+    });
+
+    describe('input fields', () => {
+        it('calls onChange when vector input value is changed', () => {
+            const onChange = vi.fn();
+            const { container } = renderControls({ vectorWeight: 0.7, lexicalWeight: 0.3, onChange });
+            const vectorInput = container.querySelectorAll('input[type="number"]')[0];
+            fireEvent.change(vectorInput, { target: { value: '0.6' } });
+            expect(onChange).toHaveBeenCalledWith({ vectorWeight: 0.6, lexicalWeight: 0.4 });
+        });
+
+        it('rejects invalid input values outside 0-1 range', async () => {
+            const user = userEvent.setup();
+            const onChange = vi.fn();
+            const { container } = renderControls({ vectorWeight: 0.7, lexicalWeight: 0.3, onChange });
+            const vectorInput = container.querySelectorAll('input[type="number"]')[0];
+            await user.clear(vectorInput);
+            await user.type(vectorInput, '1.5');
+            const outOfRangeCall = onChange.mock.calls.find(
+                (call) => call[0].vectorWeight > 1 || call[0].vectorWeight < 0
+            );
+            expect(outOfRangeCall).toBeUndefined();
+        });
+    });
+
+    describe('preset buttons', () => {
+        it('clicking "Balanced" sets 0.5/0.5', async () => {
+            const user = userEvent.setup();
+            const onChange = vi.fn();
+            renderControls({ vectorWeight: 0.7, lexicalWeight: 0.3, onChange });
+            await user.click(screen.getByRole('button', { name: /balanced/i }));
+            expect(onChange).toHaveBeenCalledWith({ vectorWeight: 0.5, lexicalWeight: 0.5 });
+        });
+
+        it('clicking "Semantic-heavy" sets 0.8/0.2', async () => {
+            const user = userEvent.setup();
+            const onChange = vi.fn();
+            renderControls({ vectorWeight: 0.7, lexicalWeight: 0.3, onChange });
+            await user.click(screen.getByRole('button', { name: /semantic/i }));
+            expect(onChange).toHaveBeenCalledWith({ vectorWeight: 0.8, lexicalWeight: 0.2 });
+        });
+
+        it('clicking "Lexical-heavy" sets 0.3/0.7', async () => {
+            const user = userEvent.setup();
+            const onChange = vi.fn();
+            renderControls({ vectorWeight: 0.7, lexicalWeight: 0.3, onChange });
+            await user.click(screen.getByRole('button', { name: /lexical/i }));
+            expect(onChange).toHaveBeenCalledWith({ vectorWeight: 0.3, lexicalWeight: 0.7 });
+        });
+    });
+
+    describe('disabled state', () => {
+        it('disables sliders, inputs, and preset buttons when disabled prop is true', () => {
+            const { container } = renderControls({ disabled: true });
+            const vectorSlider = screen.getByRole('slider', { name: /vector weight/i });
+            const lexicalSlider = screen.getByRole('slider', { name: /lexical weight/i });
+            expect(vectorSlider).toBeDisabled();
+            expect(lexicalSlider).toBeDisabled();
+            const numberInputs = container.querySelectorAll('input[type="number"]');
+            numberInputs.forEach((input) => expect(input).toBeDisabled());
+            screen.getAllByRole('button').forEach((button) => {
+                expect(button).toBeDisabled();
+            });
+        });
+    });
+});

--- a/lib/user-interface/react/src/components/chatbot/components/HybridSearchControls.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/HybridSearchControls.tsx
@@ -62,7 +62,7 @@ export default function HybridSearchControls ({ vectorWeight, lexicalWeight, onC
 
     return (
         <SpaceBetween size='s'>
-            <FormField label='Vector weight' constraintText='0.0 to 1.0 — weights must sum to 1'>
+            <FormField label='Vector weight' constraintText='0.0 to 1.0 in 0.1 increments — weights must sum to 1'>
                 <Grid gridDefinition={[{ colspan: 9 }, { colspan: 3 }]}>
                     <Slider
                         ariaLabel='Vector weight'
@@ -70,6 +70,7 @@ export default function HybridSearchControls ({ vectorWeight, lexicalWeight, onC
                         min={0}
                         max={1}
                         step={0.1}
+                        tickMarks={true}
                         onChange={handleVectorSliderChange}
                         disabled={disabled}
                     />
@@ -85,7 +86,7 @@ export default function HybridSearchControls ({ vectorWeight, lexicalWeight, onC
                     />
                 </Grid>
             </FormField>
-            <FormField label='Lexical weight'>
+            <FormField label='Lexical weight' constraintText='Automatically adjusted to complement vector weight'>
                 <Grid gridDefinition={[{ colspan: 9 }, { colspan: 3 }]}>
                     <Slider
                         ariaLabel='Lexical weight'
@@ -93,6 +94,7 @@ export default function HybridSearchControls ({ vectorWeight, lexicalWeight, onC
                         min={0}
                         max={1}
                         step={0.1}
+                        tickMarks={true}
                         onChange={handleLexicalSliderChange}
                         disabled={disabled}
                     />

--- a/lib/user-interface/react/src/components/chatbot/components/HybridSearchControls.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/HybridSearchControls.tsx
@@ -14,13 +14,14 @@
   limitations under the License.
 */
 
-import { Button, FormField, Grid, Input, Slider, SpaceBetween } from '@cloudscape-design/components';
+import { Box, Button, FormField, Grid, Icon, Input, Popover, Slider, SpaceBetween } from '@cloudscape-design/components';
 
 export type HybridSearchControlsProps = {
     vectorWeight: number;
     lexicalWeight: number;
     onChange: (weights: { vectorWeight: number; lexicalWeight: number }) => void;
     disabled?: boolean;
+    disabledReason?: string;
 };
 
 const PRESETS = [
@@ -33,7 +34,7 @@ function roundTo1 (value: number): number {
     return Math.round(value * 10) / 10;
 }
 
-export default function HybridSearchControls ({ vectorWeight, lexicalWeight, onChange, disabled }: HybridSearchControlsProps) {
+export default function HybridSearchControls ({ vectorWeight, lexicalWeight, onChange, disabled, disabledReason }: HybridSearchControlsProps) {
     const handleVectorSliderChange = ({ detail }: { detail: { value: number } }) => {
         const clamped = Math.min(1, Math.max(0, roundTo1(detail.value)));
         onChange({ vectorWeight: clamped, lexicalWeight: roundTo1(1 - clamped) });
@@ -60,9 +61,23 @@ export default function HybridSearchControls ({ vectorWeight, lexicalWeight, onC
         }
     };
 
+    const disabledInfo = disabled && disabledReason ? (
+        <Popover
+            dismissButton={false}
+            position='top'
+            size='small'
+            triggerType='custom'
+            content={<Box color='text-body-secondary'>{disabledReason}</Box>}
+        >
+            <Box display='inline-block' margin={{ left: 'xs' }}>
+                <Icon name='status-info' variant='link' />
+            </Box>
+        </Popover>
+    ) : null;
+
     return (
         <SpaceBetween size='s'>
-            <FormField label='Vector weight' constraintText='0.0 to 1.0 in 0.1 increments — weights must sum to 1'>
+            <FormField label={<span>Vector weight{disabledInfo}</span>} constraintText='0.0 to 1.0 in 0.1 increments — weights must sum to 1'>
                 <Grid gridDefinition={[{ colspan: 9 }, { colspan: 3 }]}>
                     <Slider
                         ariaLabel='Vector weight'
@@ -86,7 +101,7 @@ export default function HybridSearchControls ({ vectorWeight, lexicalWeight, onC
                     />
                 </Grid>
             </FormField>
-            <FormField label='Lexical weight' constraintText='Automatically adjusted to complement vector weight'>
+            <FormField label={<span>Lexical weight{disabledInfo}</span>} constraintText='Automatically adjusted to complement vector weight'>
                 <Grid gridDefinition={[{ colspan: 9 }, { colspan: 3 }]}>
                     <Slider
                         ariaLabel='Lexical weight'

--- a/lib/user-interface/react/src/components/chatbot/components/HybridSearchControls.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/HybridSearchControls.tsx
@@ -1,0 +1,125 @@
+/**
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { Button, FormField, Grid, Input, Slider, SpaceBetween } from '@cloudscape-design/components';
+
+export type HybridSearchControlsProps = {
+    vectorWeight: number;
+    lexicalWeight: number;
+    onChange: (weights: { vectorWeight: number; lexicalWeight: number }) => void;
+    disabled?: boolean;
+};
+
+const PRESETS = [
+    { label: 'Balanced', vectorWeight: 0.5, lexicalWeight: 0.5 },
+    { label: 'Semantic-heavy', vectorWeight: 0.8, lexicalWeight: 0.2 },
+    { label: 'Lexical-heavy', vectorWeight: 0.3, lexicalWeight: 0.7 },
+] as const;
+
+function roundTo1 (value: number): number {
+    return Math.round(value * 10) / 10;
+}
+
+export default function HybridSearchControls ({ vectorWeight, lexicalWeight, onChange, disabled }: HybridSearchControlsProps) {
+    const handleVectorSliderChange = ({ detail }: { detail: { value: number } }) => {
+        const clamped = Math.min(1, Math.max(0, roundTo1(detail.value)));
+        onChange({ vectorWeight: clamped, lexicalWeight: roundTo1(1 - clamped) });
+    };
+
+    const handleLexicalSliderChange = ({ detail }: { detail: { value: number } }) => {
+        const clamped = Math.min(1, Math.max(0, roundTo1(detail.value)));
+        onChange({ vectorWeight: roundTo1(1 - clamped), lexicalWeight: clamped });
+    };
+
+    const handleVectorInputChange = ({ detail }: { detail: { value: string } }) => {
+        const parsed = parseFloat(detail.value);
+        if (!isNaN(parsed) && parsed >= 0 && parsed <= 1) {
+            const clamped = roundTo1(parsed);
+            onChange({ vectorWeight: clamped, lexicalWeight: roundTo1(1 - clamped) });
+        }
+    };
+
+    const handleLexicalInputChange = ({ detail }: { detail: { value: string } }) => {
+        const parsed = parseFloat(detail.value);
+        if (!isNaN(parsed) && parsed >= 0 && parsed <= 1) {
+            const clamped = roundTo1(parsed);
+            onChange({ vectorWeight: roundTo1(1 - clamped), lexicalWeight: clamped });
+        }
+    };
+
+    return (
+        <SpaceBetween size='s'>
+            <FormField label='Vector weight' constraintText='0.0 to 1.0 — weights must sum to 1'>
+                <Grid gridDefinition={[{ colspan: 9 }, { colspan: 3 }]}>
+                    <Slider
+                        ariaLabel='Vector weight'
+                        value={vectorWeight}
+                        min={0}
+                        max={1}
+                        step={0.1}
+                        onChange={handleVectorSliderChange}
+                        disabled={disabled}
+                    />
+                    <Input
+                        ariaLabel='Vector weight'
+                        type='number'
+                        step={0.1}
+                        inputMode='decimal'
+                        value={vectorWeight.toString()}
+                        onChange={handleVectorInputChange}
+                        disabled={disabled}
+                        disableBrowserAutocorrect={true}
+                    />
+                </Grid>
+            </FormField>
+            <FormField label='Lexical weight'>
+                <Grid gridDefinition={[{ colspan: 9 }, { colspan: 3 }]}>
+                    <Slider
+                        ariaLabel='Lexical weight'
+                        value={lexicalWeight}
+                        min={0}
+                        max={1}
+                        step={0.1}
+                        onChange={handleLexicalSliderChange}
+                        disabled={disabled}
+                    />
+                    <Input
+                        ariaLabel='Lexical weight'
+                        type='number'
+                        step={0.1}
+                        inputMode='decimal'
+                        value={lexicalWeight.toString()}
+                        onChange={handleLexicalInputChange}
+                        disabled={disabled}
+                        disableBrowserAutocorrect={true}
+                    />
+                </Grid>
+            </FormField>
+            <SpaceBetween size='xs' direction='horizontal'>
+                {PRESETS.map((preset) => (
+                    <Button
+                        key={preset.label}
+                        variant='inline-link'
+                        disabled={disabled}
+                        onClick={() => onChange({ vectorWeight: preset.vectorWeight, lexicalWeight: preset.lexicalWeight })}
+                    >
+                        {preset.label}
+                    </Button>
+                ))}
+            </SpaceBetween>
+        </SpaceBetween>
+    );
+}

--- a/lib/user-interface/react/src/components/chatbot/components/HybridSearchControls.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/HybridSearchControls.tsx
@@ -114,7 +114,7 @@ export default function HybridSearchControls ({ vectorWeight, lexicalWeight, onC
                 {PRESETS.map((preset) => (
                     <Button
                         key={preset.label}
-                        variant='inline-link'
+                        variant='normal'
                         disabled={disabled}
                         onClick={() => onChange({ vectorWeight: preset.vectorWeight, lexicalWeight: preset.lexicalWeight })}
                     >

--- a/lib/user-interface/react/src/components/chatbot/components/Message.test.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/Message.test.tsx
@@ -79,7 +79,7 @@ describe('Message - Citations similarity scores', () => {
         });
     });
 
-    it('renders similarity score badge when similarityScore is present', () => {
+    it('does not render similarity score badge inline (scores shown only in metadata)', () => {
         const message: LisaChatMessage = {
             type: MessageTypes.AI,
             content: 'Here is the answer',
@@ -91,67 +91,12 @@ describe('Message - Citations similarity scores', () => {
                         source: 's3://bucket/doc1.pdf',
                         similarityScore: 0.87,
                     },
-                    {
-                        documentId: 'doc-2',
-                        name: 'Document Two',
-                        source: 's3://bucket/doc2.pdf',
-                        similarityScore: 0.65,
-                    },
                 ],
             },
         };
 
         renderMessage(message);
 
-        expect(screen.getByText('0.87')).toBeInTheDocument();
-        expect(screen.getByText('0.65')).toBeInTheDocument();
-    });
-
-    it('does not render score when similarityScore is undefined', () => {
-        const message: LisaChatMessage = {
-            type: MessageTypes.AI,
-            content: 'Here is the answer',
-            metadata: {
-                ragDocuments: [
-                    {
-                        documentId: 'doc-1',
-                        name: 'Document One',
-                        source: 's3://bucket/doc1.pdf',
-                    },
-                ],
-            },
-        };
-
-        renderMessage(message);
-
-        expect(screen.getByText(/\[1\] Document One/)).toBeInTheDocument();
-        expect(screen.queryByText(/\d\.\d{2}/)).toBeNull();
-    });
-
-    it('renders mixed - some docs with scores, some without', () => {
-        const message: LisaChatMessage = {
-            type: MessageTypes.AI,
-            content: 'Answer text',
-            metadata: {
-                ragDocuments: [
-                    {
-                        documentId: 'doc-1',
-                        name: 'Doc With Score',
-                        source: 's3://bucket/doc1.pdf',
-                        similarityScore: 0.92,
-                    },
-                    {
-                        documentId: 'doc-2',
-                        name: 'Doc Without Score',
-                        source: 's3://bucket/doc2.pdf',
-                    },
-                ],
-            },
-        };
-
-        renderMessage(message);
-
-        expect(screen.getByText('0.92')).toBeInTheDocument();
-        expect(screen.getByText(/\[2\] Doc Without Score/)).toBeInTheDocument();
+        expect(screen.queryByText('0.87')).not.toBeInTheDocument();
     });
 });

--- a/lib/user-interface/react/src/components/chatbot/components/Message.test.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/Message.test.tsx
@@ -128,49 +128,6 @@ describe('Message - Citations similarity scores', () => {
         expect(screen.queryByText(/\d\.\d{2}/)).toBeNull();
     });
 
-    it('does not crash when similarityScore is null', () => {
-        const message: LisaChatMessage = {
-            type: MessageTypes.AI,
-            content: 'Here is the answer',
-            metadata: {
-                ragDocuments: [
-                    {
-                        documentId: 'doc-1',
-                        name: 'Null Score Doc',
-                        source: 's3://bucket/doc1.pdf',
-                        similarityScore: null as unknown as number,
-                    },
-                ],
-            },
-        };
-
-        renderMessage(message);
-
-        expect(screen.getByText(/\[1\] Null Score Doc/)).toBeInTheDocument();
-        expect(screen.queryByText(/\d\.\d{2}/)).toBeNull();
-    });
-
-    it('renders score of zero correctly', () => {
-        const message: LisaChatMessage = {
-            type: MessageTypes.AI,
-            content: 'Answer',
-            metadata: {
-                ragDocuments: [
-                    {
-                        documentId: 'doc-1',
-                        name: 'Zero Score Doc',
-                        source: 's3://bucket/doc1.pdf',
-                        similarityScore: 0,
-                    },
-                ],
-            },
-        };
-
-        renderMessage(message);
-
-        expect(screen.getByText('0.00')).toBeInTheDocument();
-    });
-
     it('renders mixed - some docs with scores, some without', () => {
         const message: LisaChatMessage = {
             type: MessageTypes.AI,

--- a/lib/user-interface/react/src/components/chatbot/components/Message.test.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/Message.test.tsx
@@ -1,0 +1,200 @@
+/**
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { Mode } from '@cloudscape-design/global-styles';
+
+import { Message } from './Message';
+import ColorSchemeContext from '@/shared/color-scheme.provider';
+import { selectCurrentUsername } from '@/shared/reducers/user.reducer';
+import { LisaChatMessage, MessageTypes } from '../../types';
+
+vi.mock('@/config/store', () => ({
+    useAppDispatch: vi.fn(() => vi.fn()),
+    useAppSelector: vi.fn(),
+}));
+
+const mockStore = configureStore({
+    reducer: {
+        user: () => ({
+            currentUser: { name: 'TestUser' },
+        }),
+    },
+});
+
+const mockColorSchemeContext = {
+    colorScheme: Mode.Light,
+    setColorScheme: vi.fn(),
+};
+
+const baseProps = {
+    isRunning: false,
+    callingToolName: '',
+    showMetadata: false,
+    isStreaming: false,
+    markdownDisplay: true,
+    setChatConfiguration: vi.fn(),
+    handleSendGenerateRequest: vi.fn(),
+    setUserPrompt: vi.fn(),
+    chatConfiguration: {} as any,
+    onOpenDocument: vi.fn(),
+};
+
+const renderMessage = (message: LisaChatMessage) => {
+    return render(
+        <Provider store={mockStore}>
+            <MemoryRouter>
+                <ColorSchemeContext.Provider value={mockColorSchemeContext}>
+                    <Message {...baseProps} message={message} />
+                </ColorSchemeContext.Provider>
+            </MemoryRouter>
+        </Provider>
+    );
+};
+
+describe('Message - Citations similarity scores', () => {
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        const storeModule = await import('@/config/store');
+        (storeModule.useAppSelector as any).mockImplementation((selector: any) => {
+            if (selector === selectCurrentUsername) return 'TestUser';
+            return undefined;
+        });
+    });
+
+    it('renders similarity score badge when similarityScore is present', () => {
+        const message: LisaChatMessage = {
+            type: MessageTypes.AI,
+            content: 'Here is the answer',
+            metadata: {
+                ragDocuments: [
+                    {
+                        documentId: 'doc-1',
+                        name: 'Document One',
+                        source: 's3://bucket/doc1.pdf',
+                        similarityScore: 0.87,
+                    },
+                    {
+                        documentId: 'doc-2',
+                        name: 'Document Two',
+                        source: 's3://bucket/doc2.pdf',
+                        similarityScore: 0.65,
+                    },
+                ],
+            },
+        };
+
+        renderMessage(message);
+
+        expect(screen.getByText('0.87')).toBeInTheDocument();
+        expect(screen.getByText('0.65')).toBeInTheDocument();
+    });
+
+    it('does not render score when similarityScore is undefined', () => {
+        const message: LisaChatMessage = {
+            type: MessageTypes.AI,
+            content: 'Here is the answer',
+            metadata: {
+                ragDocuments: [
+                    {
+                        documentId: 'doc-1',
+                        name: 'Document One',
+                        source: 's3://bucket/doc1.pdf',
+                    },
+                ],
+            },
+        };
+
+        renderMessage(message);
+
+        expect(screen.getByText(/\[1\] Document One/)).toBeInTheDocument();
+        expect(screen.queryByText(/\d\.\d{2}/)).toBeNull();
+    });
+
+    it('does not crash when similarityScore is null', () => {
+        const message: LisaChatMessage = {
+            type: MessageTypes.AI,
+            content: 'Here is the answer',
+            metadata: {
+                ragDocuments: [
+                    {
+                        documentId: 'doc-1',
+                        name: 'Null Score Doc',
+                        source: 's3://bucket/doc1.pdf',
+                        similarityScore: null as unknown as number,
+                    },
+                ],
+            },
+        };
+
+        renderMessage(message);
+
+        expect(screen.getByText(/\[1\] Null Score Doc/)).toBeInTheDocument();
+        expect(screen.queryByText(/\d\.\d{2}/)).toBeNull();
+    });
+
+    it('renders score of zero correctly', () => {
+        const message: LisaChatMessage = {
+            type: MessageTypes.AI,
+            content: 'Answer',
+            metadata: {
+                ragDocuments: [
+                    {
+                        documentId: 'doc-1',
+                        name: 'Zero Score Doc',
+                        source: 's3://bucket/doc1.pdf',
+                        similarityScore: 0,
+                    },
+                ],
+            },
+        };
+
+        renderMessage(message);
+
+        expect(screen.getByText('0.00')).toBeInTheDocument();
+    });
+
+    it('renders mixed - some docs with scores, some without', () => {
+        const message: LisaChatMessage = {
+            type: MessageTypes.AI,
+            content: 'Answer text',
+            metadata: {
+                ragDocuments: [
+                    {
+                        documentId: 'doc-1',
+                        name: 'Doc With Score',
+                        source: 's3://bucket/doc1.pdf',
+                        similarityScore: 0.92,
+                    },
+                    {
+                        documentId: 'doc-2',
+                        name: 'Doc Without Score',
+                        source: 's3://bucket/doc2.pdf',
+                    },
+                ],
+            },
+        };
+
+        renderMessage(message);
+
+        expect(screen.getByText('0.92')).toBeInTheDocument();
+        expect(screen.getByText(/\[2\] Doc Without Score/)).toBeInTheDocument();
+    });
+});

--- a/lib/user-interface/react/src/components/chatbot/components/Message.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/Message.tsx
@@ -384,19 +384,17 @@ export const Message = React.memo(({ message, isRunning, showMetadata, isStreami
                                     <SpaceBetween direction='vertical' size='xs'>
                                         {ragDocuments.map((doc, index) => (
                                             <Box key={doc.documentId || index}>
-                                                <SpaceBetween direction='horizontal' size='xs'>
-                                                    {doc.documentId && onOpenDocument ? (
-                                                        <Link
-                                                            onFollow={() => onOpenDocument(doc)}
-                                                        >
-                                                            [{index + 1}] {doc.name}
-                                                        </Link>
-                                                    ) : (
-                                                        <Box variant='span' color='text-status-inactive'>
-                                                            [{index + 1}] {doc.name} (preview unavailable)
-                                                        </Box>
-                                                    )}
-                                                </SpaceBetween>
+                                                {doc.documentId && onOpenDocument ? (
+                                                    <Link
+                                                        onFollow={() => onOpenDocument(doc)}
+                                                    >
+                                                        [{index + 1}] {doc.name}
+                                                    </Link>
+                                                ) : (
+                                                    <Box variant='span' color='text-status-inactive'>
+                                                        [{index + 1}] {doc.name} (preview unavailable)
+                                                    </Box>
+                                                )}
                                             </Box>
                                         ))}
                                     </SpaceBetween>

--- a/lib/user-interface/react/src/components/chatbot/components/Message.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/Message.tsx
@@ -396,11 +396,6 @@ export const Message = React.memo(({ message, isRunning, showMetadata, isStreami
                                                             [{index + 1}] {doc.name} (preview unavailable)
                                                         </Box>
                                                     )}
-                                                    {doc.similarityScore != null && (
-                                                        <span aria-label={`Similarity score: ${doc.similarityScore.toFixed(2)}`}>
-                                                            <Badge color='blue'>{doc.similarityScore.toFixed(2)}</Badge>
-                                                        </span>
-                                                    )}
                                                 </SpaceBetween>
                                             </Box>
                                         ))}

--- a/lib/user-interface/react/src/components/chatbot/components/Message.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/Message.tsx
@@ -384,17 +384,24 @@ export const Message = React.memo(({ message, isRunning, showMetadata, isStreami
                                     <SpaceBetween direction='vertical' size='xs'>
                                         {ragDocuments.map((doc, index) => (
                                             <Box key={doc.documentId || index}>
-                                                {doc.documentId && onOpenDocument ? (
-                                                    <Link
-                                                        onFollow={() => onOpenDocument(doc)}
-                                                    >
-                                                        [{index + 1}] {doc.name}
-                                                    </Link>
-                                                ) : (
-                                                    <Box variant='span' color='text-status-inactive'>
-                                                        [{index + 1}] {doc.name} (preview unavailable)
-                                                    </Box>
-                                                )}
+                                                <SpaceBetween direction='horizontal' size='xs'>
+                                                    {doc.documentId && onOpenDocument ? (
+                                                        <Link
+                                                            onFollow={() => onOpenDocument(doc)}
+                                                        >
+                                                            [{index + 1}] {doc.name}
+                                                        </Link>
+                                                    ) : (
+                                                        <Box variant='span' color='text-status-inactive'>
+                                                            [{index + 1}] {doc.name} (preview unavailable)
+                                                        </Box>
+                                                    )}
+                                                    {doc.similarityScore != null && (
+                                                        <span aria-label={`Similarity score: ${doc.similarityScore.toFixed(2)}`}>
+                                                            <Badge color='blue'>{doc.similarityScore.toFixed(2)}</Badge>
+                                                        </span>
+                                                    )}
+                                                </SpaceBetween>
                                             </Box>
                                         ))}
                                     </SpaceBetween>

--- a/lib/user-interface/react/src/components/chatbot/components/SessionConfiguration.test.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/SessionConfiguration.test.tsx
@@ -71,39 +71,9 @@ function buildProps (overrides: Partial<SessionConfigurationProps> = {}): Sessio
     };
 }
 
-describe('SessionConfiguration — hybrid search', () => {
-    it('shows RAG Search Mode selector when hybridSearch enabled and repo supports it', () => {
-        const props = buildProps({
-            ragConfig: { repositoryId: 'repo-1', repositoryType: 'bedrock_knowledge_base', supportsHybridSearch: true },
-        });
-        props.systemConfig.configuration.enabledComponents.hybridSearch = true;
-        render(<SessionConfiguration {...props} />);
-        expect(screen.getByText('RAG Search Mode')).toBeInTheDocument();
-    });
-
-    it('hides RAG Search Mode selector when hybridSearch admin flag is disabled', () => {
-        const props = buildProps({
-            ragConfig: { repositoryId: 'repo-1', repositoryType: 'bedrock_knowledge_base', supportsHybridSearch: true },
-        });
-        props.systemConfig.configuration.enabledComponents.hybridSearch = false;
-        render(<SessionConfiguration {...props} />);
-        expect(screen.queryByText('RAG Search Mode')).not.toBeInTheDocument();
-    });
-
-    it('hides RAG Search Mode selector when repo does not support hybrid', () => {
-        const props = buildProps({
-            ragConfig: { repositoryId: 'repo-1', repositoryType: 'opensearch', supportsHybridSearch: false },
-        });
-        props.systemConfig.configuration.enabledComponents.hybridSearch = true;
-        render(<SessionConfiguration {...props} />);
-        expect(screen.queryByText('RAG Search Mode')).not.toBeInTheDocument();
-    });
-});
-
 describe('SessionConfiguration — RAG Settings card', () => {
     it('renders RAG Settings container when editNumOfRagDocument is enabled', () => {
         const props = buildProps();
-        props.systemConfig.configuration.enabledComponents.editNumOfRagDocument = true;
         render(<SessionConfiguration {...props} />);
         expect(screen.getByText('RAG Settings')).toBeInTheDocument();
     });
@@ -143,8 +113,52 @@ describe('SessionConfiguration — RAG Settings card', () => {
         expect(screen.getByText('RAG Settings')).toBeInTheDocument();
         expect(screen.getByText('Matching RAG Excerpts')).toBeInTheDocument();
     });
+});
 
-    it('renders HybridSearchControls when hybrid mode is active', () => {
+describe('SessionConfiguration — RAG Search Mode (disable-not-hide)', () => {
+    it('RAG Search Mode is always visible in RAG Settings card', () => {
+        const props = buildProps();
+        render(<SessionConfiguration {...props} />);
+        expect(screen.getByText('RAG Search Mode')).toBeInTheDocument();
+    });
+
+    it('RAG Search Mode is enabled when hybridSearch admin flag on and repo supports it', () => {
+        const props = buildProps({
+            ragConfig: { repositoryId: 'repo-1', repositoryType: 'opensearch', supportsHybridSearch: true },
+        });
+        props.systemConfig.configuration.enabledComponents.hybridSearch = true;
+        render(<SessionConfiguration {...props} />);
+        expect(screen.queryByText('Hybrid search is disabled by your administrator')).not.toBeInTheDocument();
+        expect(screen.queryByText('Selected repository does not support hybrid search')).not.toBeInTheDocument();
+    });
+
+    it('RAG Search Mode is disabled when hybridSearch admin flag is off', () => {
+        const props = buildProps({
+            ragConfig: { repositoryId: 'repo-1', repositoryType: 'opensearch', supportsHybridSearch: true },
+        });
+        props.systemConfig.configuration.enabledComponents.hybridSearch = false;
+        render(<SessionConfiguration {...props} />);
+        expect(screen.getByText('Hybrid search is disabled by your administrator')).toBeInTheDocument();
+    });
+
+    it('RAG Search Mode is disabled when repo does not support hybrid', () => {
+        const props = buildProps({
+            ragConfig: { repositoryId: 'repo-1', repositoryType: 'opensearch', supportsHybridSearch: false },
+        });
+        props.systemConfig.configuration.enabledComponents.hybridSearch = true;
+        render(<SessionConfiguration {...props} />);
+        expect(screen.getByText('Selected repository does not support hybrid search')).toBeInTheDocument();
+    });
+});
+
+describe('SessionConfiguration — HybridSearchControls (disable-not-hide)', () => {
+    it('weight sliders are always rendered in RAG Settings card', () => {
+        const props = buildProps();
+        render(<SessionConfiguration {...props} />);
+        expect(screen.getByRole('slider', { name: /vector weight/i })).toBeInTheDocument();
+    });
+
+    it('weight sliders are enabled when hybrid mode active on OpenSearch repo', () => {
         const props = buildProps({
             ragConfig: { repositoryId: 'repo-1', repositoryType: 'opensearch', supportsHybridSearch: true },
             chatConfiguration: {
@@ -154,10 +168,11 @@ describe('SessionConfiguration — RAG Settings card', () => {
         });
         props.systemConfig.configuration.enabledComponents.hybridSearch = true;
         render(<SessionConfiguration {...props} />);
-        expect(screen.getByRole('slider', { name: /vector weight/i })).toBeInTheDocument();
+        const slider = screen.getByRole('slider', { name: /vector weight/i });
+        expect(slider).not.toBeDisabled();
     });
 
-    it('does not render HybridSearchControls when search mode is vector', () => {
+    it('weight sliders are disabled when search mode is vector', () => {
         const props = buildProps({
             ragConfig: { repositoryId: 'repo-1', repositoryType: 'opensearch', supportsHybridSearch: true },
             chatConfiguration: {
@@ -167,12 +182,13 @@ describe('SessionConfiguration — RAG Settings card', () => {
         });
         props.systemConfig.configuration.enabledComponents.hybridSearch = true;
         render(<SessionConfiguration {...props} />);
-        expect(screen.queryByRole('slider', { name: /vector weight/i })).not.toBeInTheDocument();
+        const slider = screen.getByRole('slider', { name: /vector weight/i });
+        expect(slider).toBeDisabled();
     });
 
-    it('does not render HybridSearchControls when repo does not support hybrid', () => {
+    it('weight sliders are disabled for Bedrock KB repos even in hybrid mode', () => {
         const props = buildProps({
-            ragConfig: { repositoryId: 'repo-1', repositoryType: 'opensearch', supportsHybridSearch: false },
+            ragConfig: { repositoryId: 'repo-1', repositoryType: 'bedrock_knowledge_base', supportsHybridSearch: true },
             chatConfiguration: {
                 ...baseConfig,
                 sessionConfiguration: { ...baseConfig.sessionConfiguration, ragSearchMode: 'hybrid' },
@@ -180,6 +196,22 @@ describe('SessionConfiguration — RAG Settings card', () => {
         });
         props.systemConfig.configuration.enabledComponents.hybridSearch = true;
         render(<SessionConfiguration {...props} />);
-        expect(screen.queryByRole('slider', { name: /vector weight/i })).not.toBeInTheDocument();
+        const slider = screen.getByRole('slider', { name: /vector weight/i });
+        expect(slider).toBeDisabled();
+    });
+
+    it('weight sliders are disabled when isRunning', () => {
+        const props = buildProps({
+            isRunning: true,
+            ragConfig: { repositoryId: 'repo-1', repositoryType: 'opensearch', supportsHybridSearch: true },
+            chatConfiguration: {
+                ...baseConfig,
+                sessionConfiguration: { ...baseConfig.sessionConfiguration, ragSearchMode: 'hybrid' },
+            },
+        });
+        props.systemConfig.configuration.enabledComponents.hybridSearch = true;
+        render(<SessionConfiguration {...props} />);
+        const slider = screen.getByRole('slider', { name: /vector weight/i });
+        expect(slider).toBeDisabled();
     });
 });

--- a/lib/user-interface/react/src/components/chatbot/components/SessionConfiguration.test.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/SessionConfiguration.test.tsx
@@ -99,3 +99,87 @@ describe('SessionConfiguration — hybrid search', () => {
         expect(screen.queryByText('RAG Search Mode')).not.toBeInTheDocument();
     });
 });
+
+describe('SessionConfiguration — RAG Settings card', () => {
+    it('renders RAG Settings container when editNumOfRagDocument is enabled', () => {
+        const props = buildProps();
+        props.systemConfig.configuration.enabledComponents.editNumOfRagDocument = true;
+        render(<SessionConfiguration {...props} />);
+        expect(screen.getByText('RAG Settings')).toBeInTheDocument();
+    });
+
+    it('does not render RAG Settings container when editNumOfRagDocument is disabled', () => {
+        const props = buildProps();
+        props.systemConfig.configuration.enabledComponents.editNumOfRagDocument = false;
+        render(<SessionConfiguration {...props} />);
+        expect(screen.queryByText('RAG Settings')).not.toBeInTheDocument();
+    });
+
+    it('does not render RAG Settings container for image models', () => {
+        const props = buildProps({
+            selectedModel: { modelId: 'img-model', modelType: ModelType.imagegen } as any,
+        });
+        render(<SessionConfiguration {...props} />);
+        expect(screen.queryByText('RAG Settings')).not.toBeInTheDocument();
+    });
+
+    it('does not render RAG Settings container for video models', () => {
+        const props = buildProps({
+            selectedModel: { modelId: 'vid-model', modelType: ModelType.videogen } as any,
+        });
+        render(<SessionConfiguration {...props} />);
+        expect(screen.queryByText('RAG Settings')).not.toBeInTheDocument();
+    });
+
+    it('does not render RAG Settings container when modelOnly is true', () => {
+        const props = buildProps({ modelOnly: true });
+        render(<SessionConfiguration {...props} />);
+        expect(screen.queryByText('RAG Settings')).not.toBeInTheDocument();
+    });
+
+    it('renders Matching RAG Excerpts inside the RAG Settings card', () => {
+        const props = buildProps();
+        render(<SessionConfiguration {...props} />);
+        expect(screen.getByText('RAG Settings')).toBeInTheDocument();
+        expect(screen.getByText('Matching RAG Excerpts')).toBeInTheDocument();
+    });
+
+    it('renders HybridSearchControls when hybrid mode is active', () => {
+        const props = buildProps({
+            ragConfig: { repositoryId: 'repo-1', repositoryType: 'opensearch', supportsHybridSearch: true },
+            chatConfiguration: {
+                ...baseConfig,
+                sessionConfiguration: { ...baseConfig.sessionConfiguration, ragSearchMode: 'hybrid' },
+            },
+        });
+        props.systemConfig.configuration.enabledComponents.hybridSearch = true;
+        render(<SessionConfiguration {...props} />);
+        expect(screen.getByRole('slider', { name: /vector weight/i })).toBeInTheDocument();
+    });
+
+    it('does not render HybridSearchControls when search mode is vector', () => {
+        const props = buildProps({
+            ragConfig: { repositoryId: 'repo-1', repositoryType: 'opensearch', supportsHybridSearch: true },
+            chatConfiguration: {
+                ...baseConfig,
+                sessionConfiguration: { ...baseConfig.sessionConfiguration, ragSearchMode: 'vector' },
+            },
+        });
+        props.systemConfig.configuration.enabledComponents.hybridSearch = true;
+        render(<SessionConfiguration {...props} />);
+        expect(screen.queryByRole('slider', { name: /vector weight/i })).not.toBeInTheDocument();
+    });
+
+    it('does not render HybridSearchControls when repo does not support hybrid', () => {
+        const props = buildProps({
+            ragConfig: { repositoryId: 'repo-1', repositoryType: 'opensearch', supportsHybridSearch: false },
+            chatConfiguration: {
+                ...baseConfig,
+                sessionConfiguration: { ...baseConfig.sessionConfiguration, ragSearchMode: 'hybrid' },
+            },
+        });
+        props.systemConfig.configuration.enabledComponents.hybridSearch = true;
+        render(<SessionConfiguration {...props} />);
+        expect(screen.queryByRole('slider', { name: /vector weight/i })).not.toBeInTheDocument();
+    });
+});

--- a/lib/user-interface/react/src/components/chatbot/components/SessionConfiguration.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/SessionConfiguration.tsx
@@ -252,6 +252,13 @@ export const SessionConfiguration = ({
                                     persistToSession(updatedConfiguration);
                                 }}
                                 disabled={isRunning || effectiveRagSearchMode !== 'hybrid' || ragConfig?.repositoryType === RagRepositoryType.BEDROCK_KNOWLEDGE_BASE}
+                                disabledReason={
+                                    ragConfig?.repositoryType === RagRepositoryType.BEDROCK_KNOWLEDGE_BASE
+                                        ? 'Custom weights are ignored for Bedrock Knowledge Bases'
+                                        : effectiveRagSearchMode !== 'hybrid'
+                                            ? 'Weights only apply when search mode is set to Hybrid'
+                                            : undefined
+                                }
                             />
                         </SpaceBetween>
                     </Container>

--- a/lib/user-interface/react/src/components/chatbot/components/SessionConfiguration.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/SessionConfiguration.tsx
@@ -25,6 +25,7 @@ import {
     Select,
     SpaceBetween,
 } from '@cloudscape-design/components';
+import HybridSearchControls from './HybridSearchControls';
 
 import Toggle from '@cloudscape-design/components/toggle';
 import { IChatConfiguration } from '@/shared/model/chat.configurations.model';
@@ -169,36 +170,6 @@ export const SessionConfiguration = ({
                                 />
                             </FormField>
                         ] : []),
-                        ...(systemConfig && systemConfig.configuration.enabledComponents.editNumOfRagDocument && !isImageModel && !isVideoModel && !modelOnly ? [
-                            <FormField key='ragTopK' label='Matching RAG Excerpts'>
-                                <Select
-                                    disabled={isRunning}
-                                    filteringType='auto'
-                                    selectedOption={{
-                                        value: chatConfiguration.sessionConfiguration.ragTopK.toString(),
-                                        label: chatConfiguration.sessionConfiguration.ragTopK.toString(),
-                                    }}
-                                    onChange={({ detail }) => updateSessionConfiguration('ragTopK', parseInt(detail.selectedOption.value))}
-                                    options={oneThroughTenOptions}
-                                />
-                            </FormField>
-                        ] : []),
-                        ...(systemConfig && systemConfig.configuration.enabledComponents.hybridSearch && ragConfig?.supportsHybridSearch && !isImageModel && !isVideoModel && !modelOnly ? [
-                            <FormField key='ragSearchMode' label='RAG Search Mode'>
-                                <Select
-                                    disabled={isRunning}
-                                    selectedOption={{
-                                        value: effectiveRagSearchMode,
-                                        label: effectiveRagSearchMode === 'hybrid' ? 'Hybrid' : 'Vector',
-                                    }}
-                                    onChange={({ detail }) => updateSessionConfiguration('ragSearchMode', detail.selectedOption.value)}
-                                    options={[
-                                        { value: 'vector', label: 'Vector', description: 'Semantic similarity search' },
-                                        { value: 'hybrid', label: 'Hybrid', description: 'Combined vector + keyword search' },
-                                    ]}
-                                />
-                            </FormField>
-                        ] : []),
                         ...(selectedModel?.features?.find((feature) => feature.name === ModelFeatures.REASONING) ? [
                             <FormField key='reasoningEffort' label='Reasoning Effort'>
                                 <Select
@@ -229,6 +200,72 @@ export const SessionConfiguration = ({
                         </Grid>
                     );
                 })()}
+                {systemConfig && systemConfig.configuration.enabledComponents.editNumOfRagDocument && !isImageModel && !isVideoModel && !modelOnly && (
+                    <Container header={<Header variant='h2'>RAG Settings</Header>}>
+                        <SpaceBetween size='l'>
+                            <FormField label='Matching RAG Excerpts'>
+                                <Select
+                                    disabled={isRunning}
+                                    filteringType='auto'
+                                    selectedOption={{
+                                        value: chatConfiguration.sessionConfiguration.ragTopK.toString(),
+                                        label: chatConfiguration.sessionConfiguration.ragTopK.toString(),
+                                    }}
+                                    onChange={({ detail }) => updateSessionConfiguration('ragTopK', parseInt(detail.selectedOption.value))}
+                                    options={oneThroughTenOptions}
+                                />
+                            </FormField>
+                            {systemConfig.configuration.enabledComponents.hybridSearch && ragConfig?.supportsHybridSearch && (
+                                <FormField label='RAG Search Mode'>
+                                    <Select
+                                        disabled={isRunning}
+                                        selectedOption={{
+                                            value: effectiveRagSearchMode,
+                                            label: effectiveRagSearchMode === 'hybrid' ? 'Hybrid' : 'Vector',
+                                        }}
+                                        onChange={({ detail }) => updateSessionConfiguration('ragSearchMode', detail.selectedOption.value)}
+                                        options={[
+                                            { value: 'vector', label: 'Vector', description: 'Semantic similarity search' },
+                                            { value: 'hybrid', label: 'Hybrid', description: 'Combined vector + keyword search' },
+                                        ]}
+                                    />
+                                </FormField>
+                            )}
+                            {systemConfig.configuration.enabledComponents.hybridSearch && ragConfig?.supportsHybridSearch && effectiveRagSearchMode === 'hybrid' && (
+                                <HybridSearchControls
+                                    vectorWeight={chatConfiguration.sessionConfiguration.vectorWeight ?? 0.7}
+                                    lexicalWeight={chatConfiguration.sessionConfiguration.lexicalWeight ?? 0.3}
+                                    onChange={(weights) => {
+                                        const updatedConfiguration = {
+                                            ...chatConfiguration,
+                                            sessionConfiguration: {
+                                                ...chatConfiguration.sessionConfiguration,
+                                                ...weights,
+                                            },
+                                        };
+                                        setChatConfiguration(updatedConfiguration);
+                                        if (
+                                            session &&
+                                            updateSession &&
+                                            session.history.length > 0 &&
+                                            !sessionHistoryHasPendingAssistantToolCalls(session.history as LisaChatMessage[])
+                                        ) {
+                                            updateSession({
+                                                ...session,
+                                                configuration: {
+                                                    ...updatedConfiguration,
+                                                    selectedModel: selectedModel,
+                                                    ragConfig: ragConfig,
+                                                },
+                                            });
+                                        }
+                                    }}
+                                    disabled={isRunning}
+                                />
+                            )}
+                        </SpaceBetween>
+                    </Container>
+                )}
                 {systemConfig && systemConfig.configuration.enabledComponents.editKwargs && !isImageModel && !isVideoModel &&
                     <Container
                         header={

--- a/lib/user-interface/react/src/components/chatbot/components/SessionConfiguration.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/SessionConfiguration.tsx
@@ -36,6 +36,7 @@ import AwsCredentialsPanel from '@/components/settings/AwsCredentialsPanel';
 import { sessionHistoryHasPendingAssistantToolCalls } from '../utils/sessionPersist.utils';
 import { RagConfig } from './RagOptions';
 import { deriveRagSearchMode } from '@/shared/util/ragSearchMode';
+import { RagRepositoryType } from '#root/lib/schema';
 
 export type SessionConfigurationProps = {
     title?: string;
@@ -215,40 +216,43 @@ export const SessionConfiguration = ({
                                     options={oneThroughTenOptions}
                                 />
                             </FormField>
-                            {systemConfig.configuration.enabledComponents.hybridSearch && ragConfig?.supportsHybridSearch && (
-                                <FormField label='RAG Search Mode'>
-                                    <Select
-                                        disabled={isRunning}
-                                        selectedOption={{
-                                            value: effectiveRagSearchMode,
-                                            label: effectiveRagSearchMode === 'hybrid' ? 'Hybrid' : 'Vector',
-                                        }}
-                                        onChange={({ detail }) => updateSessionConfiguration('ragSearchMode', detail.selectedOption.value)}
-                                        options={[
-                                            { value: 'vector', label: 'Vector', description: 'Semantic similarity search' },
-                                            { value: 'hybrid', label: 'Hybrid', description: 'Combined vector + keyword search' },
-                                        ]}
-                                    />
-                                </FormField>
-                            )}
-                            {systemConfig.configuration.enabledComponents.hybridSearch && ragConfig?.supportsHybridSearch && effectiveRagSearchMode === 'hybrid' && (
-                                <HybridSearchControls
-                                    vectorWeight={chatConfiguration.sessionConfiguration.vectorWeight ?? 0.7}
-                                    lexicalWeight={chatConfiguration.sessionConfiguration.lexicalWeight ?? 0.3}
-                                    onChange={(weights) => {
-                                        const updatedConfiguration = {
-                                            ...chatConfiguration,
-                                            sessionConfiguration: {
-                                                ...chatConfiguration.sessionConfiguration,
-                                                ...weights,
-                                            },
-                                        };
-                                        setChatConfiguration(updatedConfiguration);
-                                        persistToSession(updatedConfiguration);
+                            <FormField
+                                label='RAG Search Mode'
+                                description={!systemConfig.configuration.enabledComponents.hybridSearch
+                                    ? 'Hybrid search is disabled by your administrator'
+                                    : !ragConfig?.supportsHybridSearch
+                                        ? 'Selected repository does not support hybrid search'
+                                        : undefined}
+                            >
+                                <Select
+                                    disabled={isRunning || !systemConfig.configuration.enabledComponents.hybridSearch || !ragConfig?.supportsHybridSearch}
+                                    selectedOption={{
+                                        value: effectiveRagSearchMode,
+                                        label: effectiveRagSearchMode === 'hybrid' ? 'Hybrid' : 'Vector',
                                     }}
-                                    disabled={isRunning}
+                                    onChange={({ detail }) => updateSessionConfiguration('ragSearchMode', detail.selectedOption.value)}
+                                    options={[
+                                        { value: 'vector', label: 'Vector', description: 'Semantic similarity search' },
+                                        { value: 'hybrid', label: 'Hybrid', description: 'Combined vector + keyword search' },
+                                    ]}
                                 />
-                            )}
+                            </FormField>
+                            <HybridSearchControls
+                                vectorWeight={chatConfiguration.sessionConfiguration.vectorWeight ?? 0.7}
+                                lexicalWeight={chatConfiguration.sessionConfiguration.lexicalWeight ?? 0.3}
+                                onChange={(weights) => {
+                                    const updatedConfiguration = {
+                                        ...chatConfiguration,
+                                        sessionConfiguration: {
+                                            ...chatConfiguration.sessionConfiguration,
+                                            ...weights,
+                                        },
+                                    };
+                                    setChatConfiguration(updatedConfiguration);
+                                    persistToSession(updatedConfiguration);
+                                }}
+                                disabled={isRunning || effectiveRagSearchMode !== 'hybrid' || ragConfig?.repositoryType === RagRepositoryType.BEDROCK_KNOWLEDGE_BASE}
+                            />
                         </SpaceBetween>
                     </Container>
                 )}

--- a/lib/user-interface/react/src/components/chatbot/components/SessionConfiguration.tsx
+++ b/lib/user-interface/react/src/components/chatbot/components/SessionConfiguration.tsx
@@ -69,16 +69,7 @@ export const SessionConfiguration = ({
     // Defaults based on https://huggingface.co/docs/transformers/main_classes/text_generation#transformers.GenerationConfig
     // Default stop sequences based on User/Assistant instruction prompting for Falcon, Mistral, etc.
 
-    const updateSessionConfiguration = (property: string, value: any): void => {
-        const updatedConfiguration = {
-            ...chatConfiguration,
-            sessionConfiguration: { ...chatConfiguration.sessionConfiguration, [property]: value },
-        };
-
-        setChatConfiguration(updatedConfiguration);
-
-        // Immediately persist the configuration to the session if available (avoid PUT while assistant
-        // tool calls are still pending — same half-finished history issue as Chat auto-save)
+    const persistToSession = (updatedConfiguration: IChatConfiguration): void => {
         if (
             session &&
             updateSession &&
@@ -90,10 +81,19 @@ export const SessionConfiguration = ({
                 configuration: {
                     ...updatedConfiguration,
                     selectedModel: selectedModel,
-                    ragConfig: ragConfig
-                }
+                    ragConfig: ragConfig,
+                },
             });
         }
+    };
+
+    const updateSessionConfiguration = (property: string, value: any): void => {
+        const updatedConfiguration = {
+            ...chatConfiguration,
+            sessionConfiguration: { ...chatConfiguration.sessionConfiguration, [property]: value },
+        };
+        setChatConfiguration(updatedConfiguration);
+        persistToSession(updatedConfiguration);
     };
 
     const oneThroughTenOptions = [...Array(10).keys()].map((i) => {
@@ -244,21 +244,7 @@ export const SessionConfiguration = ({
                                             },
                                         };
                                         setChatConfiguration(updatedConfiguration);
-                                        if (
-                                            session &&
-                                            updateSession &&
-                                            session.history.length > 0 &&
-                                            !sessionHistoryHasPendingAssistantToolCalls(session.history as LisaChatMessage[])
-                                        ) {
-                                            updateSession({
-                                                ...session,
-                                                configuration: {
-                                                    ...updatedConfiguration,
-                                                    selectedModel: selectedModel,
-                                                    ragConfig: ragConfig,
-                                                },
-                                            });
-                                        }
+                                        persistToSession(updatedConfiguration);
                                     }}
                                     disabled={isRunning}
                                 />

--- a/lib/user-interface/react/src/components/chatbot/utils/messageBuilder.utils.test.tsx
+++ b/lib/user-interface/react/src/components/chatbot/utils/messageBuilder.utils.test.tsx
@@ -93,6 +93,43 @@ describe('structureRagDocuments', () => {
     it('returns empty array for non-array input', () => {
         expect(structureRagDocuments('not an array')).toEqual([]);
     });
+
+    it('coerces string similarity_score to number', () => {
+        const docs = [makeDoc({ similarity_score: '0.87' })];
+        const result = structureRagDocuments(docs);
+        expect(result[0].similarityScore).toBe(0.87);
+        expect(typeof result[0].similarityScore).toBe('number');
+    });
+
+    it('returns undefined for non-numeric similarity_score string', () => {
+        const docs = [makeDoc({ similarity_score: 'not-a-number' })];
+        const result = structureRagDocuments(docs);
+        expect(result[0].similarityScore).toBeUndefined();
+    });
+
+    it('returns undefined for NaN similarity_score', () => {
+        const docs = [makeDoc({ similarity_score: NaN })];
+        const result = structureRagDocuments(docs);
+        expect(result[0].similarityScore).toBeUndefined();
+    });
+
+    it('returns undefined for Infinity similarity_score', () => {
+        const docs = [makeDoc({ similarity_score: Infinity })];
+        const result = structureRagDocuments(docs);
+        expect(result[0].similarityScore).toBeUndefined();
+    });
+
+    it('returns undefined for null similarity_score', () => {
+        const docs = [makeDoc({ similarity_score: null })];
+        const result = structureRagDocuments(docs);
+        expect(result[0].similarityScore).toBeUndefined();
+    });
+
+    it('preserves zero as valid similarity_score', () => {
+        const docs = [makeDoc({ similarity_score: 0 })];
+        const result = structureRagDocuments(docs);
+        expect(result[0].similarityScore).toBe(0);
+    });
 });
 
 describe('buildMessageMetadata', () => {

--- a/lib/user-interface/react/src/components/chatbot/utils/messageBuilder.utils.test.tsx
+++ b/lib/user-interface/react/src/components/chatbot/utils/messageBuilder.utils.test.tsx
@@ -94,42 +94,6 @@ describe('structureRagDocuments', () => {
         expect(structureRagDocuments('not an array')).toEqual([]);
     });
 
-    it('coerces string similarity_score to number', () => {
-        const docs = [makeDoc({ similarity_score: '0.87' })];
-        const result = structureRagDocuments(docs);
-        expect(result[0].similarityScore).toBe(0.87);
-        expect(typeof result[0].similarityScore).toBe('number');
-    });
-
-    it('returns undefined for non-numeric similarity_score string', () => {
-        const docs = [makeDoc({ similarity_score: 'not-a-number' })];
-        const result = structureRagDocuments(docs);
-        expect(result[0].similarityScore).toBeUndefined();
-    });
-
-    it('returns undefined for NaN similarity_score', () => {
-        const docs = [makeDoc({ similarity_score: NaN })];
-        const result = structureRagDocuments(docs);
-        expect(result[0].similarityScore).toBeUndefined();
-    });
-
-    it('returns undefined for Infinity similarity_score', () => {
-        const docs = [makeDoc({ similarity_score: Infinity })];
-        const result = structureRagDocuments(docs);
-        expect(result[0].similarityScore).toBeUndefined();
-    });
-
-    it('returns undefined for null similarity_score', () => {
-        const docs = [makeDoc({ similarity_score: null })];
-        const result = structureRagDocuments(docs);
-        expect(result[0].similarityScore).toBeUndefined();
-    });
-
-    it('preserves zero as valid similarity_score', () => {
-        const docs = [makeDoc({ similarity_score: 0 })];
-        const result = structureRagDocuments(docs);
-        expect(result[0].similarityScore).toBe(0);
-    });
 });
 
 describe('buildMessageMetadata', () => {

--- a/lib/user-interface/react/src/components/chatbot/utils/messageBuilder.utils.tsx
+++ b/lib/user-interface/react/src/components/chatbot/utils/messageBuilder.utils.tsx
@@ -75,6 +75,12 @@ export const buildMessageContent = async ({
  * Multiple chunks may come from the same document.
  * Includes all documents, even if they don't have document_id (for backward compatibility).
  */
+const parseSimilarityScore = (raw: unknown): number | undefined => {
+    if (raw == null) return undefined;
+    const num = Number(raw);
+    return Number.isFinite(num) ? num : undefined;
+};
+
 export const structureRagDocuments = (docs: any): RagDocumentCitation[] => {
     if (!docs || !Array.isArray(docs)) return [];
 
@@ -91,7 +97,7 @@ export const structureRagDocuments = (docs: any): RagDocumentCitation[] => {
                 source: source,
                 repositoryId: metadata.repositoryId,
                 collectionId: metadata.collectionId,
-                similarityScore: metadata.similarity_score,
+                similarityScore: parseSimilarityScore(metadata.similarity_score),
             });
         }
     });

--- a/lib/user-interface/react/src/components/chatbot/utils/messageBuilder.utils.tsx
+++ b/lib/user-interface/react/src/components/chatbot/utils/messageBuilder.utils.tsx
@@ -75,12 +75,6 @@ export const buildMessageContent = async ({
  * Multiple chunks may come from the same document.
  * Includes all documents, even if they don't have document_id (for backward compatibility).
  */
-const parseSimilarityScore = (raw: unknown): number | undefined => {
-    if (raw == null) return undefined;
-    const num = Number(raw);
-    return Number.isFinite(num) ? num : undefined;
-};
-
 export const structureRagDocuments = (docs: any): RagDocumentCitation[] => {
     if (!docs || !Array.isArray(docs)) return [];
 
@@ -97,7 +91,7 @@ export const structureRagDocuments = (docs: any): RagDocumentCitation[] => {
                 source: source,
                 repositoryId: metadata.repositoryId,
                 collectionId: metadata.collectionId,
-                similarityScore: parseSimilarityScore(metadata.similarity_score),
+                similarityScore: metadata.similarity_score,
             });
         }
     });

--- a/lib/user-interface/react/src/shared/model/chat.configurations.model.ts
+++ b/lib/user-interface/react/src/shared/model/chat.configurations.model.ts
@@ -63,6 +63,8 @@ export type ISessionConfiguration = {
     },
     remixVideoId?: string;
     ragSearchMode?: 'vector' | 'hybrid';
+    vectorWeight?: number;
+    lexicalWeight?: number;
 };
 
 export type GenerateLLMRequestParams = {

--- a/lib/user-interface/react/src/shared/reducers/rag.reducer.ts
+++ b/lib/user-interface/react/src/shared/reducers/rag.reducer.ts
@@ -61,6 +61,8 @@ type RelevantDocRequest = {
     topK: number,
     modelName?: string,
     searchMode?: 'vector' | 'hybrid',
+    vectorWeight?: number,
+    lexicalWeight?: number,
 };
 
 export type RelevantDocumentsResponse = {
@@ -253,6 +255,13 @@ export const ragApi = createApi({
 
                 if (request.searchMode && request.searchMode !== 'vector') {
                     params.searchMode = request.searchMode;
+                }
+
+                if (request.vectorWeight != null) {
+                    params.vectorWeight = request.vectorWeight.toString();
+                }
+                if (request.lexicalWeight != null) {
+                    params.lexicalWeight = request.lexicalWeight.toString();
                 }
 
                 const queryString = new URLSearchParams(params).toString();

--- a/lisa-sdk/lisapy/rag.py
+++ b/lisa-sdk/lisapy/rag.py
@@ -194,6 +194,8 @@ class RagMixin(BaseMixin):
         model_name: str | None = None,
         search_mode: str | None = None,
         include_score: bool = False,
+        vector_weight: float | None = None,
+        lexical_weight: float | None = None,
     ) -> dict:
         """Perform similarity search.
 
@@ -228,6 +230,12 @@ class RagMixin(BaseMixin):
 
         if include_score:
             params["score"] = "true"
+
+        if vector_weight is not None:
+            params["vectorWeight"] = vector_weight
+
+        if lexical_weight is not None:
+            params["lexicalWeight"] = lexical_weight
 
         response = self._session.get(url, params=params)
         if response.status_code == 200:

--- a/lisa-sdk/lisapy/rag.py
+++ b/lisa-sdk/lisapy/rag.py
@@ -219,7 +219,7 @@ class RagMixin(BaseMixin):
                 and 'hybrid_supported' fields describing the retrieval that was performed
         """
         url = f"{self.url}/repository/{repo_id}/similaritySearch"
-        params: dict[str, str | int] = {"query": query, "repositoryType": repo_id, "topK": k}
+        params: dict[str, str | int | float] = {"query": query, "repositoryType": repo_id, "topK": k}
 
         if collection_id:
             params["collectionId"] = collection_id

--- a/lisa-sdk/lisapy/rag.py
+++ b/lisa-sdk/lisapy/rag.py
@@ -207,6 +207,8 @@ class RagMixin(BaseMixin):
             model_name: Optional model name (required if collection_id not provided)
             search_mode: Optional search mode ('vector' or 'hybrid')
             include_score: Include similarity scores in results
+            vector_weight: Weight for vector/semantic results (0-1, must sum to 1 with lexical_weight)
+            lexical_weight: Weight for lexical/keyword results (0-1, must sum to 1 with vector_weight)
 
         Returns:
             Dict with:

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "test": "jest && npm run test --workspaces",
     "test:coverage": "jest --coverage && npm run test:coverage --workspaces --if-present && npm run test:python:coverage",
     "test:python:coverage": "bash scripts/run-pytest.sh test/lambda test/mcp-workbench test/sdk test/rest-api --verbose --cov=lambda --cov=lib/serve/mcp-workbench/src --cov=lisa-sdk/lisapy --cov=lib/serve/rest-api/src --cov-report=term-missing --cov-fail-under=80 --cov-config=lib/serve/rest-api/.coveragerc",
+    "test:unit": "jest && bash scripts/run-pytest.sh test/lambda test/sdk test/rest-api test/mcp-workbench --verbose && npm run test --prefix lib/user-interface/react",
     "test:lambda": "bash scripts/run-pytest.sh test/lambda --verbose",
     "test:mcp-workbench": "bash scripts/run-pytest.sh test/mcp-workbench --verbose",
     "test:sdk": "bash scripts/run-pytest.sh test/sdk --verbose",

--- a/test/cdk/stacks/__baselines__/LisaApiDeployment.json
+++ b/test/cdk/stacks/__baselines__/LisaApiDeployment.json
@@ -1,6 +1,6 @@
 {
   "Resources": {
-    "Deployment178044076757980EEC674": {
+    "Deployment17804400386950223EA8F": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {

--- a/test/cdk/stacks/__baselines__/LisaModels.json
+++ b/test/cdk/stacks/__baselines__/LisaModels.json
@@ -5117,7 +5117,7 @@
         ]
       }
     },
-    "ModelsApiLambdaInvokeAccessRemoteLisaModelsmodelshandler8ef5C72976C2": {
+    "ModelsApiLambdaInvokeAccessRemoteLisaModelsmodelshandler55f46C3990DF": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
@@ -5156,7 +5156,7 @@
         }
       }
     },
-    "ModelsApiLambdaInvokeAccessRemoteLisaModelsmodelshandler5139141A9A79": {
+    "ModelsApiLambdaInvokeAccessRemoteLisaModelsmodelshandler97bd3439D07B": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
@@ -5310,7 +5310,7 @@
         "RetentionInDays": 30
       }
     },
-    "ModelsApiLambdaInvokeAccessRemoteLisaModelsmodelshandler65402BF3BA05": {
+    "ModelsApiLambdaInvokeAccessRemoteLisaModelsmodelshandler4974D889C356": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
@@ -6198,7 +6198,7 @@
             "Arn"
           ]
         },
-        "timestamp": "2026-06-02T22:52:47.853Z"
+        "timestamp": "2026-06-02T22:40:38.976Z"
       },
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"

--- a/test/lambda/repository/services/test_bedrock_kb_repository_service.py
+++ b/test/lambda/repository/services/test_bedrock_kb_repository_service.py
@@ -228,13 +228,15 @@ class TestBedrockKBRepositoryService:
             ]
         }
 
-        results = bedrock_kb_service.retrieve_documents(
+        result = bedrock_kb_service.retrieve_documents(
             "test query", "ds-456", 5, "test-model", bedrock_agent_client=mock_bedrock_agent_client
         )
 
-        assert len(results) == 2
-        assert results[0]["page_content"] == "Test content 1"
-        assert results[1]["page_content"] == "Test content 2"
+        assert len(result.documents) == 2
+        assert result.documents[0]["page_content"] == "Test content 1"
+        assert result.documents[1]["page_content"] == "Test content 2"
+        assert result.actual_mode_used == "vector"
+        assert result.hybrid_supported is True
 
     def test_retrieve_documents_missing_bedrock_client(self, bedrock_kb_service):
         """Test retrieving documents without Bedrock client raises error."""
@@ -341,7 +343,7 @@ class TestBedrockKBRepositoryService:
         assert vector_config["filter"]["equals"]["value"] == "ds-456"
 
     def test_hybrid_retrieve_returns_documents_with_hybrid_metadata(self, bedrock_kb_service):
-        """hybrid_retrieve returns (docs, retrieval_metadata) tuple with hybrid mode."""
+        """hybrid_retrieve returns RetrieveResult with hybrid mode."""
         mock_client = MagicMock()
         mock_client.retrieve.return_value = {
             "retrievalResults": [
@@ -354,7 +356,7 @@ class TestBedrockKBRepositoryService:
             ]
         }
 
-        docs, retrieval_metadata = bedrock_kb_service.hybrid_retrieve(
+        result = bedrock_kb_service.hybrid_retrieve(
             query="test",
             collection_id="ds-456",
             top_k=5,
@@ -363,12 +365,12 @@ class TestBedrockKBRepositoryService:
             bedrock_agent_client=mock_client,
         )
 
-        assert len(docs) == 1
-        assert docs[0]["page_content"] == "Hybrid result"
-        assert docs[0]["metadata"]["similarity_score"] == 0.92
-        assert docs[0]["metadata"]["source"] == "s3://bucket/doc.pdf"
-        assert retrieval_metadata["actual_mode_used"] == "hybrid"
-        assert retrieval_metadata["hybrid_supported"] is True
+        assert len(result.documents) == 1
+        assert result.documents[0]["page_content"] == "Hybrid result"
+        assert result.documents[0]["metadata"]["similarity_score"] == 0.92
+        assert result.documents[0]["metadata"]["source"] == "s3://bucket/doc.pdf"
+        assert result.actual_mode_used == "hybrid"
+        assert result.hybrid_supported is True
 
     def test_hybrid_retrieve_missing_bedrock_client(self, bedrock_kb_service):
         """hybrid_retrieve raises ValueError when bedrock_agent_client is None."""
@@ -398,7 +400,7 @@ class TestBedrockKBRepositoryService:
             },
         ]
 
-        docs, retrieval_metadata = bedrock_kb_service.hybrid_retrieve(
+        result = bedrock_kb_service.hybrid_retrieve(
             query="test",
             collection_id="ds-456",
             top_k=5,
@@ -407,20 +409,15 @@ class TestBedrockKBRepositoryService:
             bedrock_agent_client=mock_client,
         )
 
-        assert len(docs) == 1
-        assert docs[0]["page_content"] == "fallback result"
-        assert docs[0]["metadata"]["similarity_score"] == 0.8
-        assert retrieval_metadata["actual_mode_used"] == "vector"
-        assert retrieval_metadata["hybrid_supported"] is False
+        assert len(result.documents) == 1
+        assert result.documents[0]["page_content"] == "fallback result"
+        assert result.documents[0]["metadata"]["similarity_score"] == 0.8
+        assert result.actual_mode_used == "vector"
+        assert result.hybrid_supported is False
         assert mock_client.retrieve.call_count == 2
 
     def test_hybrid_retrieve_fallback_metadata_when_docs_empty(self, bedrock_kb_service):
-        """Fallback metadata is reported even when the fallback response has zero docs.
-
-        Regression for the empty-docs bug: previously the per-doc metadata stamping was the
-        only signal of fallback, which disappeared when no docs matched. The retrieval
-        metadata returned alongside docs must still indicate vector fallback.
-        """
+        """Fallback metadata is reported even when the fallback response has zero docs."""
         mock_client = MagicMock()
         error_response = {"Error": {"Code": "ValidationException", "Message": "Hybrid not supported"}}
         mock_client.retrieve.side_effect = [
@@ -428,7 +425,7 @@ class TestBedrockKBRepositoryService:
             {"retrievalResults": []},
         ]
 
-        docs, retrieval_metadata = bedrock_kb_service.hybrid_retrieve(
+        result = bedrock_kb_service.hybrid_retrieve(
             query="test",
             collection_id="ds-456",
             top_k=5,
@@ -437,9 +434,9 @@ class TestBedrockKBRepositoryService:
             bedrock_agent_client=mock_client,
         )
 
-        assert docs == []
-        assert retrieval_metadata["actual_mode_used"] == "vector"
-        assert retrieval_metadata["hybrid_supported"] is False
+        assert result.documents == []
+        assert result.actual_mode_used == "vector"
+        assert result.hybrid_supported is False
         assert mock_client.retrieve.call_count == 2
 
     def test_hybrid_retrieve_reraises_non_validation_client_error(self, bedrock_kb_service):

--- a/test/lambda/repository/services/test_opensearch_repository_service.py
+++ b/test/lambda/repository/services/test_opensearch_repository_service.py
@@ -270,3 +270,30 @@ class TestOpenSearchRepositoryService:
         assert docs == []
         assert retrieval_metadata["actual_mode_used"] == "hybrid"
         assert retrieval_metadata["hybrid_supported"] is True
+
+    def test_hybrid_retrieve_returns_empty_when_index_missing(self, opensearch_service):
+        """hybrid_retrieve returns ([], metadata) when the target index does not exist.
+
+        Parity with retrieve_documents (lines 176-179): check index existence before
+        searching to avoid noisy 404s from OpenSearch. Reports hybrid_supported=True
+        (the cluster supports hybrid; the index just doesn't exist yet).
+        """
+        mock_vector_store = MagicMock()
+        mock_vector_store.client.indices.exists.return_value = False
+        mock_embeddings = MagicMock()
+        mock_embeddings.embed_query.return_value = [0.1, 0.2, 0.3]
+
+        with patch(
+            "lisa.rag.services.opensearch_repository_service.RagEmbeddings", return_value=mock_embeddings
+        ), patch.object(opensearch_service, "_get_vector_store_client", return_value=mock_vector_store):
+            docs, retrieval_metadata = opensearch_service.hybrid_retrieve(
+                query="test query",
+                collection_id="nonexistent-index",
+                top_k=5,
+                model_name="amazon.titan-embed-text-v1",
+            )
+
+        assert docs == []
+        assert retrieval_metadata["actual_mode_used"] == "hybrid"
+        assert retrieval_metadata["hybrid_supported"] is True
+        mock_vector_store.client.search.assert_not_called()

--- a/test/lambda/repository/services/test_opensearch_repository_service.py
+++ b/test/lambda/repository/services/test_opensearch_repository_service.py
@@ -128,7 +128,7 @@ class TestOpenSearchRepositoryService:
         Asserts the request body has:
           - query.hybrid.queries with both BM25 (match on `text`) and kNN (on `vector_field`)
           - search_pipeline.phase_results_processors with normalization-processor (min_max)
-          - combination weights [0.3, 0.7] (lexical, vector) — hardcoded in slice 2.2.2
+          - combination weights [0.3, 0.7] (lexical, vector) — defaults
           - top_k preserved as `size`
         """
         mock_vector_store = MagicMock()
@@ -164,6 +164,69 @@ class TestOpenSearchRepositoryService:
         norm = processors[0]["normalization-processor"]
         assert norm["normalization"]["technique"] == "min_max"
         assert norm["combination"]["technique"] == "arithmetic_mean"
+        assert norm["combination"]["parameters"]["weights"] == [0.3, 0.7]
+
+    @pytest.mark.parametrize(
+        "vector_weight,lexical_weight,expected_os_weights",
+        [
+            (0.8, 0.2, [0.2, 0.8]),  # OpenSearch order is [lexical, vector]
+            (0.5, 0.5, [0.5, 0.5]),
+            (1.0, 0.0, [0.0, 1.0]),
+            (0.0, 1.0, [1.0, 0.0]),
+        ],
+        ids=["semantic-heavy", "balanced", "vector-only", "lexical-only"],
+    )
+    def test_hybrid_retrieve_applies_custom_weights(
+        self, opensearch_service, vector_weight, lexical_weight, expected_os_weights
+    ):
+        """hybrid_retrieve passes caller-supplied weights to combination.parameters.weights.
+
+        OpenSearch weights order is [lexical, vector] — opposite of the caller's perspective.
+        """
+        mock_vector_store = MagicMock()
+        mock_vector_store.client.indices.exists.return_value = True
+        mock_vector_store.client.search.return_value = {"hits": {"hits": []}}
+
+        mock_embeddings = MagicMock()
+        mock_embeddings.embed_query.return_value = [0.1, 0.2, 0.3]
+
+        with patch(
+            "lisa.rag.services.opensearch_repository_service.RagEmbeddings", return_value=mock_embeddings
+        ), patch.object(opensearch_service, "_get_vector_store_client", return_value=mock_vector_store):
+            opensearch_service.hybrid_retrieve(
+                query="test query",
+                collection_id="test-collection",
+                top_k=5,
+                model_name="amazon.titan-embed-text-v1",
+                vector_weight=vector_weight,
+                lexical_weight=lexical_weight,
+            )
+
+        body = mock_vector_store.client.search.call_args.kwargs["body"]
+        norm = body["search_pipeline"]["phase_results_processors"][0]["normalization-processor"]
+        assert norm["combination"]["parameters"]["weights"] == expected_os_weights
+
+    def test_hybrid_retrieve_uses_defaults_when_no_weights_specified(self, opensearch_service):
+        """Without explicit weights, defaults to 0.7 vector / 0.3 lexical → [0.3, 0.7] in OpenSearch."""
+        mock_vector_store = MagicMock()
+        mock_vector_store.client.indices.exists.return_value = True
+        mock_vector_store.client.search.return_value = {"hits": {"hits": []}}
+
+        mock_embeddings = MagicMock()
+        mock_embeddings.embed_query.return_value = [0.1, 0.2, 0.3]
+
+        with patch(
+            "lisa.rag.services.opensearch_repository_service.RagEmbeddings", return_value=mock_embeddings
+        ), patch.object(opensearch_service, "_get_vector_store_client", return_value=mock_vector_store):
+            opensearch_service.hybrid_retrieve(
+                query="test query",
+                collection_id="test-collection",
+                top_k=5,
+                model_name="amazon.titan-embed-text-v1",
+            )
+
+        body = mock_vector_store.client.search.call_args.kwargs["body"]
+        norm = body["search_pipeline"]["phase_results_processors"][0]["normalization-processor"]
         assert norm["combination"]["parameters"]["weights"] == [0.3, 0.7]
 
     def test_hybrid_retrieve_returns_docs_and_hybrid_metadata(self, opensearch_service):
@@ -347,3 +410,27 @@ class TestOpenSearchRepositoryService:
                 )
 
         assert exc_info.value.status_code == 503
+
+    @pytest.mark.parametrize(
+        "vector_weight,lexical_weight",
+        [
+            (-0.1, 1.1),
+            (1.1, -0.1),
+            (0.5, 0.3),  # sum < 1
+            (0.7, 0.7),  # sum > 1
+            (float("inf"), 0.0),
+            (float("nan"), 0.3),
+        ],
+        ids=["negative-vector", "negative-lexical", "sum-lt-1", "sum-gt-1", "inf", "nan"],
+    )
+    def test_hybrid_retrieve_rejects_invalid_weights(self, opensearch_service, vector_weight, lexical_weight):
+        """hybrid_retrieve raises ValueError for out-of-range or non-summing weights."""
+        with pytest.raises(ValueError):
+            opensearch_service.hybrid_retrieve(
+                query="test",
+                collection_id="test-collection",
+                top_k=5,
+                model_name="amazon.titan-embed-text-v1",
+                vector_weight=vector_weight,
+                lexical_weight=lexical_weight,
+            )

--- a/test/lambda/repository/services/test_opensearch_repository_service.py
+++ b/test/lambda/repository/services/test_opensearch_repository_service.py
@@ -410,27 +410,3 @@ class TestOpenSearchRepositoryService:
                 )
 
         assert exc_info.value.status_code == 503
-
-    @pytest.mark.parametrize(
-        "vector_weight,lexical_weight",
-        [
-            (-0.1, 1.1),
-            (1.1, -0.1),
-            (0.5, 0.3),  # sum < 1
-            (0.7, 0.7),  # sum > 1
-            (float("inf"), 0.0),
-            (float("nan"), 0.3),
-        ],
-        ids=["negative-vector", "negative-lexical", "sum-lt-1", "sum-gt-1", "inf", "nan"],
-    )
-    def test_hybrid_retrieve_rejects_invalid_weights(self, opensearch_service, vector_weight, lexical_weight):
-        """hybrid_retrieve raises ValueError for out-of-range or non-summing weights."""
-        with pytest.raises(ValueError):
-            opensearch_service.hybrid_retrieve(
-                query="test",
-                collection_id="test-collection",
-                top_k=5,
-                model_name="amazon.titan-embed-text-v1",
-                vector_weight=vector_weight,
-                lexical_weight=lexical_weight,
-            )

--- a/test/lambda/repository/services/test_opensearch_repository_service.py
+++ b/test/lambda/repository/services/test_opensearch_repository_service.py
@@ -115,3 +115,7 @@ class TestOpenSearchRepositoryService:
 
             assert "not registered" in str(exc_info.value)
             assert opensearch_service.repository_id in str(exc_info.value)
+
+    def test_supports_hybrid_search(self, opensearch_service):
+        """OpenSearch repositories advertise hybrid search capability."""
+        assert opensearch_service.supports_hybrid_search() is True

--- a/test/lambda/repository/services/test_opensearch_repository_service.py
+++ b/test/lambda/repository/services/test_opensearch_repository_service.py
@@ -24,7 +24,7 @@ os.environ.setdefault("AWS_REGION", "us-east-1")
 os.environ.setdefault("RAG_DOCUMENT_TABLE", "test-doc-table")
 os.environ.setdefault("RAG_SUB_DOCUMENT_TABLE", "test-subdoc-table")
 
-from lisa.domain.domain_objects import RetrieveResult  # noqa: F401
+from lisa.domain.domain_objects import RetrieveResult
 from lisa.rag.services.opensearch_repository_service import OpenSearchRepositoryService
 from opensearchpy.exceptions import RequestError, TransportError
 

--- a/test/lambda/repository/services/test_opensearch_repository_service.py
+++ b/test/lambda/repository/services/test_opensearch_repository_service.py
@@ -119,3 +119,154 @@ class TestOpenSearchRepositoryService:
     def test_supports_hybrid_search(self, opensearch_service):
         """OpenSearch repositories advertise hybrid search capability."""
         assert opensearch_service.supports_hybrid_search() is True
+
+    def test_hybrid_retrieve_sends_inline_pipeline(self, opensearch_service):
+        """hybrid_retrieve sends an inline search_pipeline body with the hybrid query shape.
+
+        Asserts the request body has:
+          - query.hybrid.queries with both BM25 (match on `text`) and kNN (on `vector_field`)
+          - search_pipeline.phase_results_processors with normalization-processor (min_max)
+          - combination weights [0.3, 0.7] (lexical, vector) — hardcoded in slice 2.2.2
+          - top_k preserved as `size`
+        """
+        mock_vector_store = MagicMock()
+        mock_vector_store.client.indices.exists.return_value = True
+        mock_vector_store.client.search.return_value = {"hits": {"hits": []}}
+
+        mock_embeddings = MagicMock()
+        mock_embeddings.embed_query.return_value = [0.1, 0.2, 0.3]
+
+        with patch(
+            "lisa.rag.services.opensearch_repository_service.RagEmbeddings", return_value=mock_embeddings
+        ), patch.object(opensearch_service, "_get_vector_store_client", return_value=mock_vector_store):
+            opensearch_service.hybrid_retrieve(
+                query="exact phrase",
+                collection_id="test-collection",
+                top_k=5,
+                model_name="amazon.titan-embed-text-v1",
+            )
+
+        mock_vector_store.client.search.assert_called_once()
+        call_kwargs = mock_vector_store.client.search.call_args.kwargs
+        assert call_kwargs["index"] == "test-collection"
+        body = call_kwargs["body"]
+
+        assert body["size"] == 5
+        hybrid_queries = body["query"]["hybrid"]["queries"]
+        assert {"match": {"text": {"query": "exact phrase"}}} in hybrid_queries
+        knn_clause = next(q for q in hybrid_queries if "knn" in q)
+        assert knn_clause["knn"]["vector_field"]["vector"] == [0.1, 0.2, 0.3]
+        assert knn_clause["knn"]["vector_field"]["k"] == 5
+
+        processors = body["search_pipeline"]["phase_results_processors"]
+        norm = processors[0]["normalization-processor"]
+        assert norm["normalization"]["technique"] == "min_max"
+        assert norm["combination"]["technique"] == "arithmetic_mean"
+        assert norm["combination"]["parameters"]["weights"] == [0.3, 0.7]
+
+    def test_hybrid_retrieve_returns_docs_and_hybrid_metadata(self, opensearch_service):
+        """hybrid_retrieve returns (docs, retrieval_metadata) with actual_mode_used='hybrid'.
+
+        With include_score=True, copies hit['_score'] into metadata['similarity_score']
+        (already 0-1 from min_max normalization — no further normalization needed).
+        """
+        mock_vector_store = MagicMock()
+        mock_vector_store.client.indices.exists.return_value = True
+        mock_vector_store.client.search.return_value = {
+            "hits": {
+                "hits": [
+                    {
+                        "_score": 0.87,
+                        "_source": {
+                            "text": "Hybrid result content",
+                            "metadata": {"source": "s3://bucket/doc.pdf"},
+                        },
+                    }
+                ]
+            }
+        }
+        mock_embeddings = MagicMock()
+        mock_embeddings.embed_query.return_value = [0.1, 0.2, 0.3]
+
+        with patch(
+            "lisa.rag.services.opensearch_repository_service.RagEmbeddings", return_value=mock_embeddings
+        ), patch.object(opensearch_service, "_get_vector_store_client", return_value=mock_vector_store):
+            docs, retrieval_metadata = opensearch_service.hybrid_retrieve(
+                query="test",
+                collection_id="test-collection",
+                top_k=5,
+                model_name="amazon.titan-embed-text-v1",
+                include_score=True,
+            )
+
+        assert len(docs) == 1
+        assert docs[0]["page_content"] == "Hybrid result content"
+        assert docs[0]["metadata"]["source"] == "s3://bucket/doc.pdf"
+        assert docs[0]["metadata"]["similarity_score"] == 0.87
+        assert retrieval_metadata["actual_mode_used"] == "hybrid"
+        assert retrieval_metadata["hybrid_supported"] is True
+
+    def test_hybrid_retrieve_omits_similarity_score_by_default(self, opensearch_service):
+        """include_score=False (default) MUST NOT leak hit scores into doc metadata.
+
+        Locks the default contract: callers that don't ask for scores don't get them.
+        Without this assertion, a future refactor could populate similarity_score
+        unconditionally and the happy-path test would still pass.
+        """
+        mock_vector_store = MagicMock()
+        mock_vector_store.client.indices.exists.return_value = True
+        mock_vector_store.client.search.return_value = {
+            "hits": {
+                "hits": [
+                    {
+                        "_score": 0.42,
+                        "_source": {
+                            "text": "doc",
+                            "metadata": {"source": "s3://b/d.pdf"},
+                        },
+                    }
+                ]
+            }
+        }
+        mock_embeddings = MagicMock()
+        mock_embeddings.embed_query.return_value = [0.1, 0.2, 0.3]
+
+        with patch(
+            "lisa.rag.services.opensearch_repository_service.RagEmbeddings", return_value=mock_embeddings
+        ), patch.object(opensearch_service, "_get_vector_store_client", return_value=mock_vector_store):
+            docs, _ = opensearch_service.hybrid_retrieve(
+                query="test",
+                collection_id="test-collection",
+                top_k=5,
+                model_name="amazon.titan-embed-text-v1",
+            )
+
+        assert len(docs) == 1
+        assert "similarity_score" not in docs[0]["metadata"]
+
+    def test_hybrid_retrieve_returns_empty_docs_with_hybrid_metadata(self, opensearch_service):
+        """Empty hits still report actual_mode_used='hybrid' — metadata reports the mode that ran.
+
+        Mirrors BedrockKB's empty-fallback semantics: a caller distinguishing
+        "ran hybrid, found nothing" from "fell back to vector" needs the metadata
+        independent of whether docs is empty.
+        """
+        mock_vector_store = MagicMock()
+        mock_vector_store.client.indices.exists.return_value = True
+        mock_vector_store.client.search.return_value = {"hits": {"hits": []}}
+        mock_embeddings = MagicMock()
+        mock_embeddings.embed_query.return_value = [0.1, 0.2, 0.3]
+
+        with patch(
+            "lisa.rag.services.opensearch_repository_service.RagEmbeddings", return_value=mock_embeddings
+        ), patch.object(opensearch_service, "_get_vector_store_client", return_value=mock_vector_store):
+            docs, retrieval_metadata = opensearch_service.hybrid_retrieve(
+                query="test",
+                collection_id="test-collection",
+                top_k=5,
+                model_name="amazon.titan-embed-text-v1",
+            )
+
+        assert docs == []
+        assert retrieval_metadata["actual_mode_used"] == "hybrid"
+        assert retrieval_metadata["hybrid_supported"] is True

--- a/test/lambda/repository/services/test_opensearch_repository_service.py
+++ b/test/lambda/repository/services/test_opensearch_repository_service.py
@@ -24,7 +24,9 @@ os.environ.setdefault("AWS_REGION", "us-east-1")
 os.environ.setdefault("RAG_DOCUMENT_TABLE", "test-doc-table")
 os.environ.setdefault("RAG_SUB_DOCUMENT_TABLE", "test-subdoc-table")
 
+from lisa.domain.domain_objects import RetrieveResult  # noqa: F401
 from lisa.rag.services.opensearch_repository_service import OpenSearchRepositoryService
+from opensearchpy.exceptions import RequestError, TransportError
 
 
 @pytest.fixture
@@ -165,7 +167,7 @@ class TestOpenSearchRepositoryService:
         assert norm["combination"]["parameters"]["weights"] == [0.3, 0.7]
 
     def test_hybrid_retrieve_returns_docs_and_hybrid_metadata(self, opensearch_service):
-        """hybrid_retrieve returns (docs, retrieval_metadata) with actual_mode_used='hybrid'.
+        """hybrid_retrieve returns RetrieveResult with actual_mode_used='hybrid'.
 
         With include_score=True, copies hit['_score'] into metadata['similarity_score']
         (already 0-1 from min_max normalization — no further normalization needed).
@@ -191,7 +193,7 @@ class TestOpenSearchRepositoryService:
         with patch(
             "lisa.rag.services.opensearch_repository_service.RagEmbeddings", return_value=mock_embeddings
         ), patch.object(opensearch_service, "_get_vector_store_client", return_value=mock_vector_store):
-            docs, retrieval_metadata = opensearch_service.hybrid_retrieve(
+            result = opensearch_service.hybrid_retrieve(
                 query="test",
                 collection_id="test-collection",
                 top_k=5,
@@ -199,12 +201,13 @@ class TestOpenSearchRepositoryService:
                 include_score=True,
             )
 
-        assert len(docs) == 1
-        assert docs[0]["page_content"] == "Hybrid result content"
-        assert docs[0]["metadata"]["source"] == "s3://bucket/doc.pdf"
-        assert docs[0]["metadata"]["similarity_score"] == 0.87
-        assert retrieval_metadata["actual_mode_used"] == "hybrid"
-        assert retrieval_metadata["hybrid_supported"] is True
+        assert isinstance(result, RetrieveResult)
+        assert len(result.documents) == 1
+        assert result.documents[0]["page_content"] == "Hybrid result content"
+        assert result.documents[0]["metadata"]["source"] == "s3://bucket/doc.pdf"
+        assert result.documents[0]["metadata"]["similarity_score"] == 0.87
+        assert result.actual_mode_used == "hybrid"
+        assert result.hybrid_supported is True
 
     def test_hybrid_retrieve_omits_similarity_score_by_default(self, opensearch_service):
         """include_score=False (default) MUST NOT leak hit scores into doc metadata.
@@ -234,23 +237,18 @@ class TestOpenSearchRepositoryService:
         with patch(
             "lisa.rag.services.opensearch_repository_service.RagEmbeddings", return_value=mock_embeddings
         ), patch.object(opensearch_service, "_get_vector_store_client", return_value=mock_vector_store):
-            docs, _ = opensearch_service.hybrid_retrieve(
+            result = opensearch_service.hybrid_retrieve(
                 query="test",
                 collection_id="test-collection",
                 top_k=5,
                 model_name="amazon.titan-embed-text-v1",
             )
 
-        assert len(docs) == 1
-        assert "similarity_score" not in docs[0]["metadata"]
+        assert len(result.documents) == 1
+        assert "similarity_score" not in result.documents[0]["metadata"]
 
     def test_hybrid_retrieve_returns_empty_docs_with_hybrid_metadata(self, opensearch_service):
-        """Empty hits still report actual_mode_used='hybrid' — metadata reports the mode that ran.
-
-        Mirrors BedrockKB's empty-fallback semantics: a caller distinguishing
-        "ran hybrid, found nothing" from "fell back to vector" needs the metadata
-        independent of whether docs is empty.
-        """
+        """Empty hits still report actual_mode_used='hybrid' — metadata reports the mode that ran."""
         mock_vector_store = MagicMock()
         mock_vector_store.client.indices.exists.return_value = True
         mock_vector_store.client.search.return_value = {"hits": {"hits": []}}
@@ -260,24 +258,19 @@ class TestOpenSearchRepositoryService:
         with patch(
             "lisa.rag.services.opensearch_repository_service.RagEmbeddings", return_value=mock_embeddings
         ), patch.object(opensearch_service, "_get_vector_store_client", return_value=mock_vector_store):
-            docs, retrieval_metadata = opensearch_service.hybrid_retrieve(
+            result = opensearch_service.hybrid_retrieve(
                 query="test",
                 collection_id="test-collection",
                 top_k=5,
                 model_name="amazon.titan-embed-text-v1",
             )
 
-        assert docs == []
-        assert retrieval_metadata["actual_mode_used"] == "hybrid"
-        assert retrieval_metadata["hybrid_supported"] is True
+        assert result.documents == []
+        assert result.actual_mode_used == "hybrid"
+        assert result.hybrid_supported is True
 
     def test_hybrid_retrieve_returns_empty_when_index_missing(self, opensearch_service):
-        """hybrid_retrieve returns ([], metadata) when the target index does not exist.
-
-        Parity with retrieve_documents (lines 176-179): check index existence before
-        searching to avoid noisy 404s from OpenSearch. Reports hybrid_supported=True
-        (the cluster supports hybrid; the index just doesn't exist yet).
-        """
+        """hybrid_retrieve returns empty RetrieveResult when the target index does not exist."""
         mock_vector_store = MagicMock()
         mock_vector_store.client.indices.exists.return_value = False
         mock_embeddings = MagicMock()
@@ -286,14 +279,71 @@ class TestOpenSearchRepositoryService:
         with patch(
             "lisa.rag.services.opensearch_repository_service.RagEmbeddings", return_value=mock_embeddings
         ), patch.object(opensearch_service, "_get_vector_store_client", return_value=mock_vector_store):
-            docs, retrieval_metadata = opensearch_service.hybrid_retrieve(
+            result = opensearch_service.hybrid_retrieve(
                 query="test query",
                 collection_id="nonexistent-index",
                 top_k=5,
                 model_name="amazon.titan-embed-text-v1",
             )
 
-        assert docs == []
-        assert retrieval_metadata["actual_mode_used"] == "hybrid"
-        assert retrieval_metadata["hybrid_supported"] is True
+        assert result.documents == []
+        assert result.actual_mode_used == "hybrid"
+        assert result.hybrid_supported is True
         mock_vector_store.client.search.assert_not_called()
+
+    def test_hybrid_retrieve_propagates_request_error(self, opensearch_service):
+        """hybrid_retrieve bubbles up RequestError — no silent swallowing.
+
+        OpenSearch errors (malformed query, auth, DSL validation) must propagate
+        to the caller so they surface as actionable failures, not silent degradation.
+        """
+        mock_vector_store = MagicMock()
+        mock_vector_store.client.indices.exists.return_value = True
+        mock_vector_store.client.search.side_effect = RequestError(
+            400,
+            "parsing_exception",
+            {"error": {"reason": "malformed query"}},
+        )
+
+        mock_embeddings = MagicMock()
+        mock_embeddings.embed_query.return_value = [0.1, 0.2, 0.3]
+
+        with patch(
+            "lisa.rag.services.opensearch_repository_service.RagEmbeddings", return_value=mock_embeddings
+        ), patch.object(opensearch_service, "_get_vector_store_client", return_value=mock_vector_store):
+            with pytest.raises(RequestError) as exc_info:
+                opensearch_service.hybrid_retrieve(
+                    query="bad query",
+                    collection_id="test-collection",
+                    top_k=5,
+                    model_name="amazon.titan-embed-text-v1",
+                )
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.error == "parsing_exception"
+
+    def test_hybrid_retrieve_propagates_transport_error(self, opensearch_service):
+        """hybrid_retrieve bubbles up TransportError — infrastructure failures must surface."""
+        mock_vector_store = MagicMock()
+        mock_vector_store.client.indices.exists.return_value = True
+        mock_vector_store.client.search.side_effect = TransportError(
+            503,
+            "service_unavailable",
+            {"error": {"reason": "cluster overloaded"}},
+        )
+
+        mock_embeddings = MagicMock()
+        mock_embeddings.embed_query.return_value = [0.1, 0.2, 0.3]
+
+        with patch(
+            "lisa.rag.services.opensearch_repository_service.RagEmbeddings", return_value=mock_embeddings
+        ), patch.object(opensearch_service, "_get_vector_store_client", return_value=mock_vector_store):
+            with pytest.raises(TransportError) as exc_info:
+                opensearch_service.hybrid_retrieve(
+                    query="test",
+                    collection_id="test-collection",
+                    top_k=5,
+                    model_name="amazon.titan-embed-text-v1",
+                )
+
+        assert exc_info.value.status_code == 503

--- a/test/lambda/repository/services/test_repository_service.py
+++ b/test/lambda/repository/services/test_repository_service.py
@@ -24,7 +24,7 @@ os.environ.setdefault("AWS_REGION", "us-east-1")
 os.environ.setdefault("RAG_DOCUMENT_TABLE", "test-doc-table")
 os.environ.setdefault("RAG_SUB_DOCUMENT_TABLE", "test-subdoc-table")
 
-from lisa.domain.domain_objects import IngestionJob, RagCollectionConfig, RagDocument
+from lisa.domain.domain_objects import IngestionJob, RagCollectionConfig, RagDocument, RetrieveResult  # noqa: F401
 from lisa.rag.services.repository_service import RepositoryService
 
 
@@ -78,9 +78,11 @@ class ConcreteRepositoryService(RepositoryService):
         query: str,
         collection_id: str,
         top_k: int,
+        model_name: str = "",
+        include_score: bool = False,
         bedrock_agent_client: Any | None = None,
-    ) -> list[dict[str, Any]]:
-        return []
+    ) -> RetrieveResult:
+        return RetrieveResult(documents=[], actual_mode_used="vector", hybrid_supported=False)
 
     def validate_document_source(self, s3_path: str) -> str:
         return s3_path
@@ -131,7 +133,7 @@ class TestRepositoryService:
         assert service.validate_document_source("s3://bucket/file") == "s3://bucket/file"
         assert service.get_vector_store_client("col", None) is None
         assert service.create_default_collection() is None
-        assert service.retrieve_documents("query", "col", 5) == []
+        assert service.retrieve_documents("query", "col", 5).documents == []
 
     def test_supports_hybrid_search_returns_false_by_default(self):
         """Base implementation returns False for hybrid search support."""

--- a/test/lambda/repository/services/test_repository_service.py
+++ b/test/lambda/repository/services/test_repository_service.py
@@ -24,7 +24,7 @@ os.environ.setdefault("AWS_REGION", "us-east-1")
 os.environ.setdefault("RAG_DOCUMENT_TABLE", "test-doc-table")
 os.environ.setdefault("RAG_SUB_DOCUMENT_TABLE", "test-subdoc-table")
 
-from lisa.domain.domain_objects import IngestionJob, RagCollectionConfig, RagDocument, RetrieveResult  # noqa: F401
+from lisa.domain.domain_objects import IngestionJob, RagCollectionConfig, RagDocument, RetrieveResult
 from lisa.rag.services.repository_service import RepositoryService
 
 

--- a/test/lambda/repository/services/test_vector_store_repository_service.py
+++ b/test/lambda/repository/services/test_vector_store_repository_service.py
@@ -157,12 +157,13 @@ class TestVectorStoreRepositoryService:
 
         with patch("lisa.rag.services.opensearch_repository_service.RagEmbeddings"):
             with patch.object(vector_store_service, "_get_vector_store_client", return_value=mock_vector_store):
-                results = vector_store_service.retrieve_documents("test query", "test-collection", 5, "test-model")
+                result = vector_store_service.retrieve_documents("test query", "test-collection", 5, "test-model")
 
-                assert len(results) == 2
-                assert results[0]["page_content"] == "Content 1"
-                assert results[0]["metadata"]["source"] == "doc1.pdf"
-                assert results[1]["page_content"] == "Content 2"
+                assert len(result.documents) == 2
+                assert result.documents[0]["page_content"] == "Content 1"
+                assert result.documents[0]["metadata"]["source"] == "doc1.pdf"
+                assert result.documents[1]["page_content"] == "Content 2"
+                assert result.actual_mode_used == "vector"
 
     def test_validate_document_source_valid(self, vector_store_service):
         """Test validating valid S3 path."""

--- a/test/lambda/test_repository_lambda.py
+++ b/test/lambda/test_repository_lambda.py
@@ -4607,3 +4607,175 @@ def test_backward_compatible_response(mock_auth):
         assert body["metadata"]["search_mode"] == "vector"
         assert body["metadata"]["actual_mode_used"] == "vector"
         assert body.keys() == {"docs", "metadata"}
+
+
+# ---------------------------------------------------------------------------
+# Phase 2.3: Weight params end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_hybrid_search_passes_custom_weights(mock_auth):
+    """vectorWeight/lexicalWeight query params flow through to hybrid_retrieve()."""
+    from repository.lambda_functions import similarity_search
+
+    mock_auth.set_user("test-user", ["test-group"], is_rag_admin=True)
+
+    stack, setup = _hybrid_search_patches(is_rag_admin_val=True)
+    with stack:
+        p = setup()
+        p.vs_repo.find_repository_by_id.return_value = _opensearch_repo()
+        p.cs.get_collection_model.return_value = "test-model"
+        service = _mock_service(supports_hybrid=True)
+        p.factory.create_service.return_value = service
+
+        event = _similarity_search_event(
+            {
+                "searchMode": "hybrid",
+                "modelName": "test-model",
+                "vectorWeight": "0.8",
+                "lexicalWeight": "0.2",
+            }
+        )
+        result = similarity_search(event, SimpleNamespace())
+
+        assert result["statusCode"] == 200
+        service.hybrid_retrieve.assert_called_once()
+        call_kwargs = service.hybrid_retrieve.call_args.kwargs
+        assert call_kwargs["vector_weight"] == 0.8
+        assert call_kwargs["lexical_weight"] == 0.2
+
+
+def test_hybrid_search_uses_defaults_when_no_weights(mock_auth):
+    """No vectorWeight/lexicalWeight → uses defaults (0.7/0.3)."""
+    from repository.lambda_functions import similarity_search
+
+    mock_auth.set_user("test-user", ["test-group"], is_rag_admin=True)
+
+    stack, setup = _hybrid_search_patches(is_rag_admin_val=True)
+    with stack:
+        p = setup()
+        p.vs_repo.find_repository_by_id.return_value = _opensearch_repo()
+        p.cs.get_collection_model.return_value = "test-model"
+        service = _mock_service(supports_hybrid=True)
+        p.factory.create_service.return_value = service
+
+        event = _similarity_search_event(
+            {
+                "searchMode": "hybrid",
+                "modelName": "test-model",
+            }
+        )
+        result = similarity_search(event, SimpleNamespace())
+
+        assert result["statusCode"] == 200
+        service.hybrid_retrieve.assert_called_once()
+        call_kwargs = service.hybrid_retrieve.call_args.kwargs
+        assert call_kwargs["vector_weight"] == 0.7
+        assert call_kwargs["lexical_weight"] == 0.3
+
+
+def test_hybrid_search_rejects_non_numeric_weights(mock_auth):
+    """Non-numeric vectorWeight → 400."""
+    from repository.lambda_functions import similarity_search
+
+    mock_auth.set_user("test-user", ["test-group"], is_rag_admin=True)
+
+    stack, setup = _hybrid_search_patches(is_rag_admin_val=True)
+    with stack:
+        p = setup()
+        p.vs_repo.find_repository_by_id.return_value = _opensearch_repo()
+        p.cs.get_collection_model.return_value = "test-model"
+        p.factory.create_service.return_value = _mock_service(supports_hybrid=True)
+
+        event = _similarity_search_event(
+            {
+                "searchMode": "hybrid",
+                "modelName": "test-model",
+                "vectorWeight": "abc",
+                "lexicalWeight": "0.3",
+            }
+        )
+        result = similarity_search(event, SimpleNamespace())
+
+        assert result["statusCode"] == 400
+
+
+def test_hybrid_search_rejects_weights_not_summing_to_one(mock_auth):
+    """vectorWeight + lexicalWeight != 1 → 400."""
+    from repository.lambda_functions import similarity_search
+
+    mock_auth.set_user("test-user", ["test-group"], is_rag_admin=True)
+
+    stack, setup = _hybrid_search_patches(is_rag_admin_val=True)
+    with stack:
+        p = setup()
+        p.vs_repo.find_repository_by_id.return_value = _opensearch_repo()
+        p.cs.get_collection_model.return_value = "test-model"
+        p.factory.create_service.return_value = _mock_service(supports_hybrid=True)
+
+        event = _similarity_search_event(
+            {
+                "searchMode": "hybrid",
+                "modelName": "test-model",
+                "vectorWeight": "0.7",
+                "lexicalWeight": "0.7",
+            }
+        )
+        result = similarity_search(event, SimpleNamespace())
+
+        assert result["statusCode"] == 400
+
+
+def test_hybrid_search_rejects_out_of_range_weights(mock_auth):
+    """vectorWeight > 1 → 400."""
+    from repository.lambda_functions import similarity_search
+
+    mock_auth.set_user("test-user", ["test-group"], is_rag_admin=True)
+
+    stack, setup = _hybrid_search_patches(is_rag_admin_val=True)
+    with stack:
+        p = setup()
+        p.vs_repo.find_repository_by_id.return_value = _opensearch_repo()
+        p.cs.get_collection_model.return_value = "test-model"
+        p.factory.create_service.return_value = _mock_service(supports_hybrid=True)
+
+        event = _similarity_search_event(
+            {
+                "searchMode": "hybrid",
+                "modelName": "test-model",
+                "vectorWeight": "1.5",
+                "lexicalWeight": "-0.5",
+            }
+        )
+        result = similarity_search(event, SimpleNamespace())
+
+        assert result["statusCode"] == 400
+
+
+def test_vector_mode_ignores_weight_params(mock_auth):
+    """searchMode=vector ignores vectorWeight/lexicalWeight — no error, no passthrough."""
+    from repository.lambda_functions import similarity_search
+
+    mock_auth.set_user("test-user", ["test-group"], is_admin=True)
+
+    stack, setup = _hybrid_search_patches(is_admin_val=True)
+    with stack:
+        p = setup()
+        p.vs_repo.find_repository_by_id.return_value = _opensearch_repo()
+        p.cs.get_collection_model.return_value = "test-model"
+        service = _mock_service(supports_hybrid=True)
+        p.factory.create_service.return_value = service
+
+        event = _similarity_search_event(
+            {
+                "searchMode": "vector",
+                "modelName": "test-model",
+                "vectorWeight": "0.9",
+                "lexicalWeight": "0.1",
+            }
+        )
+        result = similarity_search(event, SimpleNamespace())
+
+        assert result["statusCode"] == 200
+        service.retrieve_documents.assert_called_once()
+        service.hybrid_retrieve.assert_not_called()

--- a/test/lambda/test_repository_lambda.py
+++ b/test/lambda/test_repository_lambda.py
@@ -1523,10 +1523,14 @@ def test_real_similarity_search_function():
         mock_RagEmbeddings.return_value = mock_embeddings
 
         # Mock the service layer
+        from lisa.domain.domain_objects import RetrieveResult
+
         mock_service = MagicMock()
-        mock_service.retrieve_documents.return_value = [
-            {"page_content": "Test content", "metadata": {"source": "test-source"}}
-        ]
+        mock_service.retrieve_documents.return_value = RetrieveResult(
+            documents=[{"page_content": "Test content", "metadata": {"source": "test-source"}}],
+            actual_mode_used="vector",
+            hybrid_supported=False,
+        )
 
         with patch("repository.lambda_functions.RepositoryServiceFactory") as mock_factory:
             mock_factory.create_service.return_value = mock_service
@@ -2820,8 +2824,8 @@ def test_similarity_search_with_score():
         with patch.object(service, "_get_vector_store_client", return_value=mock_vs):
             result = service.retrieve_documents("query", "test-collection", 3, "test-model", include_score=True)
 
-    assert len(result) == 1
-    assert "similarity_score" in result[0]["metadata"]
+    assert len(result.documents) == 1
+    assert "similarity_score" in result.documents[0]["metadata"]
 
 
 def test_similarity_search_without_score():
@@ -2842,8 +2846,8 @@ def test_similarity_search_without_score():
         with patch.object(service, "_get_vector_store_client", return_value=mock_vs):
             result = service.retrieve_documents("query", "test-collection", 3, "test-model", include_score=False)
 
-    assert len(result) == 1
-    assert result[0]["page_content"] == "test content"
+    assert len(result.documents) == 1
+    assert result.documents[0]["page_content"] == "test content"
 
 
 def test_ensure_document_ownership_admin():
@@ -3319,10 +3323,10 @@ def test_similarity_search_helpers():
 
         with patch("lisa.rag.services.opensearch_repository_service.RagEmbeddings"):
             with patch.object(service, "_get_vector_store_client", return_value=mock_vs):
-                results = service.retrieve_documents("query", "test-collection", 3, "test-model", include_score=False)
+                result = service.retrieve_documents("query", "test-collection", 3, "test-model", include_score=False)
 
-        assert len(results) == 1
-        assert results[0]["page_content"] == "test content"
+        assert len(result.documents) == 1
+        assert result.documents[0]["page_content"] == "test content"
 
 
 # Tests for list_user_collections endpoint
@@ -3944,8 +3948,14 @@ def test_similarity_search_bedrock_kb():
             "allowedGroups": ["users"],
         }
         mock_collection_service.get_collection_model.return_value = "amazon.titan-embed-text-v1"
+        from lisa.domain.domain_objects import RetrieveResult
+
         mock_service = MagicMock()
-        mock_service.retrieve_documents.return_value = [{"page_content": "test content", "metadata": {}}]
+        mock_service.retrieve_documents.return_value = RetrieveResult(
+            documents=[{"page_content": "test content", "metadata": {}}],
+            actual_mode_used="vector",
+            hybrid_supported=True,
+        )
         mock_factory.create_service.return_value = mock_service
 
         result = similarity_search(event, {})
@@ -4352,14 +4362,19 @@ def _similarity_search_event(extra_query_params=None):
 
 def _mock_service(supports_hybrid=True):
     """Create a mock RepositoryService with configurable hybrid support."""
+    from lisa.domain.domain_objects import RetrieveResult
+
     service = MagicMock()
     service.supports_hybrid_search.return_value = supports_hybrid
-    service.retrieve_documents.return_value = [
-        {"page_content": "semantic result", "metadata": {"source": "s3://bucket/doc1.pdf"}}
-    ]
-    service.hybrid_retrieve.return_value = (
-        [{"page_content": "hybrid result", "metadata": {"source": "s3://bucket/doc1.pdf"}}],
-        {"actual_mode_used": "hybrid", "hybrid_supported": True},
+    service.retrieve_documents.return_value = RetrieveResult(
+        documents=[{"page_content": "semantic result", "metadata": {"source": "s3://bucket/doc1.pdf"}}],
+        actual_mode_used="vector",
+        hybrid_supported=supports_hybrid,
+    )
+    service.hybrid_retrieve.return_value = RetrieveResult(
+        documents=[{"page_content": "hybrid result", "metadata": {"source": "s3://bucket/doc1.pdf"}}],
+        actual_mode_used="hybrid",
+        hybrid_supported=True,
     )
     return service
 
@@ -4548,9 +4563,12 @@ def test_hybrid_fallback_with_empty_docs_reports_vector_metadata(mock_auth):
         p.cs.get_collection_model.return_value = "test-model"
         service = _mock_service(supports_hybrid=True)
         # Hybrid call falls back to vector internally and returns zero matches.
-        service.hybrid_retrieve.return_value = (
-            [],
-            {"actual_mode_used": "vector", "hybrid_supported": False},
+        from lisa.domain.domain_objects import RetrieveResult
+
+        service.hybrid_retrieve.return_value = RetrieveResult(
+            documents=[],
+            actual_mode_used="vector",
+            hybrid_supported=False,
         )
         p.factory.create_service.return_value = service
 

--- a/test/lambda/test_repository_lambda.py
+++ b/test/lambda/test_repository_lambda.py
@@ -1416,7 +1416,7 @@ def test_list_all_includes_supports_hybrid_search():
         os_repo = next(r for r in body if r["repositoryId"] == "os-repo")
         kb_repo = next(r for r in body if r["repositoryId"] == "kb-repo")
 
-        assert os_repo["supportsHybridSearch"] is False
+        assert os_repo["supportsHybridSearch"] is True
         assert kb_repo["supportsHybridSearch"] is True
 
 

--- a/test/lambda/test_repository_lambda.py
+++ b/test/lambda/test_repository_lambda.py
@@ -4726,6 +4726,31 @@ def test_hybrid_search_rejects_weights_not_summing_to_one(mock_auth):
         assert result["statusCode"] == 400
 
 
+def test_hybrid_search_rejects_partial_weights(mock_auth):
+    """Only vectorWeight without lexicalWeight → 400."""
+    from repository.lambda_functions import similarity_search
+
+    mock_auth.set_user("test-user", ["test-group"], is_rag_admin=True)
+
+    stack, setup = _hybrid_search_patches(is_rag_admin_val=True)
+    with stack:
+        p = setup()
+        p.vs_repo.find_repository_by_id.return_value = _opensearch_repo()
+        p.cs.get_collection_model.return_value = "test-model"
+        p.factory.create_service.return_value = _mock_service(supports_hybrid=True)
+
+        event = _similarity_search_event(
+            {
+                "searchMode": "hybrid",
+                "modelName": "test-model",
+                "vectorWeight": "0.8",
+            }
+        )
+        result = similarity_search(event, SimpleNamespace())
+
+        assert result["statusCode"] == 400
+
+
 def test_hybrid_search_rejects_out_of_range_weights(mock_auth):
     """vectorWeight > 1 → 400."""
     from repository.lambda_functions import similarity_search

--- a/test/lambda/test_similarity_functions.py
+++ b/test/lambda/test_similarity_functions.py
@@ -47,10 +47,11 @@ def test_opensearch_retrieve_documents_without_score():
         with patch.object(service, "_get_vector_store_client", return_value=mock_vs):
             result = service.retrieve_documents("test query", "test-collection", 5, "test-model", include_score=False)
 
-    assert len(result) == 1
-    assert result[0]["page_content"] == "Test content"
-    assert result[0]["metadata"] == {"source": "test.txt"}
-    assert "similarity_score" not in result[0]["metadata"]
+    assert len(result.documents) == 1
+    assert result.documents[0]["page_content"] == "Test content"
+    assert result.documents[0]["metadata"] == {"source": "test.txt"}
+    assert "similarity_score" not in result.documents[0]["metadata"]
+    assert result.actual_mode_used == "vector"
     mock_vs.similarity_search_with_score.assert_called_once_with("test query", k=5)
 
 
@@ -70,10 +71,10 @@ def test_pgvector_retrieve_documents_with_score():
         with patch.object(service, "_get_vector_store_client", return_value=mock_vs):
             result = service.retrieve_documents("test query", "test-collection", 3, "test-model", include_score=True)
 
-    assert len(result) == 1
-    assert result[0]["page_content"] == "Test content"
-    assert result[0]["metadata"]["source"] == "test.txt"
-    assert result[0]["metadata"]["similarity_score"] == 0.6  # 1 - (0.8/2)
+    assert len(result.documents) == 1
+    assert result.documents[0]["page_content"] == "Test content"
+    assert result.documents[0]["metadata"]["source"] == "test.txt"
+    assert result.documents[0]["metadata"]["similarity_score"] == 0.6  # 1 - (0.8/2)
 
 
 def test_opensearch_retrieve_documents_with_score():
@@ -93,7 +94,7 @@ def test_opensearch_retrieve_documents_with_score():
         with patch.object(service, "_get_vector_store_client", return_value=mock_vs):
             result = service.retrieve_documents("test query", "test-collection", 3, "test-model", include_score=True)
 
-    assert len(result) == 1
-    assert result[0]["page_content"] == "Test content"
-    assert result[0]["metadata"]["source"] == "test.txt"
-    assert result[0]["metadata"]["similarity_score"] == 0.9  # Direct similarity score
+    assert len(result.documents) == 1
+    assert result.documents[0]["page_content"] == "Test content"
+    assert result.documents[0]["metadata"]["source"] == "test.txt"
+    assert result.documents[0]["metadata"]["similarity_score"] == 0.9  # Direct similarity score

--- a/test/sdk/test_sdk_rag.py
+++ b/test/sdk/test_sdk_rag.py
@@ -332,6 +332,68 @@ class TestRagMixin:
         assert responses.calls[0].request.params["searchMode"] == "hybrid"
 
     @responses.activate
+    def test_similarity_search_with_weights(self, lisa_api: LisaApi, api_url: str):
+        """Test similarity search passes vectorWeight/lexicalWeight as query params."""
+        repo_id = "opensearch-repo"
+        query = "test query"
+
+        expected_response = {
+            "docs": [],
+            "metadata": {
+                "search_mode": "hybrid",
+                "actual_mode_used": "hybrid",
+                "backend": "opensearch",
+                "hybrid_supported": True,
+            },
+        }
+
+        responses.add(
+            responses.GET, f"{api_url}/repository/{repo_id}/similaritySearch", json=expected_response, status=200
+        )
+
+        lisa_api.similarity_search(
+            repo_id=repo_id,
+            query=query,
+            model_name="test-model",
+            search_mode="hybrid",
+            vector_weight=0.8,
+            lexical_weight=0.2,
+        )
+
+        assert responses.calls[0].request.params["vectorWeight"] == "0.8"
+        assert responses.calls[0].request.params["lexicalWeight"] == "0.2"
+
+    @responses.activate
+    def test_similarity_search_omits_weights_when_not_specified(self, lisa_api: LisaApi, api_url: str):
+        """Test similarity search omits weight params when not provided."""
+        repo_id = "opensearch-repo"
+        query = "test query"
+
+        expected_response = {
+            "docs": [],
+            "metadata": {
+                "search_mode": "hybrid",
+                "actual_mode_used": "hybrid",
+                "backend": "opensearch",
+                "hybrid_supported": True,
+            },
+        }
+
+        responses.add(
+            responses.GET, f"{api_url}/repository/{repo_id}/similaritySearch", json=expected_response, status=200
+        )
+
+        lisa_api.similarity_search(
+            repo_id=repo_id,
+            query=query,
+            model_name="test-model",
+            search_mode="hybrid",
+        )
+
+        assert "vectorWeight" not in responses.calls[0].request.params
+        assert "lexicalWeight" not in responses.calls[0].request.params
+
+    @responses.activate
     def test_similarity_search_default_has_metadata(self, lisa_api: LisaApi, api_url: str):
         """Test similarity search without search_mode omits searchMode param but returns metadata."""
         repo_id = "pgvector-rag"


### PR DESCRIPTION
*Issue #, if available:*

### Summary
- Enables hybrid search for OpenSearch RAG repositories. Users selecting "Hybrid" mode get results from both semantic embedding and keyword matching via OpenSearch's inline `search_pipeline` body 
- Requires OpenSearch 2.13+.

#### Key behaviors:
- OpenSearch repos advertise `supportsHybridSearch: true`
- `hybrid_retrieve()` sends inline `normalization-processor` pipeline with configurable vector/lexical weights
- Per-citation similarity scores plumbed end-to-end (visible in message metadata)
- Chat UI: "RAG Settings" card with linked Slider+Input weight controls, preset buttons, capability gating
- Weight params (`vectorWeight`/`lexicalWeight`) 
- Admin toggle controls global hybrid availability

### How it works

When a user selects "Hybrid" search mode, the request flows through three layers:

**The backend** adds a new `hybrid_retrieve()` method to `OpenSearchRepositoryService`. Instead of the existing vector-only kNN query, it constructs a compound query combining BM25 (keyword) and kNN (semantic) legs, with a `normalization-processor` search pipeline sent inline in the request body. The weights controlling how much each leg contributes (e.g., 0.7 vector / 0.3 lexical) arrive as query string parameters, validated by a `HybridWeights` Pydantic model in the Lambda handler before reaching the service. A new `RetrieveResult` dataclass standardizes the return shape across all repository backends, carrying both the documents and metadata like `actual_mode_used` and per-document similarity scores.

**The chat UI** introduces a "RAG Settings" card inside the session configuration modal. When the selected repository supports hybrid and the admin toggle is on, users see a search mode dropdown. Choosing "Hybrid" reveals weight controls — paired sliders and number inputs that stay linked (adjusting one automatically sets the other so they sum to 1). Three preset buttons (Balanced, Semantic-heavy, Lexical-heavy) offer quick starting points. The weights are stored per-session and sent to the API on each RAG query.

**The Python SDK** (`lisapy`) exposes `vector_weight` and `lexical_weight` as optional parameters on `similarity_search()`, passing them as query string params to the REST API. SDK consumers who don't specify weights get the server-side defaults (0.7/0.3).
  
### Feature Boundaries

- Search-mode dropdown defaults to "Vector" when `hybridSearch` admin toggle is off
- `deriveRagSearchMode()` returns `'vector'` when admin flag disabled or repo doesn't support hybrid
- No silent fallback for OpenSearch hybrid. Requires 2.13+; errors propagate to the client
- No persistent infrastructure changes (no OpenSearch pipelines created, no new DDB tables)
#### Disabled Rag Controls based on Repo/Collection

<img width="982" height="957" alt="Screenshot 2026-06-05 at 14 38 12" src="https://github.com/user-attachments/assets/cc367c59-a6d0-44fe-8d4e-6971575438f1" />

#### Enabled Rag Controls for OpenSearch and Admin Toggle enabled
<img width="986" height="960" alt="Screenshot 2026-06-05 at 14 39 10" src="https://github.com/user-attachments/assets/d04661e4-b2c9-4db8-9dc5-4640873385ae" />

#### Related
- **Phase 1 (Bedrock KB):** PR #1044


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
