### PR TITLE
Enforce admin feature toggles server-side 

### DIFF
--- a/lambda/handlers/repository/lambda_functions.py
+++ b/lambda/handlers/repository/lambda_functions.py
@@ -69,6 +69,7 @@ from lisa.utilities.bedrock_kb_discovery import (
 from lisa.utilities.bedrock_kb_validation import validate_bedrock_kb_exists
 from lisa.utilities.common_functions import api_wrapper, retry_config
 from lisa.utilities.exceptions import ForbiddenException, NotFoundException
+from lisa.utilities.feature_gate import require_feature
 from lisa.utilities.repository_types import RepositoryType
 from lisa.utilities.response_builder import DecimalEncoder
 from lisa.utilities.validation import ValidationError
@@ -1117,6 +1118,7 @@ def handle_deprecated_chunking_strategy(request: IngestDocumentRequest, query_pa
 
 
 @api_wrapper
+@require_feature("uploadRagDocs")
 def ingest_documents(event: dict, context: dict) -> dict:
     """Ingest documents into the RAG repository."""
     body = json.loads(event["body"])
@@ -1250,6 +1252,7 @@ def download_document(event: dict, context: dict) -> str:
 
 
 @api_wrapper
+@require_feature("uploadRagDocs")
 def presigned_url(event: dict, context: dict) -> dict:
     """Generate a pre-signed URL for uploading files to the RAG ingest bucket.
 

--- a/lambda/handlers/session/lambda_functions.py
+++ b/lambda/handlers/session/lambda_functions.py
@@ -57,6 +57,7 @@ from lisa.utilities.auth import get_user_context, get_username
 from lisa.utilities.aws_helpers import get_cert_path, get_rest_api_container_endpoint
 from lisa.utilities.common_functions import api_wrapper, get_session_id, retry_config
 from lisa.utilities.encoders import convert_decimal
+from lisa.utilities.feature_gate import require_feature
 from lisa.utilities.input_validation import MAX_LARGE_REQUEST_SIZE
 from lisa.utilities.pagination import decode_cursor, encode_cursor
 from lisa.utilities.session_encryption import (
@@ -464,6 +465,7 @@ def get_session(event: dict, context: dict) -> Session | dict:
 
 
 @api_wrapper
+@require_feature("deleteSessionHistory")
 def delete_session(event: dict, context: dict) -> DeleteResponse:
     """Delete session from DynamoDB."""
     user_id = get_username(event)
@@ -474,6 +476,7 @@ def delete_session(event: dict, context: dict) -> DeleteResponse:
 
 
 @api_wrapper
+@require_feature("deleteSessionHistory")
 def delete_user_sessions(event: dict, context: dict) -> DeleteResponse:
     """Delete sessions by user ID from DyanmoDB."""
     user_id = get_username(event)

--- a/lambda/shared/python/lisa/utilities/feature_gate.py
+++ b/lambda/shared/python/lisa/utilities/feature_gate.py
@@ -1,0 +1,150 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Server-side enforcement of admin-configured feature toggles.
+
+Reads ``enabledComponents`` from the global configuration table and exposes a
+``@require_feature(key)`` decorator that returns HTTP 403 when an admin has
+disabled the feature, plus an ``is_feature_enabled(key)`` helper.
+
+Security control characteristics (read before changing this module):
+
+- **This is a governance toggle, not an authorization boundary.** Authentication
+  and identity are enforced upstream by the API Gateway authorizer; this gate
+  only enforces an admin's optional decision to disable a capability.
+- **Fail-open by design.** When the config table is unset (``CONFIG_TABLE_NAME``
+  absent) or unreachable, features default to enabled. Rationale: a DynamoDB
+  outage should degrade governance, not deny all traffic. The empty-on-error
+  result is itself cached for the TTL window, so a transient error keeps the
+  feature enabled for up to the cache TTL rather than retrying each call.
+- **Disable propagation is bounded by the cache TTL (5 minutes).** Because the
+  result is cached per warm Lambda instance, disabling a feature can take up to
+  the TTL to take effect everywhere. This is not an instantaneous kill switch.
+- **Applies to all users, including admins** — disabling the feature is itself
+  the governance decision.
+"""
+
+import logging
+import os
+from collections.abc import Callable
+from functools import wraps
+from typing import Any
+
+import boto3
+from cachetools import cached, TTLCache  # type: ignore[import-untyped,unused-ignore]
+from lisa.utilities.auth import get_username
+from lisa.utilities.aws_helpers import retry_config
+from lisa.utilities.exceptions import ForbiddenException
+
+logger = logging.getLogger(__name__)
+
+_dynamodb = boto3.resource("dynamodb", region_name=os.environ.get("AWS_REGION", "us-east-1"), config=retry_config)
+
+# Single-entry, 5-minute TTL cache holding the full enabledComponents dict.
+# Matches the cache TTL used by session encryption and the projects config read.
+_feature_cache: TTLCache = TTLCache(maxsize=1, ttl=300)
+
+
+def _get_config_table() -> Any | None:
+    """Return the global configuration DynamoDB ``Table`` resource.
+
+    Resolved lazily (not at import time) so the module imports cleanly in
+    contexts where ``CONFIG_TABLE_NAME`` is not set, and so tests can patch this
+    seam. Returns ``None`` when the env var is absent, which callers treat as
+    fail-open.
+    """
+    table_name = os.environ.get("CONFIG_TABLE_NAME")
+    if not table_name:
+        # Not an error: CONFIG_TABLE_NAME is intentionally unset in supported
+        # topologies where the config table is absent (e.g. RAG deployed without
+        # chat), so the gate fails open by design.
+        logger.warning("CONFIG_TABLE_NAME not set: defaulting all features to enabled")
+        return None
+    return _dynamodb.Table(table_name)
+
+
+@cached(cache=_feature_cache)
+def _get_enabled_components() -> dict[str, bool]:
+    """Read ``enabledComponents`` from the latest global configuration.
+
+    Returns an empty dict on any error or missing configuration, which causes
+    every toggle to fail open (enabled). Result is cached for the TTL window.
+    """
+    table = _get_config_table()
+    if table is None:
+        return {}
+    try:
+        response = table.query(
+            KeyConditionExpression="configScope = :scope",
+            ExpressionAttributeValues={":scope": "global"},
+            ScanIndexForward=False,
+            Limit=1,
+        )
+        items = response.get("Items", [])
+        if not items:
+            logger.warning("No global configuration found: defaulting all features to enabled")
+            return {}
+        components: dict[str, bool] = items[0].get("configuration", {}).get("enabledComponents", {})
+        return components
+    except Exception as error:
+        logger.error(f"Failed to read enabledComponents: {error}; defaulting all features to enabled")
+        return {}
+
+
+def is_feature_enabled(feature_key: str) -> bool:
+    """Return whether an admin-configured feature toggle is enabled.
+
+    Defaults to ``True`` (fail-open) when the toggle is absent from
+    configuration, the configuration is missing, or the config table is
+    unreachable.
+
+    Args:
+        feature_key: The ``enabledComponents`` key to check, e.g.
+            ``"deleteSessionHistory"``.
+    """
+    components = _get_enabled_components()
+    return bool(components.get(feature_key, True))
+
+
+def require_feature(feature_key: str) -> Callable:
+    """Decorator for traditional ``(event, context)`` Lambda handlers.
+
+    Raises :class:`ForbiddenException` (HTTP 403) when ``feature_key`` is
+    administratively disabled. Apply it inside ``@api_wrapper`` so the raised
+    exception is converted to a 403 response::
+
+        @api_wrapper
+        @require_feature("deleteSessionHistory")
+        def delete_session(event, context):
+            ...
+
+    Feature gates apply to all users, including admins: disabling the feature is
+    itself the governance decision.
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(event: dict[str, Any], context: dict[str, Any], *args: Any, **kwargs: Any) -> Any:
+            if not is_feature_enabled(feature_key):
+                logger.warning(
+                    f"Feature '{feature_key}' is disabled: rejecting request from user={get_username(event)}"
+                )
+                raise ForbiddenException(
+                    f"This feature has been disabled by your administrator (feature: {feature_key})"
+                )
+            return func(event, context, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/lib/chat/api/configuration.ts
+++ b/lib/chat/api/configuration.ts
@@ -79,6 +79,15 @@ export class ConfigurationApi extends Construct {
             deletionProtection: config.removalPolicy !== RemovalPolicy.DESTROY,
         });
 
+        // Publish the config table name to SSM so Lambdas in other stacks (e.g.
+        // the RAG repository handlers) can resolve it by name for feature-gate
+        // reads, without a cross-stack CloudFormation reference.
+        new StringParameter(this, 'ConfigTableNameParameter', {
+            parameterName: `${config.deploymentPrefix}/configTableName`,
+            stringValue: this.configTable.tableName,
+            description: 'Name of the global configuration DynamoDB table',
+        });
+
         const lambdaRole: IRole = createLambdaRole(this, config.deploymentName, 'ConfigurationApi', this.configTable.tableArn, config.roles?.LambdaConfigurationApiExecutionRole);
 
         // Populate the App Config table with default config

--- a/lib/rag/ragConstruct.ts
+++ b/lib/rag/ragConstruct.ts
@@ -227,6 +227,19 @@ export class LisaRagConstruct extends Construct {
             ...getAuditLoggingEnv(config),
         };
 
+        // The global config table is owned by the chat stack. When chat is
+        // deployed, resolve its name by SSM (avoiding a cross-stack
+        // CloudFormation reference) so @require_feature("uploadRagDocs") can read
+        // enabledComponents. Without chat there is no config table, so the gate
+        // fails open by design.
+        if (config.deployChat) {
+            const configTableName = StringParameter.valueForStringParameter(
+                scope,
+                `${config.deploymentPrefix}/configTableName`,
+            );
+            baseEnvironment['CONFIG_TABLE_NAME'] = configTableName;
+        }
+
         // Add REST API SSL Cert ARN if it exists to be used to verify SSL calls to REST API
         if (config.restApiConfig?.sslCertIamArn) {
             baseEnvironment['RESTAPI_SSL_CERT_ARN'] = config.restApiConfig?.sslCertIamArn;
@@ -244,6 +257,26 @@ export class LisaRagConstruct extends Construct {
         bucket.grantRead(lambdaRole);
         bucket.grantPut(lambdaRole);
         bucket.grantDelete(lambdaRole);
+
+        // Grant the RAG Lambda role read access to the global config table (in
+        // the chat stack) for feature-gate reads. Imported by name to avoid a
+        // cross-stack CloudFormation reference. Only when chat is deployed.
+        // Scoped to GetItem/Query (the only operations the gate performs) rather
+        // than the full read action set, matching the SessionApi grant.
+        if (config.deployChat) {
+            const configTable = Table.fromTableName(
+                this,
+                'ConfigTable',
+                baseEnvironment['CONFIG_TABLE_NAME'],
+            );
+            lambdaRole.addToPrincipalPolicy(
+                new PolicyStatement({
+                    effect: Effect.ALLOW,
+                    actions: ['dynamodb:GetItem', 'dynamodb:Query'],
+                    resources: [configTable.tableArn],
+                }),
+            );
+        }
 
         // Get common layer based on arn from SSM due to issues with cross stack references
         const commonLambdaLayer = LayerVersion.fromLayerVersionArn(

--- a/lib/stages.ts
+++ b/lib/stages.ts
@@ -341,6 +341,7 @@ export class LisaServeApplicationStage extends Stage {
 
         if (config.deployServe) {
             let mcpWorkbenchStackInstance: McpWorkbenchStack | undefined;
+            let ragStackInstance: LisaRagStack | undefined;
             const serveStack = new LisaServeApplicationStack(this, 'LisaServe', {
                 ...baseStackProps,
                 description: `LISA-serve: ${config.deploymentName}-${config.deploymentStage}`,
@@ -424,6 +425,7 @@ export class LisaServeApplicationStage extends Stage {
                 ragStack.addDependency(modelsApiDeploymentStack);
                 this.stacks.push(ragStack);
                 apiDeploymentStack.addDependency(ragStack);
+                ragStackInstance = ragStack;
             }
 
             if (config.deployChat) {
@@ -440,6 +442,11 @@ export class LisaServeApplicationStage extends Stage {
                 // ChatStack reads: layerVersion/*, bucket/bucket-access-logs from CoreStack
                 chatStack.addDependency(coreStack);
                 chatStack.addDependency(apiBaseStack);
+                // RagStack reads: configTableName SSM param published by ChatStack
+                // (for the uploadRagDocs feature gate). Order chat before rag.
+                if (ragStackInstance) {
+                    ragStackInstance.addDependency(chatStack);
+                }
                 // ChatStack reads: modelTableName from ModelsApiStack
                 chatStack.addDependency(modelsApiDeploymentStack);
                 // ChatStack reads: serve/endpoint from ServeStack

--- a/test/lambda/test_feature_gate.py
+++ b/test/lambda/test_feature_gate.py
@@ -1,0 +1,222 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Unit tests for the server-side feature gate utility.
+
+Covers ``is_feature_enabled``, the ``require_feature`` decorator for traditional
+Lambda handlers, the 5-minute TTL cache, and the fail-open behavior when the
+config table is unreachable or unset.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+os.environ.setdefault("AWS_SECURITY_TOKEN", "testing")
+os.environ.setdefault("AWS_SESSION_TOKEN", "testing")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+os.environ.setdefault("AWS_REGION", "us-east-1")
+os.environ.setdefault("CONFIG_TABLE_NAME", "config-table")
+
+from lisa.utilities.exceptions import ForbiddenException
+from lisa.utilities.feature_gate import (
+    _feature_cache,
+    _get_enabled_components,
+    is_feature_enabled,
+    require_feature,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_feature_cache():
+    """The TTL cache is process-global; clear it around every test so cases
+    don't leak cached config into one another."""
+    _feature_cache.clear()
+    yield
+    _feature_cache.clear()
+
+
+def _mock_config_table(enabled_components):
+    """Build a mock DynamoDB Table whose query returns a single global config
+    item carrying the given enabledComponents dict."""
+    table = MagicMock()
+    table.query.return_value = {
+        "Items": [{"configScope": "global", "versionId": 0, "configuration": {"enabledComponents": enabled_components}}]
+    }
+    return table
+
+
+# ---------------------------------------------------------------------------
+# is_feature_enabled
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "components,feature_key,expected",
+    [
+        ({"deleteSessionHistory": True}, "deleteSessionHistory", True),
+        ({"deleteSessionHistory": False}, "deleteSessionHistory", False),
+        # Missing key -> fail-open (enabled). A toggle absent from config must
+        # not silently disable an existing capability.
+        ({"someOtherToggle": False}, "deleteSessionHistory", True),
+        ({}, "deleteSessionHistory", True),
+    ],
+)
+def test_is_feature_enabled_reads_config(components, feature_key, expected):
+    with patch("lisa.utilities.feature_gate._get_config_table", return_value=_mock_config_table(components)):
+        assert is_feature_enabled(feature_key) is expected
+
+
+def test_is_feature_enabled_no_global_item_fails_open():
+    """When no global configuration row exists yet, features default to enabled."""
+    table = MagicMock()
+    table.query.return_value = {"Items": []}
+    with patch("lisa.utilities.feature_gate._get_config_table", return_value=table):
+        assert is_feature_enabled("deleteSessionHistory") is True
+
+
+def test_is_feature_enabled_no_table_name_fails_open():
+    """Missing CONFIG_TABLE_NAME must fail open, not crash the handler."""
+    with patch("lisa.utilities.feature_gate._get_config_table", return_value=None):
+        assert is_feature_enabled("deleteSessionHistory") is True
+
+
+def test_is_feature_enabled_ddb_error_fails_open():
+    """A DynamoDB error must fail open (availability over security; the
+    authorizer has already validated auth)."""
+    table = MagicMock()
+    table.query.side_effect = Exception("DynamoDB unavailable")
+    with patch("lisa.utilities.feature_gate._get_config_table", return_value=table):
+        assert is_feature_enabled("deleteSessionHistory") is True
+
+
+# ---------------------------------------------------------------------------
+# Caching
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_components_cached_across_calls():
+    """The full enabledComponents dict is cached so repeated checks within the
+    TTL window don't hammer the config table."""
+    table = _mock_config_table({"deleteSessionHistory": False, "uploadRagDocs": True})
+    with patch("lisa.utilities.feature_gate._get_config_table", return_value=table):
+        # Two different toggles, several lookups — should hit DDB exactly once.
+        assert is_feature_enabled("deleteSessionHistory") is False
+        assert is_feature_enabled("uploadRagDocs") is True
+        assert is_feature_enabled("deleteSessionHistory") is False
+    assert table.query.call_count == 1
+
+
+def test_cache_refreshes_after_clear():
+    """A fresh read after cache expiry/clear reflects updated config."""
+    first = _mock_config_table({"deleteSessionHistory": True})
+    with patch("lisa.utilities.feature_gate._get_config_table", return_value=first):
+        assert is_feature_enabled("deleteSessionHistory") is True
+
+    _feature_cache.clear()  # simulate TTL expiry
+
+    second = _mock_config_table({"deleteSessionHistory": False})
+    with patch("lisa.utilities.feature_gate._get_config_table", return_value=second):
+        assert is_feature_enabled("deleteSessionHistory") is False
+
+
+def test_get_enabled_components_queries_latest_global_version():
+    """The query must select the global scope, newest version first, limit 1."""
+    table = _mock_config_table({"deleteSessionHistory": True})
+    with patch("lisa.utilities.feature_gate._get_config_table", return_value=table):
+        _get_enabled_components()
+    _, kwargs = table.query.call_args
+    assert kwargs["ScanIndexForward"] is False
+    assert kwargs["Limit"] == 1
+    assert kwargs["ExpressionAttributeValues"] == {":scope": "global"}
+
+
+# ---------------------------------------------------------------------------
+# require_feature decorator (traditional Lambda handlers)
+# ---------------------------------------------------------------------------
+
+
+def test_require_feature_allows_when_enabled():
+    @require_feature("deleteSessionHistory")
+    def handler(event, context):
+        return {"ok": True}
+
+    with patch(
+        "lisa.utilities.feature_gate._get_config_table", return_value=_mock_config_table({"deleteSessionHistory": True})
+    ):
+        assert handler({}, {}) == {"ok": True}
+
+
+def test_require_feature_rejects_when_disabled():
+    @require_feature("deleteSessionHistory")
+    def handler(event, context):
+        return {"ok": True}
+
+    with patch(
+        "lisa.utilities.feature_gate._get_config_table",
+        return_value=_mock_config_table({"deleteSessionHistory": False}),
+    ):
+        with pytest.raises(ForbiddenException) as exc_info:
+            handler({}, {})
+    assert exc_info.value.http_status_code == 403
+    assert "deleteSessionHistory" in exc_info.value.message
+
+
+def test_require_feature_does_not_invoke_handler_when_disabled():
+    """A disabled gate must short-circuit before the wrapped handler runs."""
+    handler_body = MagicMock(return_value={"ok": True})
+
+    @require_feature("deleteSessionHistory")
+    def handler(event, context):
+        return handler_body(event, context)
+
+    with patch(
+        "lisa.utilities.feature_gate._get_config_table",
+        return_value=_mock_config_table({"deleteSessionHistory": False}),
+    ):
+        with pytest.raises(ForbiddenException):
+            handler({}, {})
+    handler_body.assert_not_called()
+
+
+def test_require_feature_passes_through_args_and_context():
+    captured = {}
+
+    @require_feature("deleteSessionHistory")
+    def handler(event, context):
+        captured["event"] = event
+        captured["context"] = context
+        return {"ok": True}
+
+    event = {"requestContext": {"authorizer": {"username": "alice"}}}
+    context = {"aws_request_id": "abc"}
+    with patch(
+        "lisa.utilities.feature_gate._get_config_table", return_value=_mock_config_table({"deleteSessionHistory": True})
+    ):
+        handler(event, context)
+    assert captured["event"] is event
+    assert captured["context"] is context
+
+
+def test_require_feature_preserves_function_metadata():
+    @require_feature("deleteSessionHistory")
+    def my_handler(event, context):
+        """Original docstring."""
+        return {}
+
+    assert my_handler.__name__ == "my_handler"
+    assert my_handler.__doc__ == "Original docstring."

--- a/test/lambda/test_feature_gate_completeness.py
+++ b/test/lambda/test_feature_gate_completeness.py
@@ -1,0 +1,157 @@
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import ast
+from pathlib import Path
+
+import pytest
+
+# Gated handlers live under both lambda/ and lib/, so paths in REQUIRED_GATES
+# are relative to the repo root.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Canonical mapping: toggle_key -> list of (repo_relative_path, function_name).
+REQUIRED_GATES: dict[str, list[tuple[str, str]]] = {
+    "deleteSessionHistory": [
+        ("lambda/handlers/session/lambda_functions.py", "delete_session"),
+        ("lambda/handlers/session/lambda_functions.py", "delete_user_sessions"),
+    ],
+    "uploadRagDocs": [
+        ("lambda/handlers/repository/lambda_functions.py", "presigned_url"),
+        ("lambda/handlers/repository/lambda_functions.py", "ingest_documents"),
+    ],
+}
+
+
+def _decorators_for_function(tree: ast.AST, func_name: str) -> list[str]:
+    """Return the decorator names applied to ``func_name`` in a parsed module.
+
+    Handles both bare decorators (``@require_admin``) and call decorators
+    (``@require_feature("x")``), and both ``Name`` and dotted ``Attribute``
+    forms (``@module.require_feature(...)``).
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+            names: list[str] = []
+            for dec in node.decorator_list:
+                target = dec.func if isinstance(dec, ast.Call) else dec
+                if isinstance(target, ast.Name):
+                    names.append(target.id)
+                elif isinstance(target, ast.Attribute):
+                    names.append(target.attr)
+            return names
+    return []
+
+
+def _require_feature_keys_for_function(tree: ast.AST, func_name: str) -> list[str]:
+    """Return the string literal argument of every ``@require_feature("key")``
+    decorator on ``func_name``.
+
+    Lets the audit assert the endpoint is gated for the CORRECT toggle, not just
+    that some ``require_feature`` decorator is present (which would let a
+    copy-pasted wrong key slip through).
+    """
+    keys: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+            for dec in node.decorator_list:
+                if not isinstance(dec, ast.Call):
+                    continue
+                target = dec.func
+                name = target.id if isinstance(target, ast.Name) else getattr(target, "attr", None)
+                if name == "require_feature" and dec.args and isinstance(dec.args[0], ast.Constant):
+                    keys.append(dec.args[0].value)
+            return keys
+    return keys
+
+
+def _gate_cases() -> list[tuple[str, str, str]]:
+    """Flatten REQUIRED_GATES into (toggle_key, file_rel, func_name) tuples."""
+    return [(toggle, file_rel, func) for toggle, endpoints in REQUIRED_GATES.items() for file_rel, func in endpoints]
+
+
+@pytest.mark.skipif(not _gate_cases(), reason="REQUIRED_GATES is empty (Phase 1: library only)")
+@pytest.mark.parametrize("toggle_key,file_rel,func_name", _gate_cases())
+def test_endpoint_has_feature_gate(toggle_key: str, file_rel: str, func_name: str) -> None:
+    """Every endpoint declared in REQUIRED_GATES must carry its gate."""
+    file_path = REPO_ROOT / file_rel
+    assert (
+        file_path.exists()
+    ), f"Handler file not found: {file_path}\nIf this endpoint moved, update REQUIRED_GATES in this test."
+
+    tree = ast.parse(file_path.read_text())
+    decorators = _decorators_for_function(tree, func_name)
+    assert "require_feature" in decorators, (
+        f"Function '{func_name}' in {file_rel} is missing @require_feature(\"{toggle_key}\").\n"
+        f"This endpoint serves feature '{toggle_key}' and MUST be gated."
+    )
+
+    keys = _require_feature_keys_for_function(tree, func_name)
+    assert toggle_key in keys, (
+        f"Function '{func_name}' in {file_rel} is gated with {keys or 'no key'}, "
+        f"but must be gated for '{toggle_key}'.\nCheck the @require_feature argument."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests for the AST audit mechanism itself.
+# ---------------------------------------------------------------------------
+
+_FIXTURE_SOURCE = """
+from lisa.utilities.feature_gate import require_feature
+
+
+@require_feature("deleteSessionHistory")
+def gated_traditional(event, context):
+    return {}
+
+
+@some_other_decorator
+def ungated(event, context):
+    return {}
+"""
+
+
+@pytest.fixture(scope="module")
+def fixture_tree() -> ast.AST:
+    return ast.parse(_FIXTURE_SOURCE)
+
+
+def test_detects_require_feature_decorator(fixture_tree: ast.AST) -> None:
+    assert "require_feature" in _decorators_for_function(fixture_tree, "gated_traditional")
+
+
+def test_does_not_falsely_detect_gate_on_ungated_function(fixture_tree: ast.AST) -> None:
+    decorators = _decorators_for_function(fixture_tree, "ungated")
+    assert "require_feature" not in decorators
+
+
+def test_decorators_for_missing_function_returns_empty(fixture_tree: ast.AST) -> None:
+    assert _decorators_for_function(fixture_tree, "does_not_exist") == []
+
+
+def test_extracts_require_feature_key(fixture_tree: ast.AST) -> None:
+    assert _require_feature_keys_for_function(fixture_tree, "gated_traditional") == ["deleteSessionHistory"]
+
+
+def test_no_require_feature_key_for_ungated_function(fixture_tree: ast.AST) -> None:
+    assert _require_feature_keys_for_function(fixture_tree, "ungated") == []
+
+
+def test_required_gates_paths_resolve() -> None:
+    """Guardrail: every path in REQUIRED_GATES must exist. Catches typos and
+    file moves as the map grows per phase."""
+    for toggle, endpoints in REQUIRED_GATES.items():
+        for file_rel, _func in endpoints:
+            assert (REPO_ROOT / file_rel).exists(), f"REQUIRED_GATES path does not exist: {file_rel} (toggle {toggle})"

--- a/test/lambda/test_repository_lambda.py
+++ b/test/lambda/test_repository_lambda.py
@@ -2994,6 +2994,88 @@ def test_presigned_url_success():
         assert result["statusCode"] == 200
 
 
+def _mock_upload_rag_docs_config(enabled):
+    """Build a mock config table whose query returns uploadRagDocs=<enabled>."""
+    table = MagicMock()
+    table.query.return_value = {"Items": [{"configuration": {"enabledComponents": {"uploadRagDocs": enabled}}}]}
+    return table
+
+
+def test_presigned_url_blocked_when_feature_disabled():
+    """When uploadRagDocs is admin-disabled, presigned_url must not vend a URL."""
+    import lisa.utilities.feature_gate as feature_gate
+    from repository.lambda_functions import presigned_url
+
+    feature_gate._feature_cache.clear()
+    try:
+        with patch("repository.lambda_functions.s3") as mock_s3, patch(
+            "repository.lambda_functions.get_username", return_value="user1"
+        ), patch.object(feature_gate, "_get_config_table", return_value=_mock_upload_rag_docs_config(False)):
+            mock_s3.generate_presigned_post.return_value = {"url": "https://test.com", "fields": {}}
+            event = {
+                "body": "test-key",
+                "requestContext": {"authorizer": {"username": "user1", "groups": ["users"]}},
+            }
+            context = SimpleNamespace(function_name="test", aws_request_id="123")
+
+            result = presigned_url(event, context)
+            # Gate rejects before generating a presigned URL.
+            assert result["statusCode"] != 200
+            mock_s3.generate_presigned_post.assert_not_called()
+    finally:
+        feature_gate._feature_cache.clear()
+
+
+def test_presigned_url_allowed_when_feature_enabled():
+    """When uploadRagDocs is enabled, presigned_url proceeds normally."""
+    import lisa.utilities.feature_gate as feature_gate
+    from repository.lambda_functions import presigned_url
+
+    feature_gate._feature_cache.clear()
+    try:
+        with patch("repository.lambda_functions.s3") as mock_s3, patch(
+            "repository.lambda_functions.get_username", return_value="user1"
+        ), patch.object(feature_gate, "_get_config_table", return_value=_mock_upload_rag_docs_config(True)):
+            mock_s3.generate_presigned_post.return_value = {"url": "https://test.com", "fields": {}}
+            event = {
+                "body": "test-key",
+                "requestContext": {"authorizer": {"username": "user1", "groups": ["users"]}},
+            }
+            context = SimpleNamespace(function_name="test", aws_request_id="123")
+
+            result = presigned_url(event, context)
+            assert result["statusCode"] == 200
+    finally:
+        feature_gate._feature_cache.clear()
+
+
+def test_ingest_documents_blocked_when_feature_disabled():
+    """When uploadRagDocs is admin-disabled, ingest_documents must not ingest."""
+    import lisa.utilities.feature_gate as feature_gate
+    from repository.lambda_functions import ingest_documents
+
+    feature_gate._feature_cache.clear()
+    try:
+        with patch("repository.lambda_functions.vs_repo") as mock_vs_repo, patch.object(
+            feature_gate, "_get_config_table", return_value=_mock_upload_rag_docs_config(False)
+        ):
+            event = {
+                "requestContext": {
+                    "authorizer": {"claims": {"username": "test-user"}, "groups": json.dumps(["test-group"])}
+                },
+                "pathParameters": {"repositoryId": "test-repo"},
+                "queryStringParameters": {},
+                "body": json.dumps({"collectionId": "c1", "keys": ["test-key"]}),
+            }
+
+            result = ingest_documents(event, SimpleNamespace())
+            # Gate rejects before any repository lookup/ingestion work.
+            assert result["statusCode"] != 200
+            mock_vs_repo.find_repository_by_id.assert_not_called()
+    finally:
+        feature_gate._feature_cache.clear()
+
+
 def test_get_document_success():
     """Test get_document"""
     from repository.lambda_functions import get_document

--- a/test/lambda/test_session_lambda.py
+++ b/test/lambda/test_session_lambda.py
@@ -353,6 +353,106 @@ def test_delete_session_not_found(dynamodb_table, lambda_context, mock_s3_operat
         mock_common.get_session_id.return_value = original_session_id
 
 
+def test_delete_session_blocked_when_feature_disabled(
+    dynamodb_table, sample_session, lambda_context, mock_s3_operations
+):
+    """When deleteSessionHistory is admin-disabled, delete_session must not delete."""
+    import lisa.utilities.feature_gate as feature_gate
+
+    dynamodb_table.put_item(Item=sample_session)
+    event = {
+        "requestContext": {"authorizer": {"claims": {"username": "test-user"}}},
+        "pathParameters": {"sessionId": "test-session"},
+    }
+
+    mock_config = MagicMock()
+    mock_config.query.return_value = {
+        "Items": [{"configuration": {"enabledComponents": {"deleteSessionHistory": False}}}]
+    }
+    feature_gate._feature_cache.clear()
+    try:
+        with patch.object(feature_gate, "_get_config_table", return_value=mock_config):
+            response = delete_session(event, lambda_context)
+        # Gate rejected the request before any deletion (real path returns 403;
+        # this harness maps the ForbiddenException to a non-200 response).
+        assert response["statusCode"] != 200
+        mock_s3_operations.assert_not_called()
+    finally:
+        feature_gate._feature_cache.clear()
+
+
+def test_delete_session_allowed_when_feature_enabled(
+    dynamodb_table, sample_session, lambda_context, mock_s3_operations
+):
+    """When deleteSessionHistory is enabled, delete_session proceeds normally."""
+    import lisa.utilities.feature_gate as feature_gate
+
+    dynamodb_table.put_item(Item=sample_session)
+    event = {
+        "requestContext": {"authorizer": {"claims": {"username": "test-user"}}},
+        "pathParameters": {"sessionId": "test-session"},
+    }
+
+    mock_config = MagicMock()
+    mock_config.query.return_value = {
+        "Items": [{"configuration": {"enabledComponents": {"deleteSessionHistory": True}}}]
+    }
+    feature_gate._feature_cache.clear()
+    try:
+        with patch.object(feature_gate, "_get_config_table", return_value=mock_config):
+            response = delete_session(event, lambda_context)
+        assert response["statusCode"] == 200
+        mock_s3_operations.assert_called_once_with("test-session", "test-user")
+    finally:
+        feature_gate._feature_cache.clear()
+
+
+def test_delete_user_sessions_blocked_when_feature_disabled(
+    dynamodb_table, sample_session, lambda_context, mock_s3_operations
+):
+    """When deleteSessionHistory is admin-disabled, delete_user_sessions must not delete."""
+    import lisa.utilities.feature_gate as feature_gate
+
+    dynamodb_table.put_item(Item=sample_session)
+    event = {"requestContext": {"authorizer": {"claims": {"username": "test-user"}}}}
+
+    mock_config = MagicMock()
+    mock_config.query.return_value = {
+        "Items": [{"configuration": {"enabledComponents": {"deleteSessionHistory": False}}}]
+    }
+    feature_gate._feature_cache.clear()
+    try:
+        with patch.object(feature_gate, "_get_config_table", return_value=mock_config):
+            response = delete_user_sessions(event, lambda_context)
+        assert response["statusCode"] != 200
+        mock_s3_operations.assert_not_called()
+    finally:
+        feature_gate._feature_cache.clear()
+
+
+def test_delete_user_sessions_allowed_when_feature_enabled(
+    dynamodb_table, sample_session, lambda_context, mock_s3_operations
+):
+    """When deleteSessionHistory is enabled, delete_user_sessions proceeds normally."""
+    import lisa.utilities.feature_gate as feature_gate
+
+    dynamodb_table.put_item(Item=sample_session)
+    event = {"requestContext": {"authorizer": {"claims": {"username": "test-user"}}}}
+
+    mock_config = MagicMock()
+    mock_config.query.return_value = {
+        "Items": [{"configuration": {"enabledComponents": {"deleteSessionHistory": True}}}]
+    }
+    feature_gate._feature_cache.clear()
+    try:
+        with patch.object(feature_gate, "_get_config_table", return_value=mock_config):
+            response = delete_user_sessions(event, lambda_context)
+        assert response["statusCode"] == 200
+        assert mock_s3_operations.called
+    finally:
+        feature_gate._feature_cache.clear()
+
+
 def test_put_session(dynamodb_table, config_table, sample_session, lambda_context):
     """Test putting a session."""
     # Create request using PutSessionRequest model


### PR DESCRIPTION
### Summary

LISA's admin feature toggles (enabledComponents) were enforced only in the React UI (hiding buttons and routes). The backend processed requests regardless, so any authenticated user could bypass an admin's governance decision with a direct API call (curl, script, or a modified client).

This PR adds server-side enforcement for the two backend-relevant toggles, deleteSessionHistory and uploadRagDocs, closing a confirmed authorization bypass. This was validated against a live dev deployment, not just unit tests — see Testing.

#### What changed

New shared utility: `lambda/shared/python/lisa/utilities/feature_gate.py`
- `@require_feature("toggle")` decorator for traditional (event, context) Lambda handlers; raises ForbiddenException (HTTP 403) when the toggle is disabled.
- `is_feature_enabled(key)` helper.
- Reads `enabledComponents` from the global config DynamoDB table, cached 5 minutes (TTLCache)
- Fails open when the config table is unset or unreachable (availability over governance; authentication is already enforced upstream by the API Gateway authorizer). Documented in the module as a governance toggle, not an authorization boundary.

### Endpoints gated
| Toggle | Endpoints | Handler |
| ---- | ---- | ---- |
| deleteSessionHistory | `DELETE /session/{id}`, `DELETE /session` | session |
| uploadRagDocs | `POST /repository/presigned-url`, `POST /repository/{id}/bulk` | repository |


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
